### PR TITLE
mouse-wheel zoom: preserve current window size (fixes #15 feedback)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2506,9 +2506,18 @@ void mousewheelhandler(SDL_MouseWheelEvent *e) {
     }
 
     if (ZOOM != old_zoom) {
-        if (!set_video_mode(RESOLUTION_X, RESOLUTION_Y, errstr)) {
+        // Preserve the user's current window size across zoom changes.
+        // Previously we passed RESOLUTION_X/Y (initial size from zt.conf),
+        // which snapped the window back every time the user scrolled —
+        // any manual drag-resize was lost on the next zoom tick.
+        int win_w = RESOLUTION_X;
+        int win_h = RESOLUTION_Y;
+        if (zt_main_window) {
+            SDL_GetWindowSize(zt_main_window, &win_w, &win_h);
+        }
+        if (!set_video_mode(win_w, win_h, errstr)) {
             ZOOM = old_zoom;
-            (void)set_video_mode(RESOLUTION_X, RESOLUTION_Y, errstr);
+            (void)set_video_mode(win_w, win_h, errstr);
             return;
         }
         zt_request_ui_full_refresh();


### PR DESCRIPTION
## Summary

Fix for the window-resize-on-scroll-wheel bug @m6502 mentioned in https://github.com/m6502/ztrackerprime/pull/15#issuecomment-4237889968 ("window resizes sometimes when using the mouse wheel to zoom").

## Root cause

`mousewheelhandler()` re-entered the video pipeline by calling:

```cpp
set_video_mode(RESOLUTION_X, RESOLUTION_Y, errstr);
```

`RESOLUTION_X` / `RESOLUTION_Y` are the initial-size globals seeded from `zt.conf`. If the user had manually drag-resized the window since launch, those globals were out of date — so every zoom tick snapped the window back to the original config size.

## Fix

Query the current SDL window size with `SDL_GetWindowSize()` right before calling `set_video_mode`, so zoom changes preserve whatever size the user is currently on.

```cpp
int win_w = RESOLUTION_X;
int win_h = RESOLUTION_Y;
if (zt_main_window) {
    SDL_GetWindowSize(zt_main_window, &win_w, &win_h);
}
if (!set_video_mode(win_w, win_h, errstr)) {
    ZOOM = old_zoom;
    (void)set_video_mode(win_w, win_h, errstr);
    return;
}
```

Applied to both the success-path and rollback-path calls.

## Files changed (1 file, +11/−2)

- `src/main.cpp` — mousewheelhandler only

## Test plan

- [x] Builds clean on macOS arm64 with SDL3 from Homebrew
- [ ] Resize the zTracker window manually (drag corner) to a non-default size
- [ ] Ctrl+scroll wheel up/down to change ZOOM — window should stay at the size you dragged it to, only the internal canvas scales

## Notes

- Only 11 lines. Based on current `origin/master` (post all the PR-B/C/D/A/F/G/E merges).
- No dependency on #21 — standalone one-liner-ish fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
