### PR TITLE
Cross-platform bug fixes: skin double-free, screen bleed, macOS Cmd key, layout/clamp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,3 +268,13 @@ endif()
 set_target_properties(zt PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Program"
 )
+
+# Copy runtime data (zt.conf, skins, doc) next to the binary so it works out of the box.
+add_custom_command(TARGET zt POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${CMAKE_SOURCE_DIR}/zt.conf" "$<TARGET_FILE_DIR:zt>/zt.conf"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${CMAKE_SOURCE_DIR}/skins" "$<TARGET_FILE_DIR:zt>/skins"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${CMAKE_SOURCE_DIR}/doc" "$<TARGET_FILE_DIR:zt>/doc"
+)

--- a/src/CUI_Help.cpp
+++ b/src/CUI_Help.cpp
@@ -17,9 +17,22 @@ CUI_Help::CUI_Help(void) {
     FILE *fp;
     int fs=0;
     char *help_file;
-    help_file = (char*)malloc(strlen(zt_directory) + strlen("/doc/help.txt") + 1);
-    sprintf(help_file,"%s/doc/help.txt",zt_directory);
-    if (fp = fopen(help_file,"rt")) {
+    help_file = (char*)malloc(1024);
+    // Try multiple paths: zt_directory/doc, ./doc, then plain ./help.txt.
+    fp = NULL;
+    if (zt_directory[0]) {
+        sprintf(help_file,"%s/doc/help.txt",zt_directory);
+        fp = fopen(help_file,"r");
+    }
+    if (!fp) {
+        sprintf(help_file,"doc/help.txt");
+        fp = fopen(help_file,"r");
+    }
+    if (!fp) {
+        sprintf(help_file,"help.txt");
+        fp = fopen(help_file,"r");
+    }
+    if (fp) {
         while(!feof(fp)) {
             fgetc(fp);
             fs++;
@@ -59,6 +72,9 @@ void CUI_Help::update() {
     UI->update();
     if (Keys.size()) {
         key = Keys.getkey();
+        if (key == SDLK_F1 || key == SDLK_ESCAPE) {
+            switch_page(UIP_Patterneditor);
+        }
     }
 }
 

--- a/src/CUI_InstEditor.cpp
+++ b/src/CUI_InstEditor.cpp
@@ -89,7 +89,7 @@ CUI_InstEditor::CUI_InstEditor(void) {
     ie = new InstEditor;
     UI->add_element(ie,tabindex++);
     ie->x = 5;
-    ie->y = 13;
+    ie->y = TRACKS_ROW_Y;
     ie->xsize = 29;
 
     ie->ysize = MAX_INSTS ;

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -6,7 +6,7 @@
 #define TRACKS_POS_Y                    row(TRACKS_ROW_Y)
 #define TRACKS_FIRST_NOTE_POS_Y         row(TRACKS_ROW_Y + 1)
 
-#define SPACE_IN_CHARACTERS_AT_BOTTOM   20
+#define SPACE_AT_BOTTOM                 4  // rows reserved below pattern for border/padding
 
 
 int PATTERN_EDIT_ROWS = 100;
@@ -877,14 +877,14 @@ CUI_Patterneditor::~CUI_Patterneditor(void)
 void CUI_Patterneditor::enter(void)
 {
   need_refresh = 1;
+  clear = 1;
   cur_state = STATE_PEDIT;
   mousedrawing=0;
   //PATTERN_EDIT_ROWS = 32 + 4 + (INTERNAL_RESOLUTION_Y - 480) / 8;
   
-  // <Manu> 180 es el espacio que queda más o menos para las notas descontando dónde empiezan los tracks, la toolbar, etc.
-  //        No sería mala idea calcular esto de una manera un poco más clara.
+  // Dynamic row count based on current window height - see issue #15.
 
-  PATTERN_EDIT_ROWS = (INTERNAL_RESOLUTION_Y / 8) - SPACE_IN_CHARACTERS_AT_BOTTOM ;
+  PATTERN_EDIT_ROWS = CHARS_Y - TRACKS_ROW_Y - 1 - SPACE_AT_BOTTOM ;
 
   //  this->mode = PEM_REGULARKEYS;
 }
@@ -912,9 +912,9 @@ void CUI_Patterneditor::leave(void)
 // ------------------------------------------------------------------------------------------------
 //
 //
-void CUI_Patterneditor::update() 
+void CUI_Patterneditor::update()
 {
-  PATTERN_EDIT_ROWS = (INTERNAL_RESOLUTION_Y / 8) - SPACE_IN_CHARACTERS_AT_BOTTOM ;
+  PATTERN_EDIT_ROWS = CHARS_Y - TRACKS_ROW_Y - 1 - SPACE_AT_BOTTOM ;
 
   int i,j,o=0,p=0,step=0,noplay=0,bump=0;
   unsigned char set_note=0xff,kstate;
@@ -1241,7 +1241,7 @@ void CUI_Patterneditor::update()
 /*
       if (kstate == KS_SHIFT) {
       }
-      if (kstate == KS_ALT) {
+      if (KS_HAS_ALT(kstate)) {
       }
       if (kstate == KS_CTRL) {
       }
@@ -1619,7 +1619,7 @@ void CUI_Patterneditor::update()
 
         }
 
-        if (kstate == KS_ALT ) {
+        if (KS_HAS_ALT(kstate)) {
         
           switch(key)
           {
@@ -2009,7 +2009,7 @@ void CUI_Patterneditor::update()
             
             }
         }       
-        if (kstate == KS_ALT) {
+        if (KS_HAS_ALT(kstate)) {
           switch(key) {
             
           case SDLK_GRAVE: 
@@ -2212,7 +2212,8 @@ void CUI_Patterneditor::update()
           break;
         
         // -------------------------------------------
-        case SDLK_DELETE:
+                case SDLK_BACKSPACE:   // Mac "delete" key (backspace) - same as Delete
+case SDLK_DELETE:
 
           if (kstate == KS_CTRL) {
 
@@ -3142,12 +3143,12 @@ void CUI_Patterneditor::draw(Drawable *S)
   if (S->lock()==0) {
 
 
-    // Innecesario?
-    //if (clear) {
-    //
-    //  S->fillRect(col(1),row(12),INTERNAL_RESOLUTION_X,INTERNAL_RESOLUTION_Y - (480-424),0xFF0000FF/*COLORS.Background*/);
-    //  clear=0;
-    //}
+    if (clear) {
+      S->fillRect(col(1),row(12),INTERNAL_RESOLUTION_X,INTERNAL_RESOLUTION_Y - (480-424),COLORS.Background);
+      clear=0;
+    }
+
+
 
     o=0;
     

--- a/src/CUI_Playsong.cpp
+++ b/src/CUI_Playsong.cpp
@@ -83,7 +83,7 @@ void CUI_Playsong::enter(void)
 //
 //
 void CUI_Playsong::leave(void) {
-
+    need_refresh = 1;
 }
 
 

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -10,7 +10,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
     
 //    CommentEditor *ce;
 
-    int base_y = 13;
+    int base_y = TRACKS_ROW_Y;
 
     tpb_tab[0] = 2;
     tpb_tab[1] = 4;
@@ -182,11 +182,11 @@ void CUI_Songconfig::update()
 }
 
 void CUI_Songconfig::draw(Drawable *S) {
-    int base_y = 13;
+    int base_y = TRACKS_ROW_Y;
     if (S->lock()==0) {
         UI->draw(S);
         draw_status(S);
-        printtitle(PAGE_TITLE_ROW_Y,"Song Configuration",COLORS.Text,COLORS.Background,S);
+        printtitle(PAGE_TITLE_ROW_Y,"Song Configuration (F11)",COLORS.Text,COLORS.Background,S);
         print(row(11),col(base_y),"Title",COLORS.Text,S);
         print(row(13),col(base_y+2),   "BPM",COLORS.Text,S);
         print(row(13),col(base_y+3),"TPB",COLORS.Text,S);

--- a/src/CUI_Sysconfig.cpp
+++ b/src/CUI_Sysconfig.cpp
@@ -253,6 +253,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
     TextInput *ti;
 
     int tabindex=0;
+    int base_y = TRACKS_ROW_Y;  // Align controls with Pattern Editor content start
     UI = new UserInterface;
     // MIDI Devices
 
@@ -261,7 +262,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         vs = new ValueSlider;
         UI->add_element(vs,tabindex++);
         vs->x = 4 + 15;
-        vs->y = 14;
+        vs->y = base_y;
         vs->xsize = 15+1;
         vs->ysize = 1;
         vs->value = zt_config_globals.prebuffer_rows;
@@ -271,7 +272,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         cb = new CheckBox;
         UI->add_element(cb,tabindex++);
         cb->x = 4 + 15;
-        cb->y = 16;
+        cb->y = base_y + 2;
         cb->xsize = 5;
         cb->value = &zt_config_globals.auto_send_panic;
         cb->frame = 1;
@@ -279,7 +280,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         cb = new CheckBox;
         UI->add_element(cb,tabindex++);
         cb->x = 4 + 15;
-        cb->y = 18;
+        cb->y = base_y + 4;
         cb->xsize = 5;
         cb->value = &zt_config_globals.midi_in_sync;
         cb->frame = 1;
@@ -287,7 +288,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         cb = new CheckBox;
         UI->add_element(cb,tabindex++);
         cb->x = 4 + 15;
-        cb->y = 20;
+        cb->y = base_y + 6;
         cb->xsize = 5;
         cb->value = &zt_config_globals.auto_open_midi;
         cb->frame = 1;
@@ -296,7 +297,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         UI->add_element(cb,tabindex++); // id:4
         cb->frame = 0;
         cb->x = 4+15;
-        cb->y = 22;
+        cb->y = base_y + 8;
         cb->xsize = 5;
         cb->value = &zt_config_globals.full_screen;
         cb->frame = 1;
@@ -305,7 +306,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         vs = new ValueSlider;
         UI->add_element(vs,tabindex++);
         vs->x = 4+15;
-        vs->y = 24;
+        vs->y = base_y + 10;
         vs->xsize = 15+4;
         vs->ysize = 1;
         vs->value = zt_config_globals.key_repeat_time;
@@ -315,7 +316,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         vs = new ValueSlider;
         UI->add_element(vs,tabindex++);
         vs->x = 4+15;
-        vs->y = 26;
+        vs->y = base_y + 12;
         vs->xsize = 15+4;
         vs->ysize = 1;
         vs->value = zt_config_globals.key_wait_time;
@@ -326,7 +327,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         sk = new SkinSelector;
         UI->add_element(sk,tabindex++);
         sk->x = 4+35 +10;
-        sk->y = 16;
+        sk->y = base_y + 2;
         sk->xsize = 19+4;
         sk->ysize = 10;
 
@@ -489,19 +490,19 @@ void CUI_Sysconfig::draw(Drawable *S) {
         UI->draw(S);
         draw_status(S);
         status(S);
-        printtitle(PAGE_TITLE_ROW_Y,"System Configuration",COLORS.Text,COLORS.Background,S);
-        print(row(4),col(14),"     Prebuffer",COLORS.Text,S);
-        print(row(4),col(16)," Panic on stop",COLORS.Text,S);
-        print(row(4),col(18)," MIDI-IN Slave",COLORS.Text,S);
-        print(row(4),col(20),"Auto-open MIDI",COLORS.Text,S);
+        printtitle(PAGE_TITLE_ROW_Y,"System Configuration (F12)",COLORS.Text,COLORS.Background,S);
+        print(row(4),col(TRACKS_ROW_Y),"     Prebuffer",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+2)," Panic on stop",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+4)," MIDI-IN Slave",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+6),"Auto-open MIDI",COLORS.Text,S);
 
-        print(row(4),col(22),"   Full Screen",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+8),"   Full Screen",COLORS.Text,S);
         //print(row(4),col(24),"  Step Editing",COLORS.Text,S);
 #ifndef DISABLED_CONFIGURATION_VALUES
-        print(row(4),col(24),"    Key Repeat",COLORS.Text,S);
-        print(row(4),col(26),"      Key Wait",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+10),"    Key Repeat",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+12),"      Key Wait",COLORS.Text,S);
 #endif
-        print(row(4+37+8),col(14),"Skin Selection",COLORS.Text,S);
+        print(row(4+37+8),col(TRACKS_ROW_Y+2),"Skin Selection",COLORS.Text,S);
 
         print(row(4),col(30),"MIDI Out Device Selection",COLORS.Text,S);
         print(row(4+37),col(30),"MIDI In Device Selection",COLORS.Text,S);

--- a/src/PatternDisplay.cpp
+++ b/src/PatternDisplay.cpp
@@ -107,7 +107,7 @@ int PatternDisplay::update()
       }
     }
 
-    if (kstate == KS_ALT) {
+    if (KS_HAS_ALT(kstate)) {
 
       switch(key) 
       {

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -2444,20 +2444,24 @@ int ListBox::update() {
         
         switch(key) {
             case SDLK_TAB: ret = 1; act++; break;
-            case SDLK_UP: 
+            case SDLK_UP:
                 if (cur_sel>0)
                     cur_sel--;
                 else
                 if (y_start>0)
                     y_start--;
-                act++; 
+                else
+                    ret = -1;  // At top of list, pass focus to previous element (#18)
+                act++;
                 break;
-            case SDLK_DOWN: 
+            case SDLK_DOWN:
                 if (cur_sel+y_start<num_elements-1) {
                     if (cur_sel<ysize)
                         cur_sel++;
                     else
                         y_start++;
+                } else {
+                    ret = 1;  // At bottom of list, pass focus to next element (#18)
                 }
                 act++;
                 break;
@@ -2555,6 +2559,13 @@ void ListBox::draw(Drawable *S, int active) {
     int cy;
     TColor f,b;
     unsigned char *str;
+
+    // Clamp cursor after window resize - prevent cursor from being off-screen (#13).
+    if (cur_sel > ysize) cur_sel = ysize;
+    if (y_start + cur_sel >= num_elements && num_elements > 0)
+        y_start = (num_elements - 1) - cur_sel;
+    if (y_start < 0) y_start = 0;
+
     str = (unsigned char *)malloc(xsize+1+2);
     LBNode *node = getNode(y_start);
     for (cy=0;cy<=ysize;cy++) {

--- a/src/keybuffer.cpp
+++ b/src/keybuffer.cpp
@@ -146,6 +146,15 @@ void KeyBuffer::insert(KBKey key, KBMod state, unsigned char actual_char) {
         c |= KS_CTRL;
     if (state & SDL_KMOD_SHIFT)
         c |= KS_SHIFT;
+#ifdef __APPLE__
+    // On macOS, map Cmd (SDL_KMOD_GUI) to KS_META AND KS_ALT so that
+    // Cmd+key works everywhere ALT+key does (Cmd is the primary modifier on Mac).
+    if (state & SDL_KMOD_GUI)
+        c |= KS_META | KS_ALT;
+#else
+    if (state & SDL_KMOD_GUI)
+        c |= KS_META;
+#endif
     if (state == KS_LAST_STATE) {
         buffer[head].actual_char = last_actual_char;
         buffer[head].state = ls;

--- a/src/keybuffer.h
+++ b/src/keybuffer.h
@@ -7,7 +7,12 @@
 #define KS_ALT   1
 #define KS_CTRL  2
 #define KS_SHIFT 4
+#define KS_META  8   // Cmd key on macOS, Win key on Windows
 #define KS_LAST_STATE 0xFF
+
+// Helper: true if ALT is active (matches ALT alone, META alone, or META+ALT)
+// Used so that on macOS, Cmd+key works everywhere ALT+key does.
+#define KS_HAS_ALT(ks) (((ks) & (KS_ALT|KS_META)) && !((ks) & (KS_CTRL|KS_SHIFT)))
 
 typedef unsigned int KBKey ;
 typedef unsigned int KBMod;

--- a/src/lc_sdl_wrapper.cpp
+++ b/src/lc_sdl_wrapper.cpp
@@ -77,6 +77,7 @@
     Drawable::~Drawable() {
         if (surface && free_surface_on_delete) {
             zt_destroy_surface(surface);
+            surface = NULL;
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -406,7 +406,7 @@ void close_popup_window(void)
 // ------------------------------------------------------------------------------------------------
 //
 //
-void switch_page(CUI_Page *page) 
+void switch_page(CUI_Page *page)
 {
     LastPage = ActivePage;
     if (LastPage)
@@ -415,7 +415,11 @@ void switch_page(CUI_Page *page)
     ActivePage->enter();
     if (ActivePage->UI)
         ActivePage->UI->full_refresh();
+    // Force full screen clear to prevent previous page from bleeding through (#17).
+    if (screen_buffer)
+        screen_buffer->fillRect(0, 0, INTERNAL_RESOLUTION_X, INTERNAL_RESOLUTION_Y, COLORS.Background);
     screenmanager.UpdateAll();
+    doredraw++;
     need_refresh++;
 }
 
@@ -2041,9 +2045,14 @@ int initGFX ()
 // ------------------------------------------------------------------------------------------------
 //
 //
-int postAction () 
+int postAction ()
 {  // Deinit functions
-    
+
+    // Guard against cleanup crashes when initialization failed (e.g. zt.conf not found).
+    if (!cur_dir || !MidiOut || !MidiIn) {
+        return 0;
+    }
+
     intlist *mod;
     OutputDevice *m;
     midiInDevice *mi;

--- a/src/skins.cpp
+++ b/src/skins.cpp
@@ -201,18 +201,18 @@ void Skin::freeLogo(void)
 // ------------------------------------------------------------------------------------------------
 //
 //
-void Skin::unload() 
+void Skin::unload()
 {
-  delete bmToolbar;
+  if (bmToolbar) { delete bmToolbar; bmToolbar = NULL; }
 
 #ifdef _ENABLE_LOAD_SAVE_DECORATION
-  delete bmLoad;
-  delete bmSave;
+  if (bmLoad)    { delete bmLoad;    bmLoad    = NULL; }
+  if (bmSave)    { delete bmSave;    bmSave    = NULL; }
 #endif
 
-  delete bmButtons;
-  delete bmAbout;
-  delete bmLogo;
+  if (bmButtons) { delete bmButtons; bmButtons = NULL; }
+  if (bmAbout)   { delete bmAbout;   bmAbout   = NULL; }
+  if (bmLogo)    { delete bmLogo;    bmLogo    = NULL; }
   reset();
 
 }

--- a/src/zt.h
+++ b/src/zt.h
@@ -111,7 +111,7 @@ static inline void zt_text_input_stop(void) {
 #define INITIAL_ROW 1 // <Manu> Never set to 0, there are some -1 in calculations
 #define PAGE_TITLE_ROW_Y                (INITIAL_ROW + 8)
 #define TRACKS_ROW_Y                    (PAGE_TITLE_ROW_Y + 2)
-#define HEADER_ROW                      2
+#define HEADER_ROW                      1
 
 #define BASE_OCTAVE_MIN                 0
 #define BASE_OCTAVE_MAX                 9


### PR DESCRIPTION
## Summary

Cross-platform bug fixes ported and triaged onto your SDL3 base. Many candidates from the `master` branch were dropped because your refactor either fixed them already or made them irrelevant. This PR contains only the still-needed ones.

## Triage table

| Source | Decision | Why |
|---|---|---|
| Skin double-free guard | **Ported** | `Skin::unload()` still double-deletes; `Drawable::~Drawable` doesn't null the surface |
| help.txt path fallbacks (mac) + F3 alignment | **Ported** | Help dialog path resolution + InstEditor F3 column alignment |
| `postAction()` null-guards + CMake data copy | **Ported** | `postAction()` still derefs MidiOut unguarded; CMake copy of `zt.conf`/`skins`/`doc` next to binary is genuinely useful |
| Pattern Editor full height + ListBox cursor clamp (#13, #15) | **Ported** | `SPACE_IN_CHARACTERS_AT_BOTTOM=20` still present; clamp matters more now that the window is resizeable |
| `switch_page` fill + F11/F12 hotkey labels (#17) | **Ported** | `switch_page` doesn't fill; titles lacked hotkey hints |
| Help ESC + pedit clear + Playsong refresh (#17) | **Ported** | Help has no ESC handler in origin; pedit `clear` block was commented out |
| Align all pages to TRACKS_ROW_Y + HEADER_ROW | **Ported** (partial) | Layout + HEADER_ROW; `SDL_EnableKeyRepeat` part dropped — doesn't exist in SDL3 (event-driven now) |
| F12 layout overhaul | **Ported** (partial) | Base `base_y` alignment; deeper overhaul deferred to a follow-up |
| ListBox cursor nav between controls (#18) | **Ported** | Same DIK_UP/DOWN trap behavior on origin |
| `SDL_KMOD_GUI → KS_META` mapping in `keybuffer.cpp` | **Ported** | **The fundamental fix** — without this, no Cmd-key shortcut works on macOS |
| `KS_HAS_ALT(ks)` macro accepting both KS_ALT and KS_META | **Ported** | Cheap way to make every `kstate == KS_ALT` check accept the Cmd alias |
| macOS Backspace → Delete | **Ported** | Origin had only `SDLK_DELETE` case |
| `cur_dir` allocation order | **Skipped** | Origin's `initSDL` already allocates before use |
| Path separator portability | **Skipped** | Origin already uses `_WIN32`-gated separators |
| `const char*` cleanup (19 files) | **Skipped** | Warnings only, not errors; large cross-cutting diff unsuitable for a focused bug-fix PR |
| 8-bit PNG support | **Skipped** | Already supported in `img_sdl3.cpp` via `png_set_palette_to_rgb` |
| Remove debug fprintf | **Skipped** | Already gone in origin |
| MIDI device name fix | **Skipped** | Origin uses Win32 `midiOutGetDevCaps`, not RtMidi — different code path, separate PR |

## Files changed (15 files, +120 / −57)

```
CMakeLists.txt            | 10 ++++++++++
src/CUI_Help.cpp          | 22 +++++++++++++++++++---
src/CUI_InstEditor.cpp    |  2 +-
src/CUI_Patterneditor.cpp | 33 +++++++++++++++++----------------
src/CUI_Playsong.cpp      |  2 +-
src/CUI_Songconfig.cpp    |  6 +++---
src/CUI_Sysconfig.cpp     | 37 +++++++++++++++++++------------------
src/PatternDisplay.cpp    |  2 +-
src/UserInterface.cpp     | 17 ++++++++++++++---
src/keybuffer.cpp         |  9 +++++++++
src/keybuffer.h           |  5 +++++
src/lc_sdl_wrapper.cpp    |  1 +
src/main.cpp              | 15 ++++++++++++---
src/skins.cpp             | 14 +++++++-------
src/zt.h                  |  2 +-
```

## Test plan

- [x] Builds clean on macOS arm64 with SDL3 from Homebrew (`build-pr-a/Program/zt`)
- [ ] Builds on Windows (untested — should be unaffected; macOS-specific blocks are gated by `__APPLE__` / Apple SDL key handling)
- [ ] Confirm Cmd+key shortcuts now work on macOS (the unlock from `keybuffer.cpp`)
- [ ] Confirm skin switching no longer crashes on second switch
- [ ] Confirm Help (F1) ESC returns to Pattern Editor
- [ ] Confirm no screen bleed on F2/F3/F4 page switch

## Notes

- **`SDL_KMOD_GUI` → `KS_META` is the single most important change.** Without it, **no** Cmd-key shortcut works on macOS at all. With it, Cmd+R, Cmd+Z, Cmd+1-0, Cmd+S etc. all light up automatically once `KS_HAS_ALT` is in place. This also unlocks the pattern operations in PR #9 to be Cmd-driven on macOS.
- **`SDL_EnableKeyRepeat` (SDL 1.2) does not exist in SDL3.** The key-repeat portion of the original master commit was deliberately dropped — needs a different implementation using the `repeat` flag in `SDL_EVENT_KEY_DOWN`.
- **Mixed CRLF/LF line endings** in some origin source files were preserved byte-exactly to keep the diff clean.
- **Window-resize-related fixes (#13, #15) matter more on SDL3** than on the old SDL 1.2 build because the window is now resizeable — the hidden bugs become visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
