### PR TITLE
Add Multichannel .MID and per-track .MID export

### DIFF
--- a/src/CUI_FileLists_Common.hpp
+++ b/src/CUI_FileLists_Common.hpp
@@ -28,7 +28,7 @@
 
 #define FILE_LIST_SIZE_X_CHARS             40
 #define LOAD_FILE_LIST_SIZE_Y_CHARS        (LISTS_MAX_NUMBER_OF_ELEMENTS)
-#define SAVE_FILE_LIST_SIZE_Y_CHARS        (LISTS_MAX_NUMBER_OF_ELEMENTS - 6) // We need extra space for the text input and the two buttons
+#define SAVE_FILE_LIST_SIZE_Y_CHARS        (LISTS_MAX_NUMBER_OF_ELEMENTS - 10) // text input + 4 save-format buttons
 
 
 // Directory list configuration (In characters)
@@ -66,6 +66,12 @@
 
 #define SAVE_MID_BUTTON_POS_X        FILE_LIST_POS_X_CHARS
 #define SAVE_MID_BUTTON_POS_Y        (SAVE_ZT_BUTTON_POS_Y + 1 + 1)
+
+#define SAVE_MID_MC_BUTTON_POS_X     FILE_LIST_POS_X_CHARS
+#define SAVE_MID_MC_BUTTON_POS_Y     (SAVE_MID_BUTTON_POS_Y + 1 + 1)
+
+#define SAVE_MID_PT_BUTTON_POS_X     FILE_LIST_POS_X_CHARS
+#define SAVE_MID_PT_BUTTON_POS_Y     (SAVE_MID_MC_BUTTON_POS_Y + 1 + 1)
 
 //#define SAVE_GBA_BUTTON_POS_X        FILE_LIST_POS_X_CHARS
 //#define SAVE_GBA_BUTTON_POS_Y        (SAVE_ZT_BUTTON_POS_Y + 1 + 1 + 1 + 1)

--- a/src/CUI_Page.h
+++ b/src/CUI_Page.h
@@ -233,6 +233,8 @@ class CUI_Savescreen : public CUI_Page {
         TextInput *ti;
         Button *b_zt;
         Button *b_mid;
+        Button *b_mid_mc;
+        Button *b_mid_pertrack;
         //Button *b_gba;
         
         CUI_Savescreen();

--- a/src/CUI_SaveMsg.cpp
+++ b/src/CUI_SaveMsg.cpp
@@ -59,10 +59,39 @@ unsigned long ZT_THREAD_CALL save_thread(void *) {
                 status_change = 1;
             }
             break;
-        case 2:
+        case 2: {
             ZTImportExport zie;
             zie.ExportMID((char *)song->filename,0);
             break;
+        }
+        case 3: {
+            ZTImportExport zie;
+            if (zie.ExportMultichannelMID((char *)song->filename)) {
+                sprintf(szStatmsg, "Exported multichannel MIDI to %s",
+                        (char *)song->filename);
+            } else {
+                sprintf(szStatmsg,
+                        "Multichannel MIDI export failed (no tracks with events)");
+            }
+            statusmsg = szStatmsg;
+            status_change = 1;
+            break;
+        }
+        case 4: {
+            ZTImportExport zie;
+            int n = zie.ExportPerTrackMID((char *)song->filename);
+            if (n > 0) {
+                sprintf(szStatmsg,
+                        "Exported %d per-track .MID files (e.g. *_track01.mid)",
+                        n);
+            } else {
+                sprintf(szStatmsg,
+                        "Per-track MIDI export failed (no tracks with events)");
+            }
+            statusmsg = szStatmsg;
+            status_change = 1;
+            break;
+        }
     }
     save_finished = 1;
     is_saving = 0;

--- a/src/CUI_Savescreen.cpp
+++ b/src/CUI_Savescreen.cpp
@@ -106,51 +106,32 @@ int file_exists(const char *fn)
 // ------------------------------------------------------------------------------------------------
 //
 //
+// Save-format buttons live at element IDs 4..7 (ZT, MID, MID-Multichannel,
+// MID-PerTrack). Radio-style: clicking any one toggles it on and clears the
+// others.
+#define SAVEBTN_ID_FIRST 4
+#define SAVEBTN_ID_LAST  7
+
 void BTNCLK_ToggleZTMID(UserInterfaceElement *b)
 {
     Button *btn;
     btn = (Button *)b;
-    need_refresh++; 
+    need_refresh++;
 
     if (btn->updown == 0) {
 
-        btn->updown = !btn->updown;
+        btn->updown = 1;
 
-        if (btn->ID == 4) {
+        for (int id = SAVEBTN_ID_FIRST; id <= SAVEBTN_ID_LAST; id++) {
 
-            ((Button*)UIP_Savescreen->UI->get_element(5))->updown = 0;
-            ((Button*)UIP_Savescreen->UI->get_element(5))->state = 0;
-            ((Button*)UIP_Savescreen->UI->get_element(5))->need_redraw = 1;
+            if (id == btn->ID) continue;
 
-            /*((Button*)UIP_Savescreen->UI->get_element(6))->updown = 0;
-            ((Button*)UIP_Savescreen->UI->get_element(6))->state = 0;
-            ((Button*)UIP_Savescreen->UI->get_element(6))->need_redraw = 1;*/
-        }
-        else {
+            Button *other = (Button*)UIP_Savescreen->UI->get_element(id);
+            if (!other) continue;
 
-            if (btn->ID == 5) {
-
-                ((Button*)UIP_Savescreen->UI->get_element(4))->updown = 0;
-                ((Button*)UIP_Savescreen->UI->get_element(4))->state = 0;
-                ((Button*)UIP_Savescreen->UI->get_element(4))->need_redraw = 1;
-
-                /*((Button*)UIP_Savescreen->UI->get_element(6))->updown = 0;
-                ((Button*)UIP_Savescreen->UI->get_element(6))->state = 0;
-                ((Button*)UIP_Savescreen->UI->get_element(6))->need_redraw = 1;*/
-            }
-            /*else {
-
-                if (btn->ID == 6) {
-
-                    ((Button*)UIP_Savescreen->UI->get_element(4))->updown = 0;
-                    ((Button*)UIP_Savescreen->UI->get_element(4))->state = 0;
-                    ((Button*)UIP_Savescreen->UI->get_element(4))->need_redraw = 1;
-
-                    ((Button*)UIP_Savescreen->UI->get_element(5))->updown = 0;
-                    ((Button*)UIP_Savescreen->UI->get_element(5))->state = 0;
-                    ((Button*)UIP_Savescreen->UI->get_element(5))->need_redraw = 1;
-                }
-            }*/
+            other->updown = 0;
+            other->state = 0;
+            other->need_redraw = 1;
         }
     }
 }
@@ -245,6 +226,26 @@ CUI_Savescreen::CUI_Savescreen(void)
   b_mid->xsize = strlen(b_mid->caption) + 1;
   b_mid->OnClick = (ActFunc)BTNCLK_ToggleZTMID;
   b_mid->auto_anchor_at_current_pos(ANCHOR_LEFT | ANCHOR_DOWN) ;
+
+  b_mid_mc = new Button;
+  UI->add_element(b_mid_mc, 6);
+  b_mid_mc->x = SAVE_MID_MC_BUTTON_POS_X;
+  b_mid_mc->y = SAVE_MID_MC_BUTTON_POS_Y;
+  b_mid_mc->caption = " Save as Multichannel .MID";
+  b_mid_mc->ysize = 1;
+  b_mid_mc->xsize = strlen(b_mid_mc->caption) + 1;
+  b_mid_mc->OnClick = (ActFunc)BTNCLK_ToggleZTMID;
+  b_mid_mc->auto_anchor_at_current_pos(ANCHOR_LEFT | ANCHOR_DOWN) ;
+
+  b_mid_pertrack = new Button;
+  UI->add_element(b_mid_pertrack, 7);
+  b_mid_pertrack->x = SAVE_MID_PT_BUTTON_POS_X;
+  b_mid_pertrack->y = SAVE_MID_PT_BUTTON_POS_Y;
+  b_mid_pertrack->caption = " Save per-track .MID";
+  b_mid_pertrack->ysize = 1;
+  b_mid_pertrack->xsize = strlen(b_mid_pertrack->caption) + 1;
+  b_mid_pertrack->OnClick = (ActFunc)BTNCLK_ToggleZTMID;
+  b_mid_pertrack->auto_anchor_at_current_pos(ANCHOR_LEFT | ANCHOR_DOWN) ;
 
   /*b_gba = new Button;
   UI->add_element(b_gba, 6);
@@ -348,9 +349,17 @@ void begin_save(void)
     }
   }
 
-  if (((Button *)UIP_Savescreen->UI->get_element(5))->state) {
+  // MIDI exports: .MID (2), Multichannel .MID (3), per-track .MID (4).
+  // All three ensure a .mid extension; the per-track exporter appends its
+  // own _trackNN suffix per file.
+  int mid_filetype = 0;
+  if (((Button *)UIP_Savescreen->UI->get_element(5))->state) mid_filetype = 2;
+  else if (((Button *)UIP_Savescreen->UI->get_element(6))->state) mid_filetype = 3;
+  else if (((Button *)UIP_Savescreen->UI->get_element(7))->state) mid_filetype = 4;
 
-    UIP_SaveMsg->filetype = 2;
+  if (mid_filetype) {
+
+    UIP_SaveMsg->filetype = mid_filetype;
     int i=0;
 
     while(i<255 && save_filename[i] != 0) {
@@ -374,7 +383,13 @@ void begin_save(void)
       if (i>0) memcpy(&save_filename[i+4],".mid",4);
     }
 
-    if (file_exists(save_filename)) {
+    // Per-track mode writes to <basename>_trackNN.mid, not the raw
+    // filename, so the "File exists" check based on save_filename is
+    // meaningless there -- just proceed.
+    if (mid_filetype == 4) {
+      do_save();
+    }
+    else if (file_exists(save_filename)) {
 
       UIP_RUSure->str = " File exists, sure?";
       UIP_RUSure->OnYes = (VFunc)do_save;

--- a/src/import_export.cpp
+++ b/src/import_export.cpp
@@ -485,6 +485,341 @@ int ZTImportExport::ExportMID(char *fn, int format)
 
 
 
+// ------------------------------------------------------------------------------------------------
+// Helper: scan all patterns/tracks and mark which zTracker tracks have any
+// event with an instrument assigned. Needed so empty tracks don't create
+// stub MTrks.
+//
+static void find_used_tracks(unsigned char tflag[MAX_TRACKS], zt_module *song)
+{
+  for (int i = 0; i < MAX_TRACKS; i++) tflag[i] = 0;
+
+  for (int p = 0; p < 256; p++) {
+
+    for (int t = 0; t < MAX_TRACKS; t++) {
+
+      event *e = song->patterns[p]->tracks[t]->event_list;
+
+      while (e) {
+
+        if (e->inst < MAX_INSTS) { tflag[t] = 1; break; }
+        e = e->next_event;
+      }
+    }
+  }
+}
+
+
+
+
+// ------------------------------------------------------------------------------------------------
+// Write a single MIDI event into a per-track CDataBuf. Mirrors the event
+// encoding used by ExportMID(). Returns nothing; mutates mp and dtime_ref.
+//
+static void push_midi_event(CDataBuf *mp, midi_event *e, int &dtime_ref)
+{
+  int stat;
+
+  switch (e->type) {
+
+    case ET_NOTE_OFF:
+      e->data2 = 0x0;
+      // fall through
+    case ET_NOTE_ON:
+      push_varlen(mp, dtime_ref);
+      dtime_ref = 0;
+      stat = (e->data1 & 0x0F) + 0x90;
+      mp->pushuc(stat);
+      mp->pushuc(e->command);
+      mp->pushuc((unsigned char)e->data2);
+      break;
+
+    case ET_PC:
+      if (e->data2 >= 0) {
+        unsigned short int bank;
+        unsigned char hb, lb;
+        bank = e->data2;
+        bank &= 0x3fff;
+        lb = bank & 0x007F;
+        hb = bank >> 7;
+        push_varlen(mp, dtime_ref);
+        dtime_ref = 0;
+        mp->pushuc(0xB0 + e->data2);
+        mp->pushuc(0x0);
+        mp->pushuc(lb);
+        push_varlen(mp, 0);
+        mp->pushuc(0xB0 + e->data2);
+        mp->pushuc(0x20);
+        mp->pushuc(hb);
+      }
+      push_varlen(mp, dtime_ref);
+      dtime_ref = 0;
+      mp->pushuc(0xC0 + e->data2);
+      mp->pushuc(e->command);
+      break;
+
+    case ET_CC:
+      push_varlen(mp, dtime_ref);
+      dtime_ref = 0;
+      mp->pushuc(0xB0 + e->data2);
+      mp->pushuc(e->command);
+      mp->pushuc((unsigned char)e->data1);
+      break;
+
+    case ET_PITCH: {
+      unsigned short int usi = (unsigned short int)e->data1 << 8;
+      usi += e->data2;
+      unsigned char d1, d2;
+      usi &= 0x3FFF;
+      d1 = (usi & 0x007F);
+      d2 = usi >> 7;
+      push_varlen(mp, dtime_ref);
+      dtime_ref = 0;
+      mp->pushuc(0xe0 + e->command);
+      mp->pushuc(d1);
+      mp->pushuc(d2);
+      break;
+    }
+
+    default:
+      break;
+  }
+}
+
+
+
+
+// ------------------------------------------------------------------------------------------------
+// ExportMultichannelMID: writes a MIDI Type 1 file where each zTracker
+// track that contains events becomes its own MIDI track. The MIDI channel
+// encoded in each status byte is preserved from the source event's
+// data1 low nybble (which playback populates from the instrument's
+// channel assignment).
+//
+int ZTImportExport::ExportMultichannelMID(char *fn)
+{
+  CDataBuf buffer;
+  CDataBuf mtrk[MAX_TRACKS + 1]; // track 0 = conductor, 1..N = per-track
+  midi_buf *buf;
+  midi_event *e;
+  FILE *fp;
+  int dtime[MAX_TRACKS + 1];
+  int mtrk_tmap[MAX_TRACKS]; // zt track idx -> mtrk idx (0 if unused)
+  unsigned char tflag[MAX_TRACKS];
+  int total_mtrks = 1; // conductor
+  int bpm;
+  char str[256];
+
+  for (int i = 0; i < MAX_TRACKS + 1; i++) dtime[i] = 0;
+  for (int i = 0; i < MAX_TRACKS; i++) mtrk_tmap[i] = 0;
+
+  find_used_tracks(tflag, song);
+
+  for (int t = 0; t < MAX_TRACKS; t++) {
+    if (tflag[t]) {
+      mtrk_tmap[t] = total_mtrks;
+      sprintf(str, "Track %02d", t + 1);
+      push_text(&mtrk[total_mtrks], MID_SEQNAME, (char *)&str[0]);
+      total_mtrks++;
+    }
+  }
+
+  if (total_mtrks <= 1) return 0; // nothing to export
+
+  if (!(fp = fopen(fn, "wb"))) return 0;
+
+  // MThd
+  buffer.write("MThd", 4);
+  push_le_int(&buffer, 6);
+  buffer.pushc(0); buffer.pushc(1);           // format 1
+  buffer.pushc((total_mtrks >> 8) & 0xFF);
+  buffer.pushc(total_mtrks & 0xFF);           // ntrks
+  buffer.pushc(0); buffer.pushc(96);          // 96 PPQN
+
+  // Conductor track: tempo
+  push_varlen(&mtrk[0], 0);
+  mtrk[0].pushc(0xFF);
+  mtrk[0].pushc(0x51);
+  mtrk[0].pushc(0x03);
+  bpm = 60000000 / song->bpm;
+  mtrk[0].pushc((bpm >> 16) & 0xff);
+  mtrk[0].pushc((bpm >> 8) & 0xff);
+  mtrk[0].pushc((bpm) & 0xff);
+
+  // Play through song, routing events by e->track.
+  ztPlayer->prepare_play(0, 0, 1, 0);
+  buf = new midi_buf;
+
+  while (ztPlayer->pinit) {
+
+    buf->reset();
+    ztPlayer->playback(buf, 1);
+
+    while ((e = buf->get_next_event())) {
+
+      if (e->type == ET_LOOP) continue; // skip, same as ExportMID
+      if (e->inst >= MAX_INSTS) continue;
+      if (e->track >= MAX_TRACKS) continue;
+
+      int ztrk = e->track;
+      int trk = mtrk_tmap[ztrk];
+      if (trk == 0) continue; // track wasn't tagged as used
+
+      CDataBuf *mp = &mtrk[trk];
+      push_midi_event(mp, e, dtime[trk]);
+    }
+
+    for (int i = 0; i < MAX_TRACKS + 1; i++) dtime[i]++;
+  }
+
+  delete buf;
+
+  // End-of-track + assemble chunks
+  for (int i = 0; i < total_mtrks; i++) {
+
+    push_varlen(&mtrk[i], 0);
+    mtrk[i].pushc(0xFF);
+    mtrk[i].pushc(0x2f);
+    mtrk[i].pushc(0x00);
+
+    buffer.write("MTrk", 4);
+    push_le_int(&buffer, mtrk[i].getsize());
+    buffer.write(mtrk[i].getbuffer(), mtrk[i].getsize());
+  }
+
+  fwrite(buffer.getbuffer(), buffer.getsize(), 1, fp);
+  fclose(fp);
+
+  return 1;
+}
+
+
+
+
+// ------------------------------------------------------------------------------------------------
+// ExportPerTrackMID: writes one Type 0 .mid file per zTracker track with
+// events. Output filenames: if fn ends in ".mid" (case-insensitive) the
+// suffix is stripped to form a basename; each file is then written to
+// "<basename>_track<NN>.mid".
+//
+int ZTImportExport::ExportPerTrackMID(char *fn)
+{
+  unsigned char tflag[MAX_TRACKS];
+  find_used_tracks(tflag, song);
+
+  int any = 0;
+  for (int t = 0; t < MAX_TRACKS; t++) if (tflag[t]) { any = 1; break; }
+  if (!any) return 0;
+
+  // Derive basename (strip trailing .mid if present).
+  char base[512];
+  {
+    int n = (int)strlen(fn);
+    if (n >= (int)sizeof(base)) n = (int)sizeof(base) - 1;
+    memcpy(base, fn, n);
+    base[n] = 0;
+    if (n >= 4 &&
+        (base[n-4] == '.') &&
+        (base[n-3] == 'm' || base[n-3] == 'M') &&
+        (base[n-2] == 'i' || base[n-2] == 'I') &&
+        (base[n-1] == 'd' || base[n-1] == 'D')) {
+      base[n-4] = 0;
+    }
+  }
+
+  // First, collect per-track deltas + event buffers by playing the song once.
+  CDataBuf mtrk[MAX_TRACKS];
+  int dtime[MAX_TRACKS];
+  for (int i = 0; i < MAX_TRACKS; i++) dtime[i] = 0;
+
+  // Seed each used track with its sequence name.
+  for (int t = 0; t < MAX_TRACKS; t++) {
+    if (tflag[t]) {
+      char str[64];
+      sprintf(str, "Track %02d", t + 1);
+      push_text(&mtrk[t], MID_SEQNAME, (char *)&str[0]);
+    }
+  }
+
+  // Tempo goes into each per-track file (Type 0 has exactly one track that
+  // must carry tempo if the file is to play standalone).
+  int bpm = 60000000 / song->bpm;
+  for (int t = 0; t < MAX_TRACKS; t++) {
+    if (!tflag[t]) continue;
+    push_varlen(&mtrk[t], 0);
+    mtrk[t].pushc(0xFF);
+    mtrk[t].pushc(0x51);
+    mtrk[t].pushc(0x03);
+    mtrk[t].pushc((bpm >> 16) & 0xff);
+    mtrk[t].pushc((bpm >> 8) & 0xff);
+    mtrk[t].pushc((bpm) & 0xff);
+  }
+
+  ztPlayer->prepare_play(0, 0, 1, 0);
+  midi_buf *buf = new midi_buf;
+
+  while (ztPlayer->pinit) {
+
+    buf->reset();
+    ztPlayer->playback(buf, 1);
+
+    midi_event *e;
+    while ((e = buf->get_next_event())) {
+
+      if (e->type == ET_LOOP) continue;
+      if (e->inst >= MAX_INSTS) continue;
+      if (e->track >= MAX_TRACKS) continue;
+      if (!tflag[e->track]) continue;
+
+      push_midi_event(&mtrk[e->track], e, dtime[e->track]);
+    }
+
+    for (int i = 0; i < MAX_TRACKS; i++) dtime[i]++;
+  }
+
+  delete buf;
+
+  // Write each used track to its own file.
+  int exported = 0;
+  for (int t = 0; t < MAX_TRACKS; t++) {
+
+    if (!tflag[t]) continue;
+
+    // End-of-track
+    push_varlen(&mtrk[t], 0);
+    mtrk[t].pushc(0xFF);
+    mtrk[t].pushc(0x2f);
+    mtrk[t].pushc(0x00);
+
+    char outname[600];
+    snprintf(outname, sizeof(outname), "%s_track%02d.mid", base, t + 1);
+
+    FILE *fp = fopen(outname, "wb");
+    if (!fp) continue;
+
+    CDataBuf file;
+    file.write("MThd", 4);
+    push_le_int(&file, 6);
+    file.pushc(0); file.pushc(0);   // format 0
+    file.pushc(0); file.pushc(1);   // 1 track
+    file.pushc(0); file.pushc(96);  // 96 PPQN
+
+    file.write("MTrk", 4);
+    push_le_int(&file, mtrk[t].getsize());
+    file.write(mtrk[t].getbuffer(), mtrk[t].getsize());
+
+    fwrite(file.getbuffer(), file.getsize(), 1, fp);
+    fclose(fp);
+
+    exported++;
+  }
+
+  return exported;
+}
+
+
+
+
 
 /*
 

--- a/src/import_export.h
+++ b/src/import_export.h
@@ -15,6 +15,16 @@ public:
     //int ExportIT(char *fn, zt_module* zt) { }
 
     int ExportMID(char *fn, int format); // format = 0 or 1, for MIDI format 0 or 1
+
+    // Multichannel .MID: Type 1 file where each zTracker track is its own
+    // MIDI track. MIDI channel for each event is preserved from the song's
+    // per-instrument channel assignments (encoded into e->data1 by playback).
+    int ExportMultichannelMID(char *fn);
+
+    // Per-track .MID: emits one Type 0 file per zTracker track that has
+    // events. Output filename per track is derived from fn by stripping a
+    // trailing ".mid" and appending "_trackNN.mid".
+    int ExportPerTrackMID(char *fn);
 };
 
 #endif


### PR DESCRIPTION
## Summary

The Save screen (Ctrl+S) now offers four save formats instead of two:

- Save as .ZT (unchanged)
- Save as .MID (unchanged -- existing per-instrument routing)
- Save as Multichannel .MID (**new**) -- Type 1 MIDI with one MIDI track per zTracker track; conductor track carries tempo; per-event MIDI channel preserved from the source event's channel nibble
- Save per-track .MID (**new**) -- one Type 0 MIDI file per zTracker track, named `<basename>_trackNN.mid`

Both new exporters play the song through the normal playback engine and route each emitted `midi_event` by `e->track` instead of `e->inst`, so per-track mute/arp/pitch-slide state is captured identically to the current `ExportMID`.

## Implementation notes

- `ZTImportExport::ExportMultichannelMID(fn)` and `ZTImportExport::ExportPerTrackMID(fn)` added to `import_export.cpp` / `.h`.
- Shared helper `push_midi_event()` factors out the MIDI event encoding (NOTE_ON/OFF, PC, CC, PITCH) that previously lived inline in `ExportMID`.
- `find_used_tracks()` pre-scans all patterns to skip empty zTracker tracks (no stub MTrks / no empty output files).
- Conductor track in multichannel export holds tempo; per-track files each carry tempo at their head so they play standalone.
- Save screen radio button logic (`BTNCLK_ToggleZTMID`) collapsed into a single loop over element IDs 4..7.
- `SAVE_FILE_LIST_SIZE_Y_CHARS` shrinks by 4 rows to make room for the two new buttons.
- `CUI_SaveMsg` gets cases 3 and 4, each posting a status bar message on completion.

## MIDI channel derivation

Channels come from the source event's `data1 & 0x0F` low nybble, which the playback engine populates from `song->instruments[i]->channel` when emitting notes. That preserves the song's per-instrument channel intent (not the zTracker track index), which is the right behavior when a track plays multiple instruments on different channels.

## Filename handling

- `.MID` and Multichannel `.MID`: filename gets `.mid` appended / normalized, standard "file exists -- sure?" prompt applies.
- Per-track: the raw filename is still normalized to `.mid`, but the "File exists" prompt is skipped because the actual outputs are `<basename>_trackNN.mid`.

## Test plan

- [ ] Build cleanly on macOS (verified locally via `cmake && make -j8` -- no errors)
- [ ] Load an existing `.zt` song, hit Ctrl+S, click "Save as Multichannel .MID", verify the resulting file imports into a DAW with one track per zTracker track on the expected channels
- [ ] Same song, click "Save per-track .MID", verify `<name>_track01.mid` ... `_trackNN.mid` are all playable Type 0 files
- [ ] Verify the original "Save as .MID" still produces identical output to master (no regressions in shared `push_midi_event` path)
- [ ] Windows build still compiles (layout defines and save flow are platform-neutral, but confirm)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
