### PR TITLE
Add platform build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .DS_Store
+/build-mac/
+/build-linux/
+/build-win32/
+/build-windows/

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+build_dir="${BUILD_DIR:-"$script_dir/build-linux"}"
+config="${CONFIG:-RelWithDebInfo}"
+run_after_build=0
+cmake_args=()
+app_args=()
+
+usage() {
+  cat <<'USAGE'
+Usage: ./build-linux.sh [--run] [--clean] [--debug|--release] [--] [app args...]
+
+Build zTracker for Linux with CMake.
+Requires CMake, a C/C++ compiler, pkg-config, SDL3 development files, and ALSA development files.
+USAGE
+}
+
+while (($#)); do
+  case "$1" in
+    --run)
+      run_after_build=1
+      shift
+      ;;
+    --clean)
+      rm -rf "$build_dir"
+      shift
+      ;;
+    --debug)
+      config="Debug"
+      shift
+      ;;
+    --release)
+      config="Release"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      app_args=("$@")
+      break
+      ;;
+    -D*|-G*|-C*|-U*)
+      cmake_args+=("$1")
+      shift
+      ;;
+    *)
+      app_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "build-linux.sh must be run on Linux." >&2
+  exit 1
+fi
+
+if ! command -v cmake >/dev/null 2>&1; then
+  echo "CMake is required." >&2
+  exit 1
+fi
+
+if ! pkg-config --exists sdl3 2>/dev/null; then
+  echo "SDL3 was not found by pkg-config. Install SDL3 development files or pass SDL3_INCLUDE_DIR/SDL3_LIBRARY." >&2
+  exit 1
+fi
+
+configure_args=(
+  -S "$script_dir"
+  -B "$build_dir"
+  -DCMAKE_BUILD_TYPE="$config"
+)
+
+if ((${#cmake_args[@]})); then
+  configure_args+=("${cmake_args[@]}")
+fi
+
+cmake "${configure_args[@]}"
+
+cmake --build "$build_dir" --config "$config" --parallel
+
+binary_path="$build_dir/Program/zt"
+if [[ ! -x "$binary_path" ]]; then
+  echo "Build completed, but expected executable was not found at: $binary_path" >&2
+  exit 1
+fi
+
+echo "Built: $binary_path"
+
+if ((run_after_build)); then
+  if ((${#app_args[@]})); then
+    "$binary_path" "${app_args[@]}"
+  else
+    "$binary_path"
+  fi
+fi

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+build_dir="${BUILD_DIR:-"$script_dir/build-mac"}"
+config="${CONFIG:-RelWithDebInfo}"
+run_after_build=0
+cmake_args=()
+app_args=()
+
+usage() {
+  cat <<'USAGE'
+Usage: ./build-mac.sh [--run] [--clean] [--debug|--release] [--] [app args...]
+
+Build zTracker for macOS with CMake.
+
+Options:
+  --run       Launch build-mac/Program/zt.app after a successful build.
+  --clean     Remove build-mac before configuring.
+  --debug     Build with CMAKE_BUILD_TYPE=Debug.
+  --release   Build with CMAKE_BUILD_TYPE=Release.
+
+Environment:
+  BUILD_DIR   Override the build directory.
+  CONFIG      Override the CMake build type/configuration.
+USAGE
+}
+
+while (($#)); do
+  case "$1" in
+    --run)
+      run_after_build=1
+      shift
+      ;;
+    --clean)
+      rm -rf "$build_dir"
+      shift
+      ;;
+    --debug)
+      config="Debug"
+      shift
+      ;;
+    --release)
+      config="Release"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      app_args=("$@")
+      break
+      ;;
+    -D*|-G*|-C*|-U*)
+      cmake_args+=("$1")
+      shift
+      ;;
+    *)
+      app_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "build-mac.sh must be run on macOS." >&2
+  exit 1
+fi
+
+if ! command -v cmake >/dev/null 2>&1; then
+  echo "CMake is required. Install it with: brew install cmake" >&2
+  exit 1
+fi
+
+if ! pkg-config --exists sdl3 2>/dev/null; then
+  cat >&2 <<'EOF'
+SDL3 was not found by pkg-config.
+
+Install it with:
+  brew install sdl3 pkg-config
+
+Or pass explicit CMake paths, for example:
+  ./build-mac.sh -DSDL3_INCLUDE_DIR=/opt/homebrew/include -DSDL3_LIBRARY=/opt/homebrew/lib/libSDL3.dylib
+EOF
+  exit 1
+fi
+
+configure_args=(
+  -S "$script_dir"
+  -B "$build_dir"
+  -DCMAKE_BUILD_TYPE="$config"
+)
+
+if ((${#cmake_args[@]})); then
+  configure_args+=("${cmake_args[@]}")
+fi
+
+cmake "${configure_args[@]}"
+
+cmake --build "$build_dir" --config "$config" --parallel
+
+app_path="$build_dir/Program/zt.app"
+binary_path="$app_path/Contents/MacOS/zt"
+
+if [[ ! -x "$binary_path" ]]; then
+  echo "Build completed, but expected executable was not found at: $binary_path" >&2
+  exit 1
+fi
+
+echo "Built: $app_path"
+
+if ((run_after_build)); then
+  if ((${#app_args[@]})); then
+    "$binary_path" "${app_args[@]}" >/dev/null 2>&1 &
+  else
+    "$binary_path" >/dev/null 2>&1 &
+  fi
+  echo "Launched: $binary_path"
+fi

--- a/build-win32.sh
+++ b/build-win32.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+build_dir="${BUILD_DIR:-"$script_dir/build-win32"}"
+config="${CONFIG:-RelWithDebInfo}"
+run_after_build=0
+cmake_args=()
+app_args=()
+
+usage() {
+  cat <<'USAGE'
+Usage: ./build-win32.sh [--run] [--clean] [--debug|--release] [--] [app args...]
+
+Build zTracker for Win32/Windows with CMake.
+
+This script is intended for Git Bash/MSYS/MinGW on Windows. By default it uses
+CMake's "MinGW Makefiles" generator unless another generator is supplied with -G.
+
+Environment:
+  BUILD_DIR   Override the build directory.
+  CONFIG      Override the CMake build type/configuration.
+  MINGW_ROOT  Override the 32-bit MinGW root passed to CMake.
+USAGE
+}
+
+generator_supplied=0
+
+while (($#)); do
+  case "$1" in
+    --run)
+      run_after_build=1
+      shift
+      ;;
+    --clean)
+      rm -rf "$build_dir"
+      shift
+      ;;
+    --debug)
+      config="Debug"
+      shift
+      ;;
+    --release)
+      config="Release"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      app_args=("$@")
+      break
+      ;;
+    -G*)
+      generator_supplied=1
+      cmake_args+=("$1")
+      shift
+      ;;
+    -D*|-C*|-U*)
+      cmake_args+=("$1")
+      shift
+      ;;
+    *)
+      app_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*)
+    ;;
+  *)
+    echo "build-win32.sh is intended to run from Git Bash/MSYS/MinGW on Windows." >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v cmake >/dev/null 2>&1; then
+  echo "CMake is required." >&2
+  exit 1
+fi
+
+configure_args=(
+  -S "$script_dir"
+  -B "$build_dir"
+)
+
+if ! ((generator_supplied)); then
+  configure_args+=(-G "MinGW Makefiles")
+fi
+
+configure_args+=(-DCMAKE_BUILD_TYPE="$config")
+
+if [[ -n "${MINGW_ROOT:-}" ]]; then
+  configure_args+=("-DMINGW_ROOT=$MINGW_ROOT")
+else
+  configure_args+=("-DMINGW_ROOT=W:/MINGW32")
+fi
+
+if ((${#cmake_args[@]})); then
+  configure_args+=("${cmake_args[@]}")
+fi
+
+cmake "${configure_args[@]}"
+
+cmake --build "$build_dir" --config "$config" --parallel
+
+binary_path="$build_dir/Program/zt.exe"
+if [[ ! -x "$binary_path" ]]; then
+  echo "Build completed, but expected executable was not found at: $binary_path" >&2
+  exit 1
+fi
+
+echo "Built: $binary_path"
+
+if ((run_after_build)); then
+  if ((${#app_args[@]})); then
+    "$binary_path" "${app_args[@]}"
+  else
+    "$binary_path"
+  fi
+fi

--- a/build-windows.sh
+++ b/build-windows.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+build_dir="${BUILD_DIR:-"$script_dir/build-windows"}"
+config="${CONFIG:-RelWithDebInfo}"
+run_after_build=0
+cmake_args=()
+app_args=()
+
+usage() {
+  cat <<'USAGE'
+Usage: ./build-windows.sh [--run] [--clean] [--debug|--release] [--] [app args...]
+
+Build zTracker for 64-bit Windows with CMake.
+
+This script is intended for Git Bash/MSYS/MinGW64 on Windows. By default it
+uses CMake's "MinGW Makefiles" generator unless another generator is supplied
+with -G.
+
+Environment:
+  BUILD_DIR   Override the build directory.
+  CONFIG      Override the CMake build type/configuration.
+  MINGW_ROOT  Override the 64-bit MinGW root passed to CMake.
+USAGE
+}
+
+generator_supplied=0
+
+while (($#)); do
+  case "$1" in
+    --run)
+      run_after_build=1
+      shift
+      ;;
+    --clean)
+      rm -rf "$build_dir"
+      shift
+      ;;
+    --debug)
+      config="Debug"
+      shift
+      ;;
+    --release)
+      config="Release"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      app_args=("$@")
+      break
+      ;;
+    -G*)
+      generator_supplied=1
+      cmake_args+=("$1")
+      shift
+      ;;
+    -D*|-C*|-U*|-A*)
+      cmake_args+=("$1")
+      shift
+      ;;
+    *)
+      app_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+case "$(uname -s)" in
+  MINGW64*|MSYS*|CYGWIN*)
+    ;;
+  MINGW32*)
+    echo "build-windows.sh needs a 64-bit Windows shell/toolchain. Use MinGW64/MSYS2 MinGW64, not MinGW32." >&2
+    exit 1
+    ;;
+  *)
+    echo "build-windows.sh is intended to run from Git Bash/MSYS/MinGW64 on Windows." >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v cmake >/dev/null 2>&1; then
+  echo "CMake is required." >&2
+  exit 1
+fi
+
+configure_args=(
+  -S "$script_dir"
+  -B "$build_dir"
+)
+
+if ! ((generator_supplied)); then
+  configure_args+=(-G "MinGW Makefiles")
+fi
+
+configure_args+=(-DCMAKE_BUILD_TYPE="$config")
+
+if [[ -n "${MINGW_ROOT:-}" ]]; then
+  configure_args+=("-DMINGW_ROOT=$MINGW_ROOT")
+else
+  configure_args+=("-DMINGW_ROOT=W:/MINGW64")
+fi
+
+if ((${#cmake_args[@]})); then
+  configure_args+=("${cmake_args[@]}")
+fi
+
+cmake "${configure_args[@]}"
+cmake --build "$build_dir" --config "$config" --parallel
+
+binary_path="$build_dir/Program/zt.exe"
+if [[ ! -x "$binary_path" ]]; then
+  echo "Build completed, but expected executable was not found at: $binary_path" >&2
+  exit 1
+fi
+
+echo "Built: $binary_path"
+
+if ((run_after_build)); then
+  if ((${#app_args[@]})); then
+    "$binary_path" "${app_args[@]}"
+  else
+    "$binary_path"
+  fi
+fi


### PR DESCRIPTION
Prepared with Codex.

Adds platform build entrypoints for macOS, Linux, 32-bit Windows, and 64-bit Windows.

Details:
- ./build-mac.sh builds build-mac/Program/zt.app.
- ./build-mac.sh --run builds and launches the built app executable directly from inside the bundle.
- ./build-linux.sh builds the Linux target into build-linux/Program/zt.
- ./build-win32.sh keeps a 32-bit Windows path and defaults MINGW_ROOT to W:/MINGW32.
- ./build-windows.sh adds the non-32-bit/64-bit Windows path and defaults MINGW_ROOT to W:/MINGW64.
- .gitignore now ignores generated platform build directories.

Validation run locally:
- bash -n build-mac.sh build-linux.sh build-win32.sh build-windows.sh
- ./build-mac.sh
- ./build-mac.sh --run

Windows and Linux scripts were syntax-checked from macOS; compile validation still needs those platform toolchains.