### PR TITLE
CUI_RUSure: Enter fires focused Yes/No button on same frame

### DIFF
--- a/src/CUI_RUSure.cpp
+++ b/src/CUI_RUSure.cpp
@@ -66,6 +66,21 @@ void CUI_RUSure::update() {
     int key=0;
 //  act = Keys.size(); 
 //  key = Keys.checkkey();
+    // Intercept Enter / KP-Enter BEFORE UI->update() runs. Button's
+    // two-frame press/release state machine can miss its fire point
+    // when the popup closes mid-frame, leaving the dialog up with
+    // Enter apparently doing nothing. Dispatch to the focused
+    // button's callback directly, matching the Y/N/Esc handling
+    // below.
+    {
+        KBKey peek = Keys.checkkey();
+        if (peek == SDLK_RETURN || peek == SDLK_KP_ENTER) {
+            Keys.getkey();
+            if (UI->cur_element == 0) BTNCLK_rusure_yes();
+            else                      BTNCLK_rusure_no();
+            return;
+        }
+    }
     UI->update();
     if (Keys.size()) {
         key = Keys.getkey();


### PR DESCRIPTION
## Summary

Tiny single-file fix: **Enter on the Yes/No popup** (`CUI_RUSure`) now fires the focused button the same way `Y`, `N`, and `Esc` already do.

Reproducer: `Ctrl+Alt+Q` → "Sure to quit?" popup opens → arrow over to **Yes** → press **Enter** → nothing happens. User has to type `Y` or click.

## Cause

`Button` uses a two-frame keyboard activation:
- Frame N (press): `state = 2`, `last_cmd_keyjazz = 1`
- Frame N+1 (release): keyhandler clears `last_cmd_keyjazz`, next `Button::update()` fires `OnClick` because `state==2 && !last_cmd_keyjazz`.

Inside `CUI_RUSure`, Y/N/Esc already bypass that state machine (the popup dispatches them directly to the button callback). Enter was left to Button's press/release cycle, which races with popup teardown and frequently misses the fire point — user perceives "Enter does nothing".

## Fix

At the top of `CUI_RUSure::update()`, before `UI->update()` runs, peek the key queue. If it's `SDLK_RETURN` or `SDLK_KP_ENTER`, pop it and dispatch to `BTNCLK_rusure_yes` / `BTNCLK_rusure_no` based on which button has focus. Same pattern the rest of that `update()` already uses for Y/N/Esc.

One file, +15 lines, no deletions, no behavior change elsewhere.

## Test plan

- [x] Builds clean on macOS arm64
- [ ] CI: Linux / Windows × 2 / macOS × 2 — runs on push
- [ ] Manual: `Ctrl+Alt+Q`, arrow to Yes, Enter → app quits
- [ ] Manual: `Ctrl+Alt+Q`, arrow to No, Enter → popup closes, app keeps running
- [ ] Manual: `Ctrl+Alt+Q`, numpad Enter on Yes → app quits
- [ ] Manual: Y and N hotkeys still work (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
