### PR TITLE
add Humanize Velocities (ALT+H) — Paketti-inspired

### DIFF
--- a/doc/help.txt
+++ b/doc/help.txt
@@ -44,6 +44,7 @@
  CTRL-SHIFT-Down : Rotate Track Down (last row wraps to first)
  CTRL-SHIFT-Up   : Rotate Track Up (first row wraps to last)
  CTRL-F9         : Track Solo (mute all other tracks; repeat to unsolo all)
+ ALT-H           : Humanize Velocities in selection (randomize +/- 15)
 
 |L|%==|H|Block Functions|L|==%|U|
 

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -1647,6 +1647,37 @@ void CUI_Patterneditor::update()
           statusmsg = szStatmsg; status_change = 1; need_refresh++; key = 0;
         }
 
+        // Humanize Velocities: Alt+H — randomize volume column within selection
+        // by +/- HUMANIZE_RANGE on each row that has a note. Paketti-inspired.
+        if ((kstate & KS_ALT) && !(kstate & KS_SHIFT) && !(kstate & KS_CTRL) && key == SDLK_H) {
+          if (selected) {
+            UNDO_SAVE();
+            const int HUMANIZE_RANGE = 15; // +/- steps around current value
+            int touched = 0;
+            for (int t = select_track_start; t <= select_track_end; t++) {
+              track *trk = song->patterns[cur_edit_pattern]->tracks[t];
+              if (!trk) continue;
+              for (int r = select_row_start; r <= select_row_end; r++) {
+                event *ev = trk->get_event(r);
+                if (!ev) continue;
+                if (ev->note >= 0x80) continue;      // skip rows without a real note
+                int v = (ev->vol < 0x80) ? ev->vol : 64; // treat blank vol as 64
+                int delta = (rand() % (2 * HUMANIZE_RANGE + 1)) - HUMANIZE_RANGE;
+                int nv = v + delta;
+                if (nv < 0) nv = 0;
+                if (nv > 127) nv = 127;
+                trk->update_event(r, -1, -1, nv, -1, -1, -1);
+                touched++;
+              }
+            }
+            sprintf(szStatmsg, "Humanized %d note velocit%s (+/- %d)",
+                    touched, touched == 1 ? "y" : "ies", HUMANIZE_RANGE);
+          } else {
+            sprintf(szStatmsg, "Humanize: select a block first (SHIFT+arrow)");
+          }
+          statusmsg = szStatmsg; status_change = 1; need_refresh++; key = 0;
+        }
+
         // Clone Pattern + jump to it: Ctrl+Shift+D
         if ((kstate & KS_CTRL) && (kstate & KS_SHIFT) && key == SDLK_D) {
           int src = cur_edit_pattern;


### PR DESCRIPTION
## Summary

Adds **Humanize Velocities** (ALT+H) — a small Paketti-inspired addition in the same spirit as the pattern ops you just merged in #14.

## What it does

Mark a block with CTRL+B / CTRL+E (or CTRL+L for a full track), press **ALT+H**, and every row with a real note gets its volume column randomized by ±15 steps. Blank-note rows are untouched. Results clamp to 0..127. UNDO_SAVE() is called first so ALT+Z reverts the whole operation.

Status bar reads e.g. `"Humanized 48 note velocities (+/- 15)"`.

## Why

Straight pattern data sounds machine-perfect. A light velocity jitter makes MIDI output feel played instead of programmed — standard tracker/DAW feature. Paketti has a richer humanize panel (configurable range, separate note/volume/delay axes); this is the minimal useful variant for zTracker.

## Files changed (2 files, +32/−0)

- `src/CUI_Patterneditor.cpp` — new handler in the Ctrl/Alt+letter block, placed right after Halve Pattern
- `doc/help.txt` — one line added under Track Solo

## Test plan

- [x] Builds clean on macOS arm64 with SDL3 from Homebrew
- [ ] Builds on Windows / Linux (no SDL-version-specific changes, should be unaffected)
- [ ] Mark a block with notes, press ALT+H → volume column gets randomized ±15, blank rows untouched
- [ ] Without a selection, status bar shows `"Humanize: select a block first (SHIFT+arrow)"`
- [ ] ALT+Z reverts the humanize pass

## Notes

- Key: **ALT+H** (Humanize mnemonic). Paketti convention.
- Hardcoded ±15 range for now. Easy follow-up: make it configurable via the F2-F2 Pattern Editor Options dialog.
- Based on `origin/master` **after** #14 landed (depends on Undo/UNDO_SAVE from #14 being present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
