### PR TITLE
make TextBox text const, prevent compiler warnings

### DIFF
--- a/src/CDataBuf.cpp
+++ b/src/CDataBuf.cpp
@@ -41,7 +41,7 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <cmath>
+#include <algorithm>
 #include <SDL.h>
 
 #include "CDataBuf.h"

--- a/src/CUI_About.cpp
+++ b/src/CUI_About.cpp
@@ -15,76 +15,74 @@ CUI_About::CUI_About(void) {
     l->ysize = (int)((double)26*yscale);
     l->y = 25 + ((INTERNAL_RESOLUTION_Y-480)/8) - (l->ysize-26);
     l->bWordWrap = true ;
-    l->text = "\n"
+    l->text =R"about_text(
+|H|About|U|
 
-"|H|About|U|\n"
-"\n"
-"zTracker Prime is a fork of the original zTracker project from 2001, which was a clone of Impulse Tracker, itself a clone of Scream Tracker. The original zTracker was developed by Christopher Micali until 2002.\n"
-"\n"
-"It had become my go-to software for composing music, so I forked it in 2003. Over 20 years later, it remains my primary sequencer, and as of 2024 I continue to work on it.\n"
-"\n"
-"Check for new releases at the Github project page:\n"
-"\n"
-"https://github.com/m6502/ztrackerprime\n"
-"\n"
-"You can find an archived version of the old source code for the original version here:\n"
-"\n"
-"https://github.com/cmicali/ztracker\n"
-"\n"
-"|H|Contact|U|\n"
-"" "\n"
-"This fork is currently maintained by Manuel Montoto (Debvgger)" "\n"
-"" "\n"
-"Write me to |U|mail@manuelmontoto.com|U|" "\n"
-"" "\n"
-"|H|Credits:|U|\n"
-"\n"
-"  |H|Coding|U|" "\n"
-"" "\n"
-"    Austin Luminais" "\n"
-"    Christopher Micali" "\n"
-"    Daniel Kahlin" "\n"
-"    Manuel Montoto" "\n"
-"    Nic Soudee" "\n"
-"" "\n"
-"  |H|Support|U|" "\n"
-"" "\n"
-"    Amir Geva (libCON / TONS of help)" "\n"
-"    Jeffry Lim (Impulse Tracker)" "\n"
-"    libpng team" "\n"
-"    Sami Tammilehto (Scream Tracker 3)" "\n"
-"    SDL team" "\n"
-"    zlib team" "\n"
-"" "\n"
-"  |H|Testing and Help|U|" "\n"
-"" "\n"
-"    arguru (NTK source made zt happen)" "\n"
-"    Bammer" "\n"
-"    czer323" "\n"
-"    FSM" "\n"
-"    in_tense" "\n"
-"    Oguz Akin" "\n"
-"    Quasimojo" "\n"
-"    Raptorrvl" "\n"
-"    Scurvee" "\n"
-"" "\n"
-"" "\n"
-"|H|License|U|" "\n"
-"" "\n"
-"   ztracker  is released under the BSD license.   Refer to the included |H|LICENSE.TXT|U| for details on the licensing terms." "\n"
-"" "\n"
-"Copyright (c) 2000-2001," "\n"
-"                    Christopher Micali " "\n"
-"Copyright (c) 2000-2001," "\n"
-"                    Austin Luminais" "\n"
-"Copyright (c) 2001, Nicolas Soudee" "\n"
-"Copyright (c) 2001, Daniel Kahlin" "\n"
-"Copyright (c) 2003-2025," "\n"
-"                    Manuel Montoto" "\n"
-"All rights reserved." "\n"
-"" "\n"
-"\0"
-;
+zTracker Prime is a fork of the original zTracker project from 2001, which was a clone of Impulse Tracker, itself a clone of Scream Tracker. The original zTracker was developed by Christopher Micali until 2002.
+
+It had become my go-to software for composing music, so I forked it in 2003. Over 20 years later, it remains my primary sequencer, and as of 2024 I continue to work on it.
+
+Check for new releases at the Github project page:
+
+https://github.com/m6502/ztrackerprime
+
+You can find an archived version of the old source code for the original version here:
+
+https://github.com/cmicali/ztracker
+
+|H|Contact|U|
+
+This fork is currently maintained by Manuel Montoto (Debvgger)
+
+Write me to |U|mail@manuelmontoto.com|U|
+
+|H|Credits:|U|
+
+  |H|Coding|U|
+
+    Austin Luminais
+    Christopher Micali
+    Daniel Kahlin
+    Manuel Montoto
+    Nic Soudee
+
+  |H|Support|U|
+
+    Amir Geva (libCON / TONS of help)
+    Jeffry Lim (Impulse Tracker)
+    libpng team
+    Sami Tammilehto (Scream Tracker 3)
+    SDL team
+    zlib team
+
+  |H|Testing and Help|U|
+
+    arguru (NTK source made zt happen)
+    Bammer
+    czer323
+    FSM
+    in_tense
+    Oguz Akin
+    Quasimojo
+    Raptorrvl
+    Scurvee
+
+
+|H|License|U|
+
+   ztracker  is released under the BSD license.   Refer to the included |H|LICENSE.TXT|U| for details on the licensing terms.
+
+Copyright (c) 2000-2001,
+                    Christopher Micali
+Copyright (c) 2000-2001,
+                    Austin Luminais
+Copyright (c) 2001, Nicolas Soudee
+Copyright (c) 2001, Daniel Kahlin
+Copyright (c) 2003-2025,
+                    Manuel Montoto
+
+All rights reserved.
+)about_text";
 }
 
 CUI_About::~CUI_About(void) {

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -280,11 +280,6 @@ void CUI_Config::draw(Drawable *S) {
         }
 #endif
         sprintf(buf,"\n|U|Current Settings in memory:\n");
-        if(tb->text != NULL)
-        {
-            free(tb->text);
-            tb->text = NULL;
-        }
         sprintf(buf+strlen(buf),"\n|U| Auto-Open MIDI |L|[|H|%s|L|]",zt_config_globals.auto_open_midi?"On":"Off");
         sprintf(buf+strlen(buf),"\n|U| Autoload .ZT  |L|[|H|%s|L|]",zt_config_globals.autoload_ztfile?"On":"Off");
         sprintf(buf+strlen(buf),"\n|U| Autoload File |L|[|H|%s|L|]",zt_config_globals.autoload_ztfile_filename);
@@ -317,6 +312,10 @@ void CUI_Config::draw(Drawable *S) {
         sprintf(buf+strlen(buf),"\n|U| Key Wait      |L|[|H|%d|L|]",zt_config_globals.key_wait_time);
 #endif
 
+        if(tb->text != NULL)
+        {
+            free((void*)tb->text);
+        }
         tb->text = strdup(buf);
         UI->draw(S);
 #ifdef _ACTIVAR_CAMBIO_TAMANYO_COLUMNAS

--- a/src/CUI_Help.cpp
+++ b/src/CUI_Help.cpp
@@ -39,10 +39,11 @@ CUI_Help::CUI_Help(void) {
             fs++;
         }
         fseek(fp,0,SEEK_SET);
-        tb->text = new char[fs+10];
-        memset(tb->text,0,fs+10);
-        fread(tb->text, fs, 1, fp);
+        char *text = new char[fs + 10];
+        memset(text,0,fs+10);
+        fread(text, fs, 1, fp);
         fclose(fp);
+        tb->text = text;
         needfree = 1;
 #ifdef __APPLE__
         // On macOS every primary modifier (CTRL, ALT, Cmd) triggers the same
@@ -62,7 +63,7 @@ CUI_Help::CUI_Help(void) {
         // SHIFT combos naturally run wider and push the colon right.
         {
             int src_len = fs;
-            char *src = tb->text;
+            const char *src = tb->text;
             char *dst = new char[src_len * 3 + 32];
             int di = 0;
             int i = 0;

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -1671,9 +1671,8 @@ void AboutBox::draw(Drawable *S, int) {
 // ------------------------------------------------------------------------------------------------
 //
 //
-TextBox::TextBox(int ro) 
+TextBox::TextBox()
 {
-  readonly = ro;
   mousestate = soff = startline = 0;
   bEof = false;
   bUseColors = 1;
@@ -1812,7 +1811,7 @@ int TextBox::update()
 // ------------------------------------------------------------------------------------------------
 //
 //
-int nextline(char *str, int p) {
+int nextline(const char *str, int p) {
     while(str[p]) {
         if (str[p]=='\n')
             return p+1;

--- a/src/UserInterface.h
+++ b/src/UserInterface.h
@@ -221,11 +221,11 @@ class AboutBox : public UserInterfaceElement {
 class TextBox : public UserInterfaceElement {
     public:
         bool bEof,bUseColors,bWordWrap;
-        int readonly, startline, soff,mousestate,starti,startl;
-        char *text;
+        int startline, soff,mousestate,starti,startl;
+        const char *text;
         Frame frm;
 
-        TextBox(int ro = 0);
+        TextBox();
         ~TextBox() = default ;
 
         int update();


### PR DESCRIPTION
This fixes a const correctness issue in `TextBox` and some of its users, which the compiler complained about.