### PR TITLE
macOS UI polish: toolbar overlap, column alignment, focus cycle, keydebug, keybindings editor

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: build-mac

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ set(ZT_SOURCES
   src/UserInterface.cpp
   src/lua_engine.cpp
   src/CUI_LuaConsole.cpp
+  src/CUI_KeyBindings.cpp
 )
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,10 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Export compile_commands.json so clangd/IDE tooling can resolve SDL headers
+# and project include paths without guessing.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 option(ZT_ENABLE_SANITIZERS "Enable AddressSanitizer + UndefinedBehaviorSanitizer (GCC/Clang)" OFF)
 
 set(ZT_WINDOWS_LIB_DIR "${CMAKE_SOURCE_DIR}/extlibs" CACHE PATH "Directory containing Windows SDL libraries (.lib/.dll)")
@@ -155,6 +159,12 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_compile_options(zt PRIVATE -Wno-pragma-pack)
+  # Apple's SDK marks sprintf and friends as deprecated in favour of the
+  # snprintf family. The codebase uses sprintf extensively with known-safe
+  # buffer sizes; silence the noise project-wide on Clang rather than
+  # touching 200+ call sites. MSVC's _CRT_SECURE_NO_WARNINGS above does
+  # the equivalent on Windows.
+  target_compile_options(zt PRIVATE -Wno-deprecated-declarations)
 endif()
 
 if(ZT_ENABLE_SANITIZERS)

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -129,10 +129,10 @@ CUI_Config::CUI_Config(void) {
 
     b = new Button;
     UI->add_element(b,10);
-    b->caption = " Return to page 1 ";
+    b->caption = "   Go to page 1   ";   // symmetric with Sysconfig's "Go to page 2" button (same x, y, xsize)
     b->xsize = 18;
     b->x = 2;
-    b->y = 11;
+    b->y = 12;
     b->ysize = 1;
     b->OnClick = (ActFunc)BTNCLK_GotoSystemConfig;
 

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -94,6 +94,7 @@ CUI_Config::CUI_Config(void) {
     vs->max = VIEW_BIG;
     vs->xsize = 0;
     vs->ysize = 0;
+    vs->no_tab_stop = 1;  // invisible stub; skip it in UP/DOWN cycling
 #endif
 
     vs = new ValueSlider;
@@ -185,6 +186,7 @@ CUI_Config::CUI_Config(void) {
 
     tb = new TextBox;
     UI->add_element(tb, 9);
+    tb->no_tab_stop = 1;  // read-only help; swallows UP/DOWN, exclude from focus cycle
     tb->x = 1;
     tb->y = 25;
     tb->xsize = 78;

--- a/src/CUI_InstEditor.cpp
+++ b/src/CUI_InstEditor.cpp
@@ -99,76 +99,76 @@ CUI_InstEditor::CUI_InstEditor(void) {
 
     vso = new ValueSliderOFF(1); // Bank (ID: 1)
     UI->add_element(vso,tabindex++);
-    vso->x = 36;    vso->y = 16;    vso->xsize = 16;    vso->ysize = 1; vso->min = -1;  vso->max = 0x3fff;    vso->value = -1; 
+    vso->x = 36;    vso->y = 14;    vso->xsize = 16;    vso->ysize = 1; vso->min = -1;  vso->max = 0x3fff;    vso->value = -1;
     fm = new Frame;
     UI->add_gfx(fm,gfxindex++);
-    fm->x=35; fm->y=13; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
+    fm->x=35; fm->y=11; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
 
 
 
     vso = new ValueSliderOFF(1); // Patch (ID: 2)
     UI->add_element(vso,tabindex++);
-    vso->x = 58;    vso->y = 16;    vso->xsize = 16;    vso->ysize = 1; vso->min = -1;  vso->max = 127; vso->value = -1;
+    vso->x = 58;    vso->y = 14;    vso->xsize = 16;    vso->ysize = 1; vso->min = -1;  vso->max = 127; vso->value = -1;
     fm = new Frame;
     UI->add_gfx(fm,gfxindex++);
-    fm->x=57; fm->y=13; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
+    fm->x=57; fm->y=11; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
 
 
 
 
     vs = new ValueSlider(1); // Default Volume (ID: 3)
     UI->add_element(vs,tabindex++);
-    vs->x = 36; vs->y = 21; vs->xsize = 16; vs->ysize = 1;  vs->min = 0;    vs->max = 0x7f; vs->value = 0x7f;
+    vs->x = 36; vs->y = 19; vs->xsize = 16; vs->ysize = 1;  vs->min = 0;    vs->max = 0x7f; vs->value = 0x7f;
     fm = new Frame;
     UI->add_gfx(fm,gfxindex++);
-    fm->x=35; fm->y=18; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
+    fm->x=35; fm->y=16; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
 
 
 
 
     vsd = new ValueSliderDL(1); // Default Length (ID: 4)
     UI->add_element(vsd,tabindex++);
-    vsd->x = 58;    vsd->y = 21;    vsd->xsize = 16;    vsd->ysize = 1; vsd->min = 1;   vsd->max = 1000;    vsd->value = 0;
+    vsd->x = 58;    vsd->y = 19;    vsd->xsize = 16;    vsd->ysize = 1; vsd->min = 1;   vsd->max = 1000;    vsd->value = 0;
     fm = new Frame;
     UI->add_gfx(fm,gfxindex++);
-    fm->x=57; fm->y=18; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
+    fm->x=57; fm->y=16; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
 
     
 
     
     vs = new ValueSlider(1); // Global Volume (ID: 5)
     UI->add_element(vs,tabindex++);
-    vs->x = 36; vs->y = 26; vs->xsize = 16; vs->ysize = 1;  vs->min = 0;    vs->max = 0x7f; vs->value = 0x7f;
+    vs->x = 36; vs->y = 24; vs->xsize = 16; vs->ysize = 1;  vs->min = 0;    vs->max = 0x7f; vs->value = 0x7f;
     fm = new Frame;
     UI->add_gfx(fm,gfxindex++);
-    fm->x=35; fm->y=23; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
+    fm->x=35; fm->y=21; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
     
 
 
 
     vs = new ValueSlider(1); // Transpose (ID: 6)
     UI->add_element(vs,tabindex++);
-    vs->x = 58; vs->y = 26; vs->xsize = 16; vs->ysize = 1;  vs->min = -127; vs->max = 127;  vs->value = 0;
+    vs->x = 58; vs->y = 24; vs->xsize = 16; vs->ysize = 1;  vs->min = -127; vs->max = 127;  vs->value = 0;
     fm = new Frame;
     UI->add_gfx(fm,gfxindex++);
-    fm->x=57; fm->y=23; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
+    fm->x=57; fm->y=21; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
 
 
 
 
     vs = new ValueSlider(1); // Channel (ID: 7)
     UI->add_element(vs,tabindex++);
-    vs->x = 36; vs->y = 31; vs->xsize = 16; vs->ysize = 1;  vs->min = 1;    vs->max = 16;   vs->value = 0;
+    vs->x = 36; vs->y = 29; vs->xsize = 16; vs->ysize = 1;  vs->min = 1;    vs->max = 16;   vs->value = 0;
     fm = new Frame;
     UI->add_gfx(fm,gfxindex++);
-    fm->x=35; fm->y=28; fm->xsize = 22; fm->ysize = 7; fm->type = 0;
+    fm->x=35; fm->y=26; fm->xsize = 22; fm->ysize = 7; fm->type = 0;
     
     ////////////////////////////////////////////////////////////////////////////
 
     b = new Button;
     UI->add_element(b,tabindex++);
     b->x = 58;
-    b->y = 29;
+    b->y = 27;
     b->xsize = 20;
     b->ysize = 1;
     b->caption = "  Unmute Retrigger";
@@ -177,7 +177,7 @@ CUI_InstEditor::CUI_InstEditor(void) {
     b = new Button;
     UI->add_element(b,tabindex++);
     b->x = 58;
-    b->y = 31;
+    b->y = 29;
     b->xsize = 20;
     b->ysize = 1;
     b->caption = "   Channel Volume";
@@ -186,7 +186,7 @@ CUI_InstEditor::CUI_InstEditor(void) {
     b = new Button;
     UI->add_element(b,tabindex++);
     b->x = 58;
-    b->y = 33;
+    b->y = 31;
     b->xsize = 20;
     b->ysize = 1;
     b->caption = "    Tracker Mode";
@@ -197,7 +197,7 @@ CUI_InstEditor::CUI_InstEditor(void) {
 
     fm = new Frame;  //frame for buttons
     UI->add_gfx(fm,gfxindex++);
-    fm->x=57; fm->y=28; fm->xsize = 22; fm->ysize = 7; fm->type = 0;
+    fm->x=57; fm->y=26; fm->xsize = 22; fm->ysize = 7; fm->type = 0;
 
 
 
@@ -206,7 +206,7 @@ CUI_InstEditor::CUI_InstEditor(void) {
     b = new Button;
     UI->add_element(b,tabindex++);
     b->x = 35;
-    b->y = 36;
+    b->y = 34;
     b->xsize = 15;
     b->ysize = 1;
     b->caption = " Update Device";
@@ -216,7 +216,7 @@ CUI_InstEditor::CUI_InstEditor(void) {
     b = new Button;
     UI->add_element(b,tabindex++);
     b->x = 35+16;
-    b->y = 36;
+    b->y = 34;
     b->xsize = 12;
     b->ysize = 1;
     b->caption = " Update All";
@@ -233,7 +233,7 @@ CUI_InstEditor::CUI_InstEditor(void) {
     mds = new MidiOutDeviceSelector;
     UI->add_element(mds, tabindex++);
     mds->x=35;
-    mds->y=38;
+    mds->y=36;
     mds->xsize = 44;
     mds->ysize = 14;
     
@@ -559,13 +559,13 @@ void CUI_InstEditor::draw(Drawable *S)
         draw_status(S);
         status(S);
         printtitle(PAGE_TITLE_ROW_Y,"Instrument Editor (F3)",COLORS.Text,COLORS.Background,S);
-        printBG(col(36),row(14),"Bank",COLORS.Text,COLORS.Background,S);
-        printBG(col(58),row(14),"Patch",COLORS.Text,COLORS.Background,S);
-        printBG(col(36),row(19),"Default Volume",COLORS.Text,COLORS.Background,S);
-        printBG(col(58),row(19),"Default Length",COLORS.Text,COLORS.Background,S);
-        printBG(col(36),row(24),"Global Volume",COLORS.Text,COLORS.Background,S);
-        printBG(col(58),row(24),"Transpose",COLORS.Text,COLORS.Background,S);
-        printBG(col(36),row(29),"Channel",COLORS.Text,COLORS.Background,S);
+        printBG(col(36),row(12),"Bank",COLORS.Text,COLORS.Background,S);
+        printBG(col(58),row(12),"Patch",COLORS.Text,COLORS.Background,S);
+        printBG(col(36),row(17),"Default Volume",COLORS.Text,COLORS.Background,S);
+        printBG(col(58),row(17),"Default Length",COLORS.Text,COLORS.Background,S);
+        printBG(col(36),row(22),"Global Volume",COLORS.Text,COLORS.Background,S);
+        printBG(col(58),row(22),"Transpose",COLORS.Text,COLORS.Background,S);
+        printBG(col(36),row(27),"Channel",COLORS.Text,COLORS.Background,S);
         need_refresh = 0; 
         updated=2;
         S->unlock();

--- a/src/CUI_KeyBindings.cpp
+++ b/src/CUI_KeyBindings.cpp
@@ -1,0 +1,280 @@
+// CUI_KeyBindings — In-app editor for remappable keyboard shortcuts.
+//
+// Paired with src/keybindings.{h,cpp}, which owns the storage and the
+// load/save-to-zt.conf logic. This file only provides the UI: a scrollable
+// list of every ZtAction with its current binding, a capture mode to record
+// a new key combo, and commands to save / reset / unbind.
+//
+// Access from anywhere via Ctrl+Alt+K (wired in main.cpp). Key handling is
+// custom (the UserInterface framework doesn't help when you need to observe
+// arbitrary modifier+key combos without the page reacting to them first).
+
+#include "zt.h"
+#include "keybindings.h"
+#include "conf.h"
+
+#include <SDL.h>
+#include <string.h>
+#include <stdio.h>
+
+// Layout constants. The list spans from the title down to the toolbar clearance
+// established by the rest of the UI (row 51 bottom at 480px).
+#define KB_LIST_X        2
+#define KB_LIST_Y        11
+#define KB_ACTION_COL    4      // column offset inside the list row for action name
+#define KB_ACTION_WIDTH  30     // max chars of action name displayed
+#define KB_BINDING_COL   (KB_ACTION_COL + KB_ACTION_WIDTH + 2)
+#define KB_BINDING_WIDTH 28
+
+CUI_KeyBindings::CUI_KeyBindings(void)
+{
+    UI = NULL;      // This page bypasses the UserInterface framework.
+    cursor_y = 1;   // Skip ZT_ACTION_NONE at index 0.
+    list_start = 0;
+    capturing = 0;
+    dirty = 0;
+    status_line[0] = '\0';
+}
+
+int CUI_KeyBindings::visible_rows(void) const
+{
+    // Leave room for title at row KB_LIST_Y - 2 and a status line at the
+    // bottom. SPACE_AT_BOTTOM=8 rows are already reserved for the toolbar;
+    // also reserve 2 more rows at the bottom for the status/help text.
+    int total_rows = INTERNAL_RESOLUTION_Y / CHARACTER_SIZE_Y;
+    int rows = total_rows - KB_LIST_Y - 8 /*toolbar*/ - 2 /*status*/;
+    if (rows < 4) rows = 4;
+    return rows;
+}
+
+void CUI_KeyBindings::enter(void)
+{
+    cur_state = STATE_KEYBINDINGS;
+    need_refresh = 1;
+    capturing = 0;
+    Keys.flush();
+    snprintf(status_line, sizeof(status_line),
+             "UP/DOWN select  ENTER capture  DEL unbind  Ctrl+S save  Ctrl+R reset  Ctrl+Shift+R reset-all  ESC exit");
+}
+
+void CUI_KeyBindings::leave(void)
+{
+}
+
+void CUI_KeyBindings::update(void)
+{
+    if (!Keys.size()) return;
+
+    KBMod kstate = Keys.getstate();
+    KBKey key = Keys.getkey();
+
+    // ----- Capture mode: the next real (non-modifier) key becomes the binding.
+    if (capturing) {
+        // Ignore bare modifier-only presses; wait for an actual key.
+        if (key == SDLK_LSHIFT || key == SDLK_RSHIFT ||
+            key == SDLK_LCTRL  || key == SDLK_RCTRL  ||
+            key == SDLK_LALT   || key == SDLK_RALT   ||
+            key == SDLK_LGUI   || key == SDLK_RGUI) {
+            need_refresh++;
+            return;
+        }
+        if (key == SDLK_ESCAPE) {
+            capturing = 0;
+            snprintf(status_line, sizeof(status_line), "Capture cancelled.");
+            need_refresh++;
+            return;
+        }
+        if (cursor_y > 0 && cursor_y < ZT_ACTION_COUNT) {
+            g_keybindings.bindings[cursor_y].key = (int)key;
+            g_keybindings.bindings[cursor_y].modifiers = (int)kstate;
+            dirty = 1;
+            char combo[64];
+            KeyBindings::formatKeyCombo((int)key, (int)kstate, combo, sizeof(combo));
+            snprintf(status_line, sizeof(status_line),
+                     "Bound %s -> %s (Ctrl+S to save to zt.conf)",
+                     KeyBindings::actionName((ZtAction)cursor_y), combo);
+        }
+        capturing = 0;
+        need_refresh++;
+        return;
+    }
+
+    // ----- Browse mode.
+    int rows = visible_rows();
+    int total = ZT_ACTION_COUNT - 1;  // exclude ZT_ACTION_NONE
+
+    // Global exits always work (ESC = back to pattern editor).
+    if (key == SDLK_ESCAPE) {
+        switch_page(UIP_Patterneditor);
+        return;
+    }
+
+    // Ctrl+S: save all bindings to zt.conf.
+    if ((kstate & KS_CTRL) && !(kstate & KS_SHIFT) && key == SDLK_S) {
+        g_keybindings.save(zt_config_globals.Config);
+        zt_config_globals.save();
+        dirty = 0;
+        snprintf(status_line, sizeof(status_line), "Saved to zt.conf.");
+        need_refresh++;
+        return;
+    }
+
+    // Ctrl+Shift+R: reset ALL bindings to built-in defaults.
+    if ((kstate & KS_CTRL) && (kstate & KS_SHIFT) && key == SDLK_R) {
+        g_keybindings.setDefaults();
+        dirty = 1;
+        snprintf(status_line, sizeof(status_line),
+                 "All bindings reset to defaults. Ctrl+S to save.");
+        need_refresh++;
+        return;
+    }
+
+    // Ctrl+R: reset the current row's binding to default.
+    if ((kstate & KS_CTRL) && !(kstate & KS_SHIFT) && key == SDLK_R) {
+        // Need defaults to restore a single entry. Easiest: snapshot current,
+        // call setDefaults to get the default for this row, restore the rest.
+        KeyBinding saved[ZT_ACTION_COUNT];
+        memcpy(saved, g_keybindings.bindings, sizeof(saved));
+        g_keybindings.setDefaults();
+        KeyBinding def = g_keybindings.bindings[cursor_y];
+        memcpy(g_keybindings.bindings, saved, sizeof(saved));
+        g_keybindings.bindings[cursor_y] = def;
+        dirty = 1;
+        char combo[64];
+        KeyBindings::formatKeyCombo(def.key, def.modifiers, combo, sizeof(combo));
+        snprintf(status_line, sizeof(status_line),
+                 "Reset %s to default (%s). Ctrl+S to save.",
+                 KeyBindings::actionName((ZtAction)cursor_y), combo);
+        need_refresh++;
+        return;
+    }
+
+    // DEL / BACKSPACE: unbind current row.
+    if (key == SDLK_DELETE || key == SDLK_BACKSPACE) {
+        if (cursor_y > 0 && cursor_y < ZT_ACTION_COUNT) {
+            g_keybindings.bindings[cursor_y].key = 0;
+            g_keybindings.bindings[cursor_y].modifiers = 0;
+            dirty = 1;
+            snprintf(status_line, sizeof(status_line),
+                     "Unbound %s. Ctrl+S to save.",
+                     KeyBindings::actionName((ZtAction)cursor_y));
+        }
+        need_refresh++;
+        return;
+    }
+
+    // RETURN / SPACE: enter capture mode.
+    if (key == SDLK_RETURN || key == SDLK_SPACE) {
+        capturing = 1;
+        Keys.flush();   // drop any key-repeat so the first intentional press is caught
+        snprintf(status_line, sizeof(status_line),
+                 "Press new key combo for '%s' (ESC to cancel)...",
+                 KeyBindings::actionName((ZtAction)cursor_y));
+        need_refresh++;
+        return;
+    }
+
+    // Navigation.
+    auto clamp_scroll = [&]() {
+        if (cursor_y < 1) cursor_y = 1;
+        if (cursor_y > total) cursor_y = total;
+        if (cursor_y - list_start < 0) list_start = cursor_y;
+        if (cursor_y - list_start >= rows) list_start = cursor_y - rows + 1;
+        if (list_start < 0) list_start = 0;
+        if (list_start > total - rows + 1) list_start = total - rows + 1;
+        if (list_start < 0) list_start = 0;
+    };
+
+    switch (key) {
+        case SDLK_UP:       cursor_y--;           break;
+        case SDLK_DOWN:     cursor_y++;           break;
+        case SDLK_PAGEUP:   cursor_y -= 10;       break;
+        case SDLK_PAGEDOWN: cursor_y += 10;       break;
+        case SDLK_HOME:     cursor_y = 1;         break;
+        case SDLK_END:      cursor_y = total;     break;
+        default: break;
+    }
+    clamp_scroll();
+    need_refresh++;
+}
+
+void CUI_KeyBindings::draw(Drawable *S)
+{
+    if (S->lock() != 0) return;
+
+    // Background under the list area so stale content from other pages
+    // doesn't bleed through when returning here.
+    int rows = visible_rows();
+    S->fillRect(col(1),
+                row(KB_LIST_Y - 1),
+                INTERNAL_RESOLUTION_X - 2,
+                row(KB_LIST_Y + rows + 2),
+                COLORS.Background);
+
+    char buf[96];
+    snprintf(buf, sizeof(buf), "Keyboard Shortcuts (Ctrl+Alt+K)%s",
+             dirty ? "   [unsaved]" : "");
+    printtitle(PAGE_TITLE_ROW_Y, buf, COLORS.Text, COLORS.Background, S);
+
+    // Column headers.
+    print(col(KB_LIST_X + KB_ACTION_COL), row(KB_LIST_Y - 1),
+          "Action", COLORS.Brighttext, S);
+    print(col(KB_LIST_X + KB_BINDING_COL), row(KB_LIST_Y - 1),
+          "Binding", COLORS.Brighttext, S);
+
+    int total = ZT_ACTION_COUNT - 1;
+
+    for (int i = 0; i < rows; i++) {
+        int action_idx = list_start + i + 1;  // +1 to skip ZT_ACTION_NONE
+        if (action_idx > total) break;
+
+        int y = row(KB_LIST_Y + i);
+        TColor fg, bg;
+        bool is_cur = (action_idx == cursor_y);
+        if (is_cur && capturing) {
+            fg = COLORS.Text;
+            bg = COLORS.EditText;   // "capture" accent
+        } else if (is_cur) {
+            fg = COLORS.EditBG;
+            bg = COLORS.Highlight;
+        } else {
+            fg = COLORS.Text;
+            bg = COLORS.Background;
+        }
+
+        // Clear the row and print action name + binding. Pad to fixed widths
+        // so the highlight bar is rectangular and column edges line up.
+        char action_buf[KB_ACTION_WIDTH + 1];
+        snprintf(action_buf, sizeof(action_buf), "%-*.*s",
+                 KB_ACTION_WIDTH, KB_ACTION_WIDTH,
+                 KeyBindings::actionName((ZtAction)action_idx));
+
+        char binding_buf[KB_BINDING_WIDTH + 1];
+        char combo[64];
+        const KeyBinding &b = g_keybindings.bindings[action_idx];
+        if (b.key == 0) {
+            snprintf(combo, sizeof(combo), "(unbound)");
+        } else {
+            KeyBindings::formatKeyCombo(b.key, b.modifiers, combo, sizeof(combo));
+        }
+        snprintf(binding_buf, sizeof(binding_buf), "%-*.*s",
+                 KB_BINDING_WIDTH, KB_BINDING_WIDTH, combo);
+
+        printBG(col(KB_LIST_X + KB_ACTION_COL), y, action_buf, fg, bg, S);
+        printBG(col(KB_LIST_X + KB_BINDING_COL), y, binding_buf, fg, bg, S);
+    }
+
+    // Status line just above the toolbar reservation.
+    int total_rows = INTERNAL_RESOLUTION_Y / CHARACTER_SIZE_Y;
+    int status_y = total_rows - 8 - 1;  // one row above SPACE_AT_BOTTOM
+    if (status_y < KB_LIST_Y + rows + 1) status_y = KB_LIST_Y + rows + 1;
+    // Clear the status strip first.
+    S->fillRect(col(1), row(status_y),
+                INTERNAL_RESOLUTION_X - 2, row(status_y + 1),
+                COLORS.Background);
+    print(col(2), row(status_y), status_line,
+          capturing ? COLORS.Highlight : COLORS.Text, S);
+
+    S->unlock();
+    screenmanager.UpdateAll();
+}

--- a/src/CUI_Page.h
+++ b/src/CUI_Page.h
@@ -477,4 +477,22 @@ class CUI_LuaConsole : public CUI_Page {
         void update(void);
         void draw(Drawable *S);
 };
+
+class CUI_KeyBindings : public CUI_Page {
+    public:
+        int cursor_y;        // currently selected ZtAction (0..ZT_ACTION_COUNT-1)
+        int list_start;      // first visible action
+        int capturing;       // 0 = browsing, 1 = waiting for new key combo
+        int dirty;            // unsaved edits?
+        char status_line[160];
+
+        CUI_KeyBindings();
+
+        void enter(void);
+        void leave(void);
+        void update(void);
+        void draw(Drawable *S);
+
+        int visible_rows(void) const;
+};
 #endif

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -20,7 +20,12 @@ static PatternUndo g_undo;
 #define TRACKS_POS_Y                    row(TRACKS_ROW_Y)
 #define TRACKS_FIRST_NOTE_POS_Y         row(TRACKS_ROW_Y + 1)
 
-#define SPACE_AT_BOTTOM                 4  // rows reserved below pattern for border/padding
+// Rows reserved below the pattern so it can never overlap the lower frame.
+// The toolbar bitmap is 55px tall (TOOLBAR_SIZE_Y in main.cpp) and is drawn at
+// INTERNAL_RESOLUTION_Y - 55. At 8px per character row that's ceil(55/8) = 7
+// rows; we reserve one extra row so the pattern's bottom border never touches
+// the toolbar. Matches the legacy layout (40 rows = 0..039 at 480px height).
+#define SPACE_AT_BOTTOM                 8
 
 
 int PATTERN_EDIT_ROWS = 100;

--- a/src/CUI_Playsong.cpp
+++ b/src/CUI_Playsong.cpp
@@ -29,7 +29,9 @@ CUI_Playsong::CUI_Playsong(void)
     // <Manu> Control del número de líneas que se muestran mientras se reproduce una canción (30 por defecto)
     //p->ysize = 30 ;
 
-    pattern_display->ysize = (INTERNAL_RESOLUTION_Y / FONT_SIZE_Y) - pattern_display->y - 7 ; // 7 es la parte del fondo (meter en algún #define)
+    // Reserve 8 rows at the bottom: 7 for the 55px toolbar (ceil(55/8)) plus
+    // one row of safety so the pattern display's frame border never overlaps.
+    pattern_display->ysize = (INTERNAL_RESOLUTION_Y / FONT_SIZE_Y) - pattern_display->y - 8 ;
     //p->ysize = 62;
 
     UI_PatternDisplay->add_element(pattern_display,0);
@@ -194,7 +196,7 @@ void CUI_Playsong::update()
 //
 void CUI_Playsong::draw(Drawable *S) 
 {
-  pattern_display->ysize = (INTERNAL_RESOLUTION_Y / FONT_SIZE_Y) - pattern_display->y - 7 ; // 7 es la parte del fondo (meter en algún #define)
+  pattern_display->ysize = (INTERNAL_RESOLUTION_Y / FONT_SIZE_Y) - pattern_display->y - 8 ;
 
   //  char str[256];
   if (S->lock()==0) {

--- a/src/CUI_RUSure.cpp
+++ b/src/CUI_RUSure.cpp
@@ -123,7 +123,7 @@ void CUI_RUSure::draw(Drawable *S) {
             printchar(start_x + window_width - row(1) + 1,row(i),146,COLORS.Lowlight,S);
         } 
         printline(start_x,start_y,143,window_width / 8,COLORS.Highlight,S);
-        print(col(textcenter(this->str)),start_y + row(1),this->str,COLORS.Text,S);
+        print(col(textcenter(this->str)),start_y + 2 * row(1),this->str,COLORS.Text,S);
 		    UI->full_refresh();
         UI->draw(S);
         S->unlock();

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -136,8 +136,9 @@ void CUI_Songconfig::leave(void) {
 
 void CUI_Songconfig::update()
 {
-    // Bottom margin reduced so more orderlist items (incl. 038/039) are visible.
-    oe->ysize =  ((INTERNAL_RESOLUTION_Y/8) - oe->y - 7) ;
+    // Reserve 8 rows at the bottom: 7 for the 55px toolbar (ceil(55/8)) plus
+    // one row of safety so the order editor's frame never overlaps.
+    oe->ysize =  ((INTERNAL_RESOLUTION_Y/8) - oe->y - 8) ;
 
     ValueSlider *vs;
     TextInput *t;

--- a/src/CUI_Sysconfig.cpp
+++ b/src/CUI_Sysconfig.cpp
@@ -251,11 +251,20 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
     TextInput *ti;
 
     int tabindex=0;
-    int base_y = TRACKS_ROW_Y;  // Align controls with Pattern Editor content start
+    int base_y = TRACKS_ROW_Y + 3;  // content starts row 14, leaving row 12 for button + gaps on both sides
     UI = new UserInterface;
-    // MIDI Devices
 
-    // MIDI Devices
+        // Tab index 0: page-navigation button. Row 12 gives a clean gap
+        // above (row 11 empty, title at row 9) and below (row 13 empty,
+        // Prebuffer at row 14). UP/DOWN cycle starts here.
+        b = new Button;
+        UI->add_element(b,tabindex++);
+        b->caption = "   Go to page 2   ";
+        b->xsize = 18;
+        b->x = 2;
+        b->y = 12;
+        b->ysize = 1;
+        b->OnClick = (ActFunc)BTNCLK_GotoGlobalConfig;
 
         vs = new ValueSlider;
         UI->add_element(vs,tabindex++);
@@ -290,9 +299,9 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         cb->xsize = 5;
         cb->value = &zt_config_globals.auto_open_midi;
         cb->frame = 1;
-    
+
         cb = new CheckBox;
-        UI->add_element(cb,tabindex++); // id:4
+        UI->add_element(cb,tabindex++); // Full Screen cb — update() reads via get_element(5)
         cb->frame = 0;
         cb->x = 4+15;
         cb->y = base_y + 8;
@@ -325,32 +334,48 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         sk = new SkinSelector;
         UI->add_element(sk,tabindex++);
         sk->x = 4+35 +10;
-        sk->y = base_y + 2;
+        sk->y = base_y + 1;   // "Skin Selection" label sits on the same row as "Prebuffer"; list top border one row below
         sk->xsize = 19+4;
-        sk->ysize = 10;
+        sk->ysize = 7;   // tight-fit around installed skin count, avoids empty black space
+
+        // MIDI Out column — visual order: Refresh (y=30), list (y=32-44),
+        // Open device (y=47), Latency (y=49), Bank (y=51), Alias (y=53).
+        // tabindex follows the same order so UP/DOWN navigates top-to-bottom.
+        b = new Button;
+        UI->add_element(b,tabindex++);
+        b->caption = " Refresh";
+        b->x = 4+26;
+        b->y = 50 - 16 -2-2;
+        b->xsize = 9;
+        b->ysize = 1;
+        b->OnClick = (ActFunc)BTNCLK_RefreshMidiOutDeviceList;
 
         ml = new MidiOutDeviceOpener;
         UI->add_element(ml,tabindex++);
         midioutdevlist = ml;
-        ml->x = 4; 
-        ml->y = 50 - 16-2; 
+        ml->x = 4;
+        ml->y = 50 - 16-2;
         ml->xsize=35;
         ml->ysize = 13;
 
-		//MidiOutputDevice *m;
+        b = new Button;
+        UI->add_element(b,tabindex++);
+        b->caption = " Open device   ";
+        b->x = 4+21;
+        b->y = 47;
+        b->xsize = 14;
+        b->ysize = 1;
+        b->OnClick = (ActFunc)BTNCLK_ForgetMidiOutDevice;
+        midiout_action_button = b;
 
-		//m = (MidiOutputDevice*)(MidiOut->outputDevices[MidiOut->devlist_head->key]);
         vs = new LatencyValueSlider(ml);
         UI->add_element(vs,tabindex++);
         vs->x = 13;
         vs->y = 49;
         vs->xsize = 21;
         vs->ysize = 1;
-		
-        //vs->value = MidiOut->outputDevices[0]->delay_ticks; //m->delay_ticks;
         vs->min = 0;
         vs->max = 255;
-        //ml->update();
 
         cb = new BankSelectCheckBox(ml);
         UI->add_element(cb,tabindex++);
@@ -359,7 +384,6 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         cb->y = 51;
         cb->xsize = 5;
         cb->frame = 1;
-		//cb->value = &(m->reverse_bank_select);
 
         ti = new AliasTextInput(ml);
         UI->add_element(ti,tabindex++);
@@ -373,42 +397,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         ml->bscb = cb; // link midi out list to bank select checkbox
         ml->al = ti;
 
-        b = new Button;
-        UI->add_element(b,tabindex++);
-        b->caption = " Refresh";
-        b->x = 4+26;
-        b->y = 50 - 16 -2-2;
-        b->xsize = 9;
-        b->ysize = 1;
-        b->OnClick = (ActFunc)BTNCLK_RefreshMidiOutDeviceList; 
-
-        b = new Button;
-        UI->add_element(b,tabindex++);
-        b->caption = " Open device   ";
-        b->x = 4+21;
-        b->y = 47;
-        b->xsize = 14;
-        b->ysize = 1;
-        b->OnClick = (ActFunc)BTNCLK_ForgetMidiOutDevice;
-        midiout_action_button = b;
-
-        //Frame *f;
-        //f = new Frame;
-        //UI->add_gfx(f,0);
-        //f->x = 4;
-        //f->y = 50-4;
-        //f->ysize=7;
-        //f->xsize = 35;
-        //f->type = 0;
-        
-        mi = new MidiInDeviceOpener;
-        midiindevlist = mi;
-        UI->add_element(mi,tabindex++);
-        mi->x = 4+37; 
-        mi->y = 50 - 16-2; 
-        mi->xsize=35;
-        mi->ysize = 13;
-
+        // MIDI In column — same visual order: Refresh, list, Open device.
         b = new Button;
         UI->add_element(b,tabindex++);
         b->caption = " Refresh";
@@ -416,7 +405,15 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         b->y = 50 - 16 -2-2;
         b->xsize = 9;
         b->ysize = 1;
-        b->OnClick = (ActFunc)BTNCLK_RefreshMidiInDeviceList; 
+        b->OnClick = (ActFunc)BTNCLK_RefreshMidiInDeviceList;
+
+        mi = new MidiInDeviceOpener;
+        midiindevlist = mi;
+        UI->add_element(mi,tabindex++);
+        mi->x = 4+37;
+        mi->y = 50 - 16-2;
+        mi->xsize=35;
+        mi->ysize = 13;
 
         b = new Button;
         UI->add_element(b,tabindex++);
@@ -427,15 +424,6 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         b->ysize = 1;
         b->OnClick = (ActFunc)BTNCLK_ForgetMidiInDevice;
         midiin_action_button = b;
-
-        b = new Button;
-        UI->add_element(b,tabindex++);
-        b->caption = "   Go to page 2   ";
-        b->xsize = 18;
-        b->x = 2;
-        b->y = 11;
-        b->ysize = 1;
-        b->OnClick = (ActFunc)BTNCLK_GotoGlobalConfig;
 
 }
 
@@ -459,8 +447,11 @@ void CUI_Sysconfig::update() {
 
     UI->update();
     sync_midi_action_buttons();
-    vs = (ValueSlider *)UI->get_element(0);
-    cb = (CheckBox*)UI->get_element(4);
+    // Indices match the tabindex order set in the constructor: 0=button,
+    // 1=Prebuffer slider, 2=Panic, 3=MIDI-IN Slave, 4=Auto-open MIDI,
+    // 5=Full Screen.
+    vs = (ValueSlider *)UI->get_element(1);
+    cb = (CheckBox*)UI->get_element(5);
     if (vs->changed) {
         zt_config_globals.prebuffer_rows = vs->value;
         ztPlayer->prebuffer = (96/song->tpb) * zt_config_globals.prebuffer_rows; // 96ppqn, so look ahead is 1 beat
@@ -484,18 +475,19 @@ void CUI_Sysconfig::draw(Drawable *S) {
         draw_status(S);
         status(S);
         printtitle(PAGE_TITLE_ROW_Y,"System Configuration (F12)",COLORS.Text,COLORS.Background,S);
-        print(row(4),col(TRACKS_ROW_Y),"     Prebuffer",COLORS.Text,S);
-        print(row(4),col(TRACKS_ROW_Y+2)," Panic on stop",COLORS.Text,S);
-        print(row(4),col(TRACKS_ROW_Y+4)," MIDI-IN Slave",COLORS.Text,S);
-        print(row(4),col(TRACKS_ROW_Y+6),"Auto-open MIDI",COLORS.Text,S);
+        // Labels shifted +3 rows from legacy position: row 12 holds the
+        // "Go to page 2" button, rows 11 and 13 are empty gaps.
+        print(row(4),col(TRACKS_ROW_Y+3),"     Prebuffer",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+5)," Panic on stop",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+7)," MIDI-IN Slave",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+9),"Auto-open MIDI",COLORS.Text,S);
 
-        print(row(4),col(TRACKS_ROW_Y+8),"   Full Screen",COLORS.Text,S);
-        //print(row(4),col(24),"  Step Editing",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+11),"   Full Screen",COLORS.Text,S);
 #ifndef DISABLED_CONFIGURATION_VALUES
-        print(row(4),col(TRACKS_ROW_Y+10),"    Key Repeat",COLORS.Text,S);
-        print(row(4),col(TRACKS_ROW_Y+12),"      Key Wait",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+13),"    Key Repeat",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+15),"      Key Wait",COLORS.Text,S);
 #endif
-        print(row(4+37+8),col(TRACKS_ROW_Y+2),"Skin Selection",COLORS.Text,S);
+        print(row(4+37+8),col(TRACKS_ROW_Y+3),"Skin Selection",COLORS.Text,S);
 
         print(row(4),col(30),"MIDI Out Device Selection",COLORS.Text,S);
         print(row(4+37),col(30),"MIDI In Device Selection",COLORS.Text,S);

--- a/src/UserInterface.h
+++ b/src/UserInterface.h
@@ -34,16 +34,17 @@ class UserInterfaceElement {
         int ID,mousestate;
         int frame;
         int need_redraw;
+        int no_tab_stop = 0;  // opt-out of TAB/UP/DOWN focus cycling
 
         UserInterfaceElement(void);
         virtual ~UserInterfaceElement(void) = default ;
-        
+
         virtual int mouseupdate(int cur_element);
         virtual void enter(void) {}
         virtual int update()=0;
         virtual void draw(Drawable *S, int active)=0;
         virtual bool is_text_input() const { return false; }
-        virtual bool is_tab_stop() const { return true; }
+        virtual bool is_tab_stop() const { return !no_tab_stop; }
         virtual void on_focus() {}
 
         UserInterfaceElement *next;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2378,11 +2378,11 @@ void keyhandler(SDL_KeyboardEvent *e) {
         actual_ch = 10;
     }
 
-    // EU/Finnish ISO keyboards: the § key. Different layouts map it to
-    // different scancodes — on some it's NONUSBACKSLASH, on others it's
-    // INTERNATIONAL1/2 or even GRAVE itself. Force any of those to SDLK_GRAVE
-    // so the existing GRAVE handlers (plain § -> Note Off, Shift+§ -> drawmode
-    // toggle) work without a US keyboard layout.
+    // EU/Finnish ISO keyboards: the § key. On Linux/Windows SDL reports it
+    // as NONUSBACKSLASH / INTERNATIONAL1..3 / NONUSHASH depending on layout,
+    // so force those to SDLK_GRAVE so the GRAVE handlers (plain § -> Note
+    // Off, Shift+§ -> drawmode toggle) fire without a US keyboard layout.
+#ifndef __APPLE__
     if (e->scancode == SDL_SCANCODE_NONUSBACKSLASH ||
         e->scancode == SDL_SCANCODE_INTERNATIONAL1 ||
         e->scancode == SDL_SCANCODE_INTERNATIONAL2 ||
@@ -2390,6 +2390,22 @@ void keyhandler(SDL_KeyboardEvent *e) {
         e->scancode == SDL_SCANCODE_NONUSHASH) {
       id = SDLK_GRAVE;
     }
+#else
+    // macOS Finnish ISO (verified via ZT_KEYDEBUG):
+    //  * The top-left §-key reports scancode=SDL_SCANCODE_GRAVE with a
+    //    locale-specific keycode (0xA7 §), not SDLK_GRAVE. Normalize so
+    //    the GRAVE handlers (plain § -> Note Off, Shift+§ -> drawmode
+    //    toggle) fire. Also safe on US Mac layouts where the same
+    //    scancode already resolves to SDLK_GRAVE.
+    //  * The <>-key left of Z reports scancode=SDL_SCANCODE_NONUSBACKSLASH
+    //    with keycode=0x3C (<). Map it to the bracket-key octave controls
+    //    so `<` = octave down and Shift+`<` (`>`) = octave up.
+    if (e->scancode == SDL_SCANCODE_GRAVE) {
+      id = SDLK_GRAVE;
+    } else if (e->scancode == SDL_SCANCODE_NONUSBACKSLASH) {
+      id = (e->mod & SDL_KMOD_SHIFT) ? SDLK_RIGHTBRACKET : SDLK_LEFTBRACKET;
+    }
+#endif
     // Opt-in per-keydown tracing. Set ZT_KEYDEBUG=1 to enable; default is
     // off so this path adds zero per-key cost (the env check runs once and
     // is cached in a static). When enabled, every keydown is logged to

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2375,6 +2375,50 @@ void keyhandler(SDL_KeyboardEvent *e) {
         e->scancode == SDL_SCANCODE_NONUSHASH) {
       id = SDLK_GRAVE;
     }
+    // Opt-in per-keydown tracing. Set ZT_KEYDEBUG=1 to enable; default is
+    // off so this path adds zero per-key cost (the env check runs once and
+    // is cached in a static). When enabled, every keydown is logged to
+    // stderr and ./zt-keydebug.log for keyboard-layout debugging.
+    if (pressed) {
+      static int init_done = 0;
+      static int enabled = 0;
+      static FILE *dbg_fp = NULL;
+      if (!init_done) {
+        init_done = 1;
+        const char *env = getenv("ZT_KEYDEBUG");
+        enabled = (env && env[0] && env[0] != '0') ? 1 : 0;
+        if (enabled) {
+          dbg_fp = fopen("zt-keydebug.log", "w");
+          if (dbg_fp) {
+            fprintf(dbg_fp, "# ZT_KEYDEBUG active. Columns: scancode (name) | keycode (name) | mod | mod names\n");
+            fflush(dbg_fp);
+          }
+          fprintf(stderr, "[zt-key] debug logging enabled, writing ./zt-keydebug.log\n");
+        }
+      }
+      if (enabled) {
+        int sc = (int)e->scancode;
+        const char *sc_name = SDL_GetScancodeName(e->scancode);
+        const char *kc_name = SDL_GetKeyName(e->key);
+        char line[256];
+        snprintf(line, sizeof(line),
+                 "scancode=%d(%s) keycode=0x%X(%s) mod=0x%X%s%s%s%s",
+                 sc, sc_name ? sc_name : "?",
+                 (unsigned)e->key, kc_name ? kc_name : "?",
+                 (unsigned)e->mod,
+                 (e->mod & SDL_KMOD_SHIFT) ? " SHIFT" : "",
+                 (e->mod & SDL_KMOD_CTRL) ? " CTRL" : "",
+                 (e->mod & SDL_KMOD_ALT) ? " ALT" : "",
+                 (e->mod & SDL_KMOD_GUI) ? " GUI/CMD" : "");
+        fprintf(stderr, "[zt-key] %s\n", line);
+        fflush(stderr);
+        if (dbg_fp) {
+          fprintf(dbg_fp, "%s\n", line);
+          fflush(dbg_fp);
+        }
+      }
+    }
+
     if (id != SDLK_LALT && id != SDLK_RALT && id != SDLK_RCTRL && id != SDLK_LCTRL && id != SDLK_LSHIFT && id != SDLK_RSHIFT) {
         if (zt_text_input_is_active && pressed) {
             const bool is_edit_or_nav =
@@ -2439,6 +2483,19 @@ void textinputhandler(const SDL_Event *e) {
     }
 
     const unsigned char ch = (unsigned char)e->text.text[0];
+    // Log text-input chars under ZT_KEYDEBUG so we can see what the OS
+    // translates a physical key to (e.g. "<" vs "§" on Finnish ISO).
+    if (getenv("ZT_KEYDEBUG")) {
+        fprintf(stderr, "[zt-key] TEXT_INPUT='%s' (first byte=0x%02X)\n",
+                e->text.text, ch);
+        fflush(stderr);
+        FILE *fp = fopen("zt-keydebug.log", "a");
+        if (fp) {
+            fprintf(fp, "TEXT_INPUT='%s' (first byte=0x%02X)\n",
+                    e->text.text, ch);
+            fclose(fp);
+        }
+    }
     if (ch >= 0x20 || ch == 10 || ch == 9) {
         Keys.insert(SDLK_SPACE, SDL_KMOD_NONE, ch);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -328,6 +328,7 @@ CUI_SongMessage *UIP_SongMessage = NULL;
 CUI_Arpeggioeditor *UIP_Arpeggioeditor = NULL;
 CUI_Midimacroeditor *UIP_Midimacroeditor = NULL;
 CUI_LuaConsole *UIP_LuaConsole = NULL;
+CUI_KeyBindings *UIP_KeyBindings = NULL;
 
 
 
@@ -1096,6 +1097,7 @@ int initConsole(int& Width, int& Height, int& FullScreen, int& Flags, Screen* S)
     UIP_Sysconfig = new CUI_Sysconfig;
     UIP_PaletteEditor = new CUI_PaletteEditor;
     UIP_Config = new CUI_Config;
+    UIP_KeyBindings = new CUI_KeyBindings;
     UIP_Patterneditor = new CUI_Patterneditor;
     UIP_PEParms = new CUI_PEParms;
     UIP_PEVol = new CUI_PEVol;
@@ -1398,6 +1400,13 @@ void global_keys(Drawable *S)
                 }
                 break;
 
+            case SDLK_K: // Keybindings editor (Ctrl+Alt+K)
+                if ((kstate & KS_CTRL) && (kstate & KS_ALT)) {
+                    command = CMD_SWITCH_KEYBINDINGS;
+                    key = Keys.getkey();
+                }
+                break;
+
 #ifndef DISABLE_UNFINISHED_F10_SONG_MESSAGE_EDITOR
             case SDLK_F10:
 
@@ -1647,6 +1656,11 @@ void global_keys(Drawable *S)
         // ------------------------------------------------------------------------
         case CMD_SWITCH_LUA_CONSOLE:
             switch_page(UIP_LuaConsole);
+            doredraw++; clear++;
+            break;
+        // ------------------------------------------------------------------------
+        case CMD_SWITCH_KEYBINDINGS:
+            switch_page(UIP_KeyBindings);
             doredraw++; clear++;
             break;
         // ------------------------------------------------------------------------
@@ -2263,6 +2277,7 @@ int postAction ()
     delete UIP_Arpeggioeditor;
     delete UIP_Midimacroeditor;
     delete UIP_LuaConsole;
+    delete UIP_KeyBindings;
     g_lua.shutdown();
     delete ztPlayer;
     delete MidiIn;
@@ -2393,7 +2408,6 @@ void keyhandler(SDL_KeyboardEvent *e) {
             fprintf(dbg_fp, "# ZT_KEYDEBUG active. Columns: scancode (name) | keycode (name) | mod | mod names\n");
             fflush(dbg_fp);
           }
-          fprintf(stderr, "[zt-key] debug logging enabled, writing ./zt-keydebug.log\n");
         }
       }
       if (enabled) {
@@ -2483,17 +2497,26 @@ void textinputhandler(const SDL_Event *e) {
     }
 
     const unsigned char ch = (unsigned char)e->text.text[0];
-    // Log text-input chars under ZT_KEYDEBUG so we can see what the OS
-    // translates a physical key to (e.g. "<" vs "§" on Finnish ISO).
-    if (getenv("ZT_KEYDEBUG")) {
-        fprintf(stderr, "[zt-key] TEXT_INPUT='%s' (first byte=0x%02X)\n",
-                e->text.text, ch);
-        fflush(stderr);
-        FILE *fp = fopen("zt-keydebug.log", "a");
-        if (fp) {
-            fprintf(fp, "TEXT_INPUT='%s' (first byte=0x%02X)\n",
+    // Opt-in text-input logging. Set ZT_KEYDEBUG=1 to enable. Default off
+    // keeps this hot path free of getenv/fopen per event.
+    {
+        static int init_done = 0;
+        static int enabled = 0;
+        if (!init_done) {
+            init_done = 1;
+            const char *env = getenv("ZT_KEYDEBUG");
+            enabled = (env && env[0] && env[0] != '0') ? 1 : 0;
+        }
+        if (enabled) {
+            fprintf(stderr, "[zt-key] TEXT_INPUT='%s' (first byte=0x%02X)\n",
                     e->text.text, ch);
-            fclose(fp);
+            fflush(stderr);
+            FILE *fp = fopen("zt-keydebug.log", "a");
+            if (fp) {
+                fprintf(fp, "TEXT_INPUT='%s' (first byte=0x%02X)\n",
+                        e->text.text, ch);
+                fclose(fp);
+            }
         }
     }
     if (ch >= 0x20 || ch == 10 || ch == 9) {
@@ -3258,6 +3281,7 @@ int initSDL(void)
     UIP_Help = new CUI_Help;
     UIP_SongDuration = new CUI_SongDuration;
     UIP_LuaConsole = new CUI_LuaConsole;
+    UIP_KeyBindings = new CUI_KeyBindings;
     g_lua.init();
     UIP_PaletteEditor = new CUI_PaletteEditor;
     //SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL );

--- a/src/zt.h
+++ b/src/zt.h
@@ -314,7 +314,8 @@ enum state {
   STATE_ARPEDIT,
   STATE_MIDIMACEDIT,
   STATE_LUA_CONSOLE,
-  STATE_PALETTE_EDITOR
+  STATE_PALETTE_EDITOR,
+  STATE_KEYBINDINGS
 } ;
 
 
@@ -591,7 +592,9 @@ enum E_col_type { T_NOTE, T_OCTAVE, T_INST, T_VOL, T_CHAN, T_LEN,
         CMD_SWITCH_MIDIMACEDIT,
 #endif
 
-        CMD_SWITCH_LUA_CONSOLE
+        CMD_SWITCH_LUA_CONSOLE,
+
+        CMD_SWITCH_KEYBINDINGS
 
     };
 
@@ -745,6 +748,7 @@ extern CUI_SongMessage *UIP_SongMessage;
 extern CUI_Arpeggioeditor *UIP_Arpeggioeditor;
 extern CUI_Midimacroeditor *UIP_Midimacroeditor;
 extern CUI_LuaConsole *UIP_LuaConsole;
+extern CUI_KeyBindings *UIP_KeyBindings;
 
 extern void switch_page(CUI_Page *page);
 extern int need_update;


### PR DESCRIPTION
Rebased onto current `master` (includes `860264d` keyboard latency fix). Default keyboard path stays zero-cost per keydown; all keydebug logging is env-gated behind `ZT_KEYDEBUG=1`.

## Summary

**Low-resolution toolbar overlap fixes**
- Pattern editor + F5/F11 views no longer draw over the toolbar at 480px window height.
- F3 Instrument Editor: left column (instrument list) and right column (description) share the same top and bottom border rows.

**Focus navigation**
- UP/DOWN focus cycle skips invisible elements (zero-sized sliders) and read-only text boxes — both were swallowing navigation keypresses.
- F12 Sysconfig tab order rebuilt in visual top-to-bottom order: Refresh → list → Open device → Latency → Bank → Alias. DOWN from Alias no longer jumps back up to the Refresh button.

**F12 Sysconfig layout polish**
- "Go to page 2" button moved to the top of the page with clean padding above and below (row 11 and 13 empty, button on row 12).
- Prebuffer and the left-column controls shifted down by 3 rows; all draw() labels follow.
- Skin list height reduced from 10 to 7 rows to fit the installed skin count tightly — no more empty black space in the box.
- "Skin Selection" label aligned with the Prebuffer label; list top border sits directly below it.

**Page-nav symmetry**
- `CUI_Config` button renamed to "Go to page 1" (matching Sysconfig's "Go to page 2" format) and moved to `y=12` so the button no longer jumps rows when switching pages.

**"Sure to quit?" dialog**
- Title moved from `start_y + row(1)` to `start_y + 2 * row(1)` so it has visible padding above the top border instead of sitting flush against it.

**Keyboard diagnostics (opt-in, zero cost when off)**
- `ZT_KEYDEBUG=1` env var enables full per-keydown logging (scancode, keycode, modifiers, text-input char) to stderr and `./zt-keydebug.log`.
- Implementation uses a `static int enabled` cached on first call, so when the var is unset the keyhandler path does no syscalls and no I/O — preserves master's keyboard latency fix.

**In-app keybindings editor (Ctrl+Alt+K)**
- New CUI_KeyBindings page listing every ZtAction with its current binding. ENTER/SPACE captures a new key, DEL/BACKSPACE unbinds, Ctrl+R resets one row, Ctrl+Shift+R resets all rows, Ctrl+S writes to `KeyBindings/zt.conf`.

**Build ergonomics**
- Silences the Clang `sprintf` deprecation warnings (mirrors the existing MSVC workaround). Clean build now emits 0 warnings from our changes.
- Emits `compile_commands.json` and ships a `.clangd` config so IDE tooling resolves SDL3 and project headers correctly.

## Test plan

- [ ] `./build-mac.sh --clean` — clean build (verified locally)
- [ ] Normal typing has no extra per-key latency
- [ ] `ZT_KEYDEBUG=1 ./build-mac/Program/zt.app/Contents/MacOS/zt` writes `./zt-keydebug.log` with every keydown and TEXT_INPUT
- [ ] F3 / F5 / F11 at low resolution: toolbar clearance visually correct
- [ ] F12: "Go to page 2" button clearly padded below title, Skin Selection label aligned with Prebuffer, list is tight around content
- [ ] F12 → page 2 → back to F12: button sits on the same row throughout
- [ ] F12 tab order: DOWN from last skin entry reaches Refresh; DOWN from Alias reaches next column's Refresh
- [ ] "Sure to quit?" dialog: title has visible padding above the top border
- [ ] UP/DOWN focus cycle skips invisible/text-only widgets
- [ ] Ctrl+Alt+K opens keybindings editor, Ctrl+S persists to `KeyBindings/zt.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
