### PR TITLE
Pattern operations: Undo, Replicate, Double/Halve/Clone, Interpolate, Reverse, Rotate, Solo, Follow

### DIFF
--- a/doc/help.txt
+++ b/doc/help.txt
@@ -29,10 +29,21 @@
               Use TAB here to switch edit mode
  
  CTRL-1 => 0: Change the step-value in the pattern editor
- ALT-`      : Set previous note's length to distance between 
+ ALT-`      : Set previous note's length to distance between
               note and current cursor position
- ScrollLock : Pattern-follow mode (cursor follows
-              playback)
+ ScrollLock : Follow playback toggle (cursor follows playback position)
+
+|L|%==|H|Pattern Operations|L|==%|U|
+
+ ALT-R / Cmd-R   : Replicate at Cursor (rows 0..cursor repeat across rest)
+ ALT-Z / Cmd-Z   : Undo last destructive pattern operation (single level)
+ CTRL-SHIFT-G    : Double Pattern (duplicate rows, max 256)
+ CTRL-SHIFT-H    : Halve Pattern (keep every other row, min 32)
+ CTRL-SHIFT-D    : Clone Pattern (copy to next empty slot and jump to it)
+ CTRL-SHIFT-R    : Reverse Selection (reverse row order in selected block)
+ CTRL-SHIFT-Down : Rotate Track Down (last row wraps to first)
+ CTRL-SHIFT-Up   : Rotate Track Up (first row wraps to last)
+ CTRL-F9         : Track Solo (mute all other tracks; repeat to unsolo all)
 
 |L|%==|H|Block Functions|L|==%|U|
 
@@ -55,7 +66,9 @@
  
  CTRL-N     : Set length of first row of block to length of block
  CTRL-W     : Clear unused volumes
- CTRL-I     : Interpolate effect data thru block
+ CTRL-I     : Interpolate values through selection (note, vol, or fx param,
+              depending on which column the cursor is on; falls back to
+              effect-data interpolation when no selection column applies)
  CTRL-T     : Set all effect and effect data fields of block to same
               value as first row in block
  CTRL-K     : Interpolate volume (block)
@@ -106,7 +119,7 @@
  SHIFT-F7   : Play song from the current order
  F8         : Stop playback
  F9         : Panic (all midi-off/SHIFT-F9 performs a hard driver panic)
- CTRL-F9    : Load Song...
+ CTRL-F9    : Track Solo (pattern editor)
  CTRL-F10   : Save Song As...
  F11        : Song Configuration and Order editor
  F12        : System Configuration (midi dev select)

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -1,4 +1,18 @@
 #include "zt.h"
+#include "platform/undo.h"
+
+// KS_META stub for Cmd key support (SDL3 maps macOS Cmd to SDL_KMOD_GUI).
+// Currently keybuffer does not translate GUI -> KS_META, so KS_META is a
+// compile-time no-op here. PR-C (configurable keybindings) defines the real
+// bits; keeping this stub lets the same source compile on both branches.
+#ifndef KS_META
+#define KS_META 0
+#endif
+
+static PatternUndo g_undo;
+
+// Save undo snapshot before destructive pattern operations
+#define UNDO_SAVE() g_undo.save(song, cur_edit_pattern)
 
 #define LEFT_MARGIN                     40
 #define RIGHT_MARGIN                    2
@@ -1564,11 +1578,239 @@ void CUI_Patterneditor::update()
                   
                   // END NEW SHIFT SELECTION
                   ////////////////////////////////////////////////////////////////////////////////////////
-                  
+
             }
         }
 
 
+        // ------------------------------------------------------------------
+        // Pattern operations (ported from master: Undo, Double, Halve, Clone,
+        // Interpolate Selection, Reverse Selection, Rotate Up/Down, Track Solo).
+        // Keys are hardcoded here; PR-C (#8) makes them remappable once merged.
+        // ------------------------------------------------------------------
+
+        // Undo: ALT+Z / Cmd+Z (Ctrl+Z is already block-clear)
+        if ((kstate & KS_ALT || kstate & KS_META) && !(kstate & KS_CTRL) && !(kstate & KS_SHIFT) && key == SDLK_Z) {
+          int restored = g_undo.restore(song);
+          if (restored >= 0) {
+            cur_edit_pattern = restored;
+            statusmsg = "Undo";
+          } else {
+            statusmsg = "Nothing to undo";
+          }
+          status_change = 1; need_refresh++; key = 0;
+        }
+
+        // Double Pattern: Ctrl+Shift+G
+        if ((kstate & KS_CTRL) && (kstate & KS_SHIFT) && key == SDLK_G) {
+          UNDO_SAVE();
+          int pat_len = song->patterns[cur_edit_pattern]->length;
+          int new_len = pat_len * 2;
+          if (new_len <= 256) {
+            song->patterns[cur_edit_pattern]->resize(new_len);
+            for (int t = 0; t < MAX_TRACKS; t++) {
+              track *trk = song->patterns[cur_edit_pattern]->tracks[t];
+              if (!trk) continue;
+              for (int r = 0; r < pat_len; r++) {
+                event *ev = trk->get_event(r);
+                if (ev) trk->update_event(r + pat_len, ev->note, ev->inst, ev->vol, ev->length, ev->effect, ev->effect_data);
+              }
+            }
+            sprintf(szStatmsg, "Pattern doubled: %d -> %d rows", pat_len, new_len);
+          } else {
+            sprintf(szStatmsg, "Cannot double: max 256 rows");
+          }
+          statusmsg = szStatmsg; status_change = 1; need_refresh++; key = 0;
+        }
+
+        // Halve Pattern: Ctrl+Shift+H
+        if ((kstate & KS_CTRL) && (kstate & KS_SHIFT) && key == SDLK_H) {
+          UNDO_SAVE();
+          int pat_len = song->patterns[cur_edit_pattern]->length;
+          int new_len = pat_len / 2;
+          if (new_len >= 32) {
+            for (int t = 0; t < MAX_TRACKS; t++) {
+              track *trk = song->patterns[cur_edit_pattern]->tracks[t];
+              if (!trk) continue;
+              for (int r = 0; r < new_len; r++) {
+                event *ev = trk->get_event(r * 2);
+                if (ev) trk->update_event(r, ev->note, ev->inst, ev->vol, ev->length, ev->effect, ev->effect_data);
+                else    trk->update_event(r, blank_event.note, blank_event.inst, blank_event.vol, blank_event.length, blank_event.effect, blank_event.effect_data);
+              }
+            }
+            song->patterns[cur_edit_pattern]->resize(new_len);
+            if (cur_edit_row >= new_len) cur_edit_row = new_len - 1;
+            sprintf(szStatmsg, "Pattern halved: %d -> %d rows", pat_len, new_len);
+          } else {
+            sprintf(szStatmsg, "Cannot halve: minimum pattern length is 32 rows");
+          }
+          statusmsg = szStatmsg; status_change = 1; need_refresh++; key = 0;
+        }
+
+        // Clone Pattern + jump to it: Ctrl+Shift+D
+        if ((kstate & KS_CTRL) && (kstate & KS_SHIFT) && key == SDLK_D) {
+          int src = cur_edit_pattern;
+          int dest = -1;
+          for (int p = 0; p < 256; p++) {
+            if (p != src && song->patterns[p] && song->patterns[p]->isempty()) { dest = p; break; }
+          }
+          if (dest < 0) {
+            for (int p = 0; p < 256; p++) {
+              if (p != src && !song->patterns[p]) {
+                song->patterns[p] = new pattern(song->patterns[src]->length);
+                dest = p; break;
+              }
+            }
+          }
+          if (dest >= 0) {
+            int pat_len = song->patterns[src]->length;
+            song->patterns[dest]->resize(pat_len);
+            for (int t = 0; t < MAX_TRACKS; t++) {
+              track *st = song->patterns[src]->tracks[t];
+              track *dt = song->patterns[dest]->tracks[t];
+              if (!st || !dt) continue;
+              for (int r = 0; r < pat_len; r++) {
+                event *ev = st->get_event(r);
+                if (ev) dt->update_event(r, ev->note, ev->inst, ev->vol, ev->length, ev->effect, ev->effect_data);
+              }
+            }
+            cur_edit_pattern = dest;
+            sprintf(szStatmsg, "Cloned pattern %03d -> %03d", src, dest);
+          } else {
+            sprintf(szStatmsg, "No empty pattern slot");
+          }
+          statusmsg = szStatmsg; status_change = 1; need_refresh++; key = 0;
+        }
+
+        // Interpolate Selection: Ctrl+I
+        // (Note: the plain Ctrl+I inside the KS_CTRL switch below is the
+        // legacy "Interpolate effect" op; this one is richer — it picks the
+        // column type from where the cursor is.)
+        if (kstate == KS_CTRL && key == SDLK_I && selected) {
+          UNDO_SAVE();
+          int rows = select_row_end - select_row_start;
+          if (rows >= 1) {
+            for (int t = select_track_start; t <= select_track_end; t++) {
+              track *trk = song->patterns[cur_edit_pattern]->tracks[t];
+              if (!trk) continue;
+              event *e_start = trk->get_event(select_row_start);
+              event *e_end   = trk->get_event(select_row_end);
+              if (!e_start || !e_end) continue;
+              int ctype = edit_cols[cur_edit_col].type;
+              int v0 = 0, v1 = 0;
+              if (ctype == T_VOL) {
+                v0 = (e_start->vol < 0x80) ? e_start->vol : 0;
+                v1 = (e_end->vol   < 0x80) ? e_end->vol   : 0;
+              } else if (ctype == T_FXP) {
+                v0 = e_start->effect_data;
+                v1 = e_end->effect_data;
+              } else if (ctype == T_NOTE) {
+                v0 = (e_start->note < 0x80) ? e_start->note : -1;
+                v1 = (e_end->note   < 0x80) ? e_end->note   : -1;
+              } else {
+                continue; // unsupported column type, skip track
+              }
+              if (v0 < 0 || v1 < 0) continue;
+              for (int r = select_row_start + 1; r < select_row_end; r++) {
+                int pos = r - select_row_start;
+                int val = v0 + (v1 - v0) * pos / rows;
+                if (ctype == T_VOL)
+                  trk->update_event(r, -1, -1, val, -1, -1, -1);
+                else if (ctype == T_FXP)
+                  trk->update_event(r, -1, -1, -1, -1, -1, val);
+                else if (ctype == T_NOTE)
+                  trk->update_event(r, val, -1, -1, -1, -1, -1);
+              }
+            }
+            statusmsg = "Interpolated selection";
+            status_change = 1; need_refresh++; key = 0;
+          }
+        }
+
+        // Track Solo: Ctrl+F9
+        if ((kstate & KS_CTRL) && !(kstate & KS_SHIFT) && !(kstate & KS_ALT) && key == SDLK_F9) {
+          bool all_others_muted = true;
+          for (int t = 0; t < MAX_TRACKS; t++) {
+            if (t != cur_edit_track && !song->track_mute[t]) {
+              all_others_muted = false;
+              break;
+            }
+          }
+          if (all_others_muted) {
+            for (int t = 0; t < MAX_TRACKS; t++) { unmutetrack(t); }
+            statusmsg = "Unsolo: all tracks unmuted";
+          } else {
+            for (int t = 0; t < MAX_TRACKS; t++) {
+              if (t == cur_edit_track) { unmutetrack(t); }
+              else                     { mutetrack(t);   }
+            }
+            sprintf(szStatmsg, "Solo track %d", cur_edit_track + 1);
+            statusmsg = szStatmsg;
+          }
+          status_change = 1; need_refresh++; key = 0;
+        }
+
+        // Reverse Selection: Ctrl+Shift+R
+        if ((kstate & KS_CTRL) && (kstate & KS_SHIFT) && key == SDLK_R) {
+          if (selected) {
+            UNDO_SAVE();
+            for (int t = select_track_start; t <= select_track_end; t++) {
+              track *trk = song->patterns[cur_edit_pattern]->tracks[t];
+              if (!trk) continue;
+              int lo = select_row_start;
+              int hi = select_row_end;
+              while (lo < hi) {
+                event *ea = trk->get_event(lo);
+                event *eb = trk->get_event(hi);
+                event tmp_a = ea ? *ea : blank_event;
+                event tmp_b = eb ? *eb : blank_event;
+                trk->update_event(lo, tmp_b.note, tmp_b.inst, tmp_b.vol, tmp_b.length, tmp_b.effect, tmp_b.effect_data);
+                trk->update_event(hi, tmp_a.note, tmp_a.inst, tmp_a.vol, tmp_a.length, tmp_a.effect, tmp_a.effect_data);
+                lo++; hi--;
+              }
+            }
+            statusmsg = "Selection reversed";
+          } else {
+            statusmsg = "No selection";
+          }
+          status_change = 1; need_refresh++; key = 0;
+        }
+
+        // Rotate Track Down: Ctrl+Shift+Down
+        if ((kstate & KS_CTRL) && (kstate & KS_SHIFT) && key == SDLK_DOWN) {
+          UNDO_SAVE();
+          int pat_len = song->patterns[cur_edit_pattern]->length;
+          track *trk = song->patterns[cur_edit_pattern]->tracks[cur_edit_track];
+          if (trk && pat_len > 1) {
+            event *last = trk->get_event(pat_len - 1);
+            event saved = last ? *last : blank_event;
+            for (int r = pat_len - 1; r > 0; r--) {
+              event *ep = trk->get_event(r - 1);
+              if (ep) trk->update_event(r, ep->note, ep->inst, ep->vol, ep->length, ep->effect, ep->effect_data);
+              else    trk->update_event(r, blank_event.note, blank_event.inst, blank_event.vol, blank_event.length, blank_event.effect, blank_event.effect_data);
+            }
+            trk->update_event(0, saved.note, saved.inst, saved.vol, saved.length, saved.effect, saved.effect_data);
+          }
+          statusmsg = "Rotated track down"; status_change = 1; need_refresh++; key = 0;
+        }
+
+        // Rotate Track Up: Ctrl+Shift+Up
+        if ((kstate & KS_CTRL) && (kstate & KS_SHIFT) && key == SDLK_UP) {
+          UNDO_SAVE();
+          int pat_len = song->patterns[cur_edit_pattern]->length;
+          track *trk = song->patterns[cur_edit_pattern]->tracks[cur_edit_track];
+          if (trk && pat_len > 1) {
+            event *first = trk->get_event(0);
+            event saved = first ? *first : blank_event;
+            for (int r = 0; r < pat_len - 1; r++) {
+              event *ep = trk->get_event(r + 1);
+              if (ep) trk->update_event(r, ep->note, ep->inst, ep->vol, ep->length, ep->effect, ep->effect_data);
+              else    trk->update_event(r, blank_event.note, blank_event.inst, blank_event.vol, blank_event.length, blank_event.effect, blank_event.effect_data);
+            }
+            trk->update_event(pat_len - 1, saved.note, saved.inst, saved.vol, saved.length, saved.effect, saved.effect_data);
+          }
+          statusmsg = "Rotated track up"; status_change = 1; need_refresh++; key = 0;
+        }
 
 
         if (kstate == KS_CTRL ) {
@@ -2085,6 +2327,35 @@ void CUI_Patterneditor::update()
             
             
             break;
+          case SDLK_R: /* Replicate at Cursor (from Paketti, ALT+R / Cmd+R) */
+          {
+            UNDO_SAVE();
+            // Take rows 0..cur_edit_row-1 (above cursor, not including cursor)
+            // as the source chunk on the current track, then repeat that chunk
+            // from cur_edit_row to end of pattern.
+            int pat_len = song->patterns[cur_edit_pattern]->length;
+            int chunk_len = cur_edit_row; // rows 0 through cur_edit_row-1
+            if (chunk_len > 0 && cur_edit_row < pat_len) {
+              for (j = cur_edit_row; j < pat_len; j++) {
+                int src_row = (j - cur_edit_row) % chunk_len;
+                event *src = song->patterns[cur_edit_pattern]->tracks[cur_edit_track]->get_event(src_row);
+                if (src) {
+                  song->patterns[cur_edit_pattern]->tracks[cur_edit_track]->update_event(
+                    j, src->note, src->inst, src->vol, src->length, src->effect, src->effect_data);
+                } else {
+                  // Clear destination row if source is empty
+                  song->patterns[cur_edit_pattern]->tracks[cur_edit_track]->update_event(
+                    j, 0x80, MAX_INSTS, 0x80, 0, 0xFF, 0);
+                }
+              }
+              need_refresh++;
+              sprintf(szStatmsg, "Replicated rows 0-%d from cursor (%d rows)", cur_edit_row - 1, pat_len);
+              statusmsg = szStatmsg;
+              status_change = 1;
+            }
+          }
+          break;
+
           case SDLK_Q: /* Transpose up */
             if (selected) {
               for(i=select_track_start;i<=select_track_end;i++)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -902,6 +902,14 @@ void update_status(Drawable *S)
     }
 
     statusmsg = szStatmsg;
+
+    // Follow Playback (Scroll Lock): in pattern editor, cursor follows
+    // the playhead in real time.
+    if (bScrollLock && cur_state == STATE_PEDIT) {
+      cur_edit_pattern = ztPlayer->playing_cur_pattern;
+      cur_edit_row     = ztPlayer->playing_cur_row;
+      need_refresh++;
+    }
   }
 
   if (S->lock() == 0) {
@@ -1268,6 +1276,8 @@ void global_keys(Drawable *S)
                     bScrollLock = 0;
                 else
                     bScrollLock = 1;
+                statusmsg = (char*)(bScrollLock ? "Follow playback ON" : "Follow playback OFF");
+                status_change = 1; need_refresh++;
                 break;
             case SDLK_Q: 
                 if (kstate & KS_ALT && kstate & KS_CTRL) {

--- a/src/platform/undo.h
+++ b/src/platform/undo.h
@@ -1,0 +1,118 @@
+// Simple single-level undo for pattern editing.
+// Saves a snapshot of one pattern's event data before destructive operations.
+
+#ifndef ZT_UNDO_H
+#define ZT_UNDO_H
+
+#include "module.h"
+
+struct UndoEvent {
+    unsigned short row;
+    unsigned char note, inst, vol, effect;
+    unsigned short length, effect_data;
+};
+
+struct UndoTrack {
+    UndoEvent *events;
+    int count;
+};
+
+class PatternUndo {
+public:
+    int saved_pattern;
+    int saved_length;
+    UndoTrack tracks[MAX_TRACKS];
+    bool has_undo;
+
+    PatternUndo() : saved_pattern(-1), saved_length(0), has_undo(false) {
+        for (int i = 0; i < MAX_TRACKS; i++) {
+            tracks[i].events = nullptr;
+            tracks[i].count = 0;
+        }
+    }
+
+    ~PatternUndo() { clear(); }
+
+    void clear() {
+        for (int i = 0; i < MAX_TRACKS; i++) {
+            delete[] tracks[i].events;
+            tracks[i].events = nullptr;
+            tracks[i].count = 0;
+        }
+        has_undo = false;
+    }
+
+    // Save a snapshot of the given pattern
+    void save(zt_module *song, int pat_idx) {
+        clear();
+        if (!song->patterns[pat_idx]) return;
+
+        saved_pattern = pat_idx;
+        saved_length = song->patterns[pat_idx]->length;
+
+        for (int t = 0; t < MAX_TRACKS; t++) {
+            track *trk = song->patterns[pat_idx]->tracks[t];
+            if (!trk) continue;
+
+            // Count events
+            int count = 0;
+            for (int r = 0; r < saved_length; r++) {
+                if (trk->get_event(r)) count++;
+            }
+
+            if (count == 0) continue;
+
+            tracks[t].events = new UndoEvent[count];
+            tracks[t].count = count;
+            int idx = 0;
+            for (int r = 0; r < saved_length; r++) {
+                event *e = trk->get_event(r);
+                if (e) {
+                    tracks[t].events[idx].row = r;
+                    tracks[t].events[idx].note = e->note;
+                    tracks[t].events[idx].inst = e->inst;
+                    tracks[t].events[idx].vol = e->vol;
+                    tracks[t].events[idx].effect = e->effect;
+                    tracks[t].events[idx].length = e->length;
+                    tracks[t].events[idx].effect_data = e->effect_data;
+                    idx++;
+                }
+            }
+        }
+        has_undo = true;
+    }
+
+    // Restore the saved snapshot
+    int restore(zt_module *song) {
+        if (!has_undo || saved_pattern < 0) return -1;
+        if (!song->patterns[saved_pattern]) return -1;
+
+        // Clear all events in the pattern
+        for (int t = 0; t < MAX_TRACKS; t++) {
+            track *trk = song->patterns[saved_pattern]->tracks[t];
+            if (!trk) continue;
+            trk->reset();
+        }
+
+        // Resize if needed
+        if (song->patterns[saved_pattern]->length != saved_length) {
+            song->patterns[saved_pattern]->resize(saved_length);
+        }
+
+        // Restore events
+        for (int t = 0; t < MAX_TRACKS; t++) {
+            track *trk = song->patterns[saved_pattern]->tracks[t];
+            if (!trk || tracks[t].count == 0) continue;
+
+            for (int i = 0; i < tracks[t].count; i++) {
+                UndoEvent &ue = tracks[t].events[i];
+                trk->update_event(ue.row, ue.note, ue.inst, ue.vol, ue.length, ue.effect, ue.effect_data);
+            }
+        }
+
+        has_undo = false;
+        return saved_pattern;
+    }
+};
+
+#endif


### PR DESCRIPTION
## Summary

Adds 11 pattern editing operations inspired by Impulse Tracker / Paketti workflow. All hardcoded to SDLK_ key codes (no dependency on PR #8 keybindings — once both merge, these can be wired into `g_keybindings` for remappability in a follow-up).

## Operations added

| Shortcut | Action |
|----------|--------|
| ALT+Z (Cmd+Z once GUI mod is mapped) | **Undo** — single-level pattern snapshot |
| ALT+R (Cmd+R) | **Replicate at Cursor** — repeats rows 0..cursor across pattern |
| Ctrl+Shift+G | **Double Pattern** — doubles length, copies first half to second (max 256) |
| Ctrl+Shift+H | **Halve Pattern** — removes every other row (min 32) |
| Ctrl+Shift+D | **Clone Pattern** — copies to next empty slot, jumps to it |
| Ctrl+I | **Interpolate Selection** — linear ramp on note / volume / effect param (column-aware) |
| Ctrl+Shift+R | **Reverse Selection** — reverses row order in selected block |
| Ctrl+Shift+Down | **Rotate Down** — shifts rows in track down with wrap |
| Ctrl+Shift+Up | **Rotate Up** — shifts rows in track up with wrap |
| Ctrl+F9 | **Track Solo** — mutes all except current; toggle to unmute all |
| Scroll Lock | **Follow Playback** — cursor follows playing position |

Every destructive operation calls `UNDO_SAVE()` first and shows a status message on completion.

## Files changed

- `src/CUI_Patterneditor.cpp` — new handlers + `#include "platform/undo.h"` + KS_META stub
- `src/main.cpp` — Scroll Lock follow-playback in `update_status()`
- `src/platform/undo.h` — new file, snapshot-based single-level undo
- `doc/help.txt` — new Pattern Operations section

## Test plan

- [x] Builds clean on macOS arm64 with SDL3 from Homebrew (`build-macos/Program/zt`, 1.1 MB Mach-O)
- [ ] Builds on Windows (untested in this branch — should be unaffected since all changes use SDLK_*)
- [ ] Runtime verification of each operation
- [ ] Verify Cmd+Z / Cmd+R activate once `SDL_KMOD_GUI → KS_META` is wired in `keybuffer.cpp` (currently only ALT triggers them on macOS)

## Notes

- **KS_META is stubbed to 0** via `#ifndef KS_META` guard — Manuel's `keybuffer.cpp` doesn't currently translate `SDL_KMOD_GUI` (macOS Cmd) to a key state flag. The undo handler accepts both `KS_ALT` and `KS_META` so it lights up automatically once GUI→META is wired.
- **Ctrl+Z is intentionally NOT undo** — it's already the legacy block-clear operation in `CUI_Patterneditor.cpp:1917`. ALT+Z mirrors what the upstream master commit chose for the same reason.
- New Ctrl+Shift+X handlers run **before** Manuel's existing `if (kstate == KS_CTRL)` switch (which uses exact equality and would skip Shift combos). Each sets `key = 0` after handling to prevent double-dispatch.
- New `Ctrl+I` interpolate is column-aware (`T_NOTE` / `T_VOL` / `T_FXP`) and falls through to the legacy effect-data interpolation when the selection is too small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
