### PR TITLE
Lua Console: fix invisible rendering, dead keyboard, and swallowed shortcuts (closes Lua part of #28)

### DIFF
--- a/src/CUI_LuaConsole.cpp
+++ b/src/CUI_LuaConsole.cpp
@@ -67,9 +67,8 @@ void CUI_LuaConsole::enter()
 
     if (!s_welcomed) {
         g_lua.print_line("zTracker Lua Console — Lua 5.4");
-        g_lua.print_line("Type Lua code, press Enter to execute.");
-        g_lua.print_line("Up/Down = history   PgUp/PgDn = scroll   Esc = exit");
-        g_lua.print_line("Try:  print('hello')   or   for i=1,3 do print(i) end");
+        g_lua.print_line("Enter=run  Up/Down=history  PgUp/PgDn=scroll  Tab=complete  Esc=exit");
+        g_lua.print_api_list();
         g_lua.print_line("");
         s_welcomed = 1;
     }
@@ -180,6 +179,11 @@ void CUI_LuaConsole::update()
 
     case SDLK_END:
         s_cursor = (int)strlen(s_input);
+        break;
+
+    case SDLK_TAB:
+        g_lua.tab_complete(s_input, (int)sizeof(s_input), &s_cursor);
+        g_lua.scroll_off = 0;
         break;
 
     default: {

--- a/src/CUI_LuaConsole.cpp
+++ b/src/CUI_LuaConsole.cpp
@@ -1,17 +1,15 @@
 // CUI_LuaConsole.cpp — Lua REPL console page for zTracker
 //
-// Layout:
-//   - Scrollback area fills most of the screen (TRACKS_ROW_Y .. CHARS_Y-3)
-//   - A single-line text input at the bottom row
-//   - Title bar at PAGE_TITLE_ROW_Y
+// Layout (top to bottom):
+//   row PAGE_TITLE_ROW_Y              title bar ("Lua Console")
+//   row TRACKS_ROW_Y .. sep_y-1       scrollback (history of output)
+//   row sep_y                         horizontal separator
+//   row inp_y                         input line with ">" prompt + cursor
+//   (rows below inp_y are covered by the skin's toolbar strip)
 //
-// Keys:
-//   Enter      — execute current input line
-//   Escape/F2  — return to pattern editor
-//   Up/Down    — browse input history / scroll scrollback
-//   PgUp/PgDn  — scroll scrollback by page
-//   Backspace  — delete character to left
-//   Delete     — clear input line
+// Drawable::fillRect takes (x1, y1, x2, y2, color) — two corner points,
+// inclusive on the low side, inclusive on the high side (see
+// lc_sdl_wrapper.cpp:93). NOT (x, y, w, h).
 
 #include "zt.h"
 #include "lua_engine.h"
@@ -20,51 +18,45 @@
 #include "font.h"
 
 // ---------------------------------------------------------------------------
-// Local state (kept outside the class to avoid header pollution)
+// Local state
 // ---------------------------------------------------------------------------
-static char   s_input[256]    = "";  // current input buffer
-static int    s_cursor        = 0;   // cursor position in s_input
+static char s_input[256] = "";
+static int  s_cursor     = 0;
+static int  s_welcomed   = 0;
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Layout (all values are character rows/cols; convert with row()/col())
 // ---------------------------------------------------------------------------
+static int frame_x1() { return 1; }
+static int frame_x2() { return CHARS_X - 2; }
 
-// Number of visible rows in the scrollback area
-static int console_rows()
+// Reserve 8 rows at the bottom for the skin toolbar strip (55 px / 8 ≈ 7).
+static int bottom_margin_rows() { return 8; }
+
+static int sep_row()   { return CHARS_Y - bottom_margin_rows() - 1; }
+static int input_row() { return sep_row() + 1; }
+
+static int scrollback_top()    { return TRACKS_ROW_Y; }
+static int scrollback_bottom() { return sep_row() - 1; }
+static int scrollback_rows()
 {
-    return CHARS_Y - TRACKS_ROW_Y - 3; // leave 2 rows for input + border
+    int n = scrollback_bottom() - scrollback_top() + 1;
+    return (n > 0) ? n : 1;
 }
 
-// Draw a single text row at character position (cx, cy) with given colors
-static void draw_text_row(const char *text, int cx, int cy,
-                           TColor fg, TColor bg, Drawable *S)
-{
-    // Clear the row first
-    int px = col(cx);
-    int py = row(cy);
-    int pw = (CHARS_X - 2) * CHARACTER_SIZE_X;
-    S->fillRect(px, py, pw, CHARACTER_SIZE_Y, bg);
-    if (text && text[0])
-        printBG(col(cx), row(cy), text, fg, bg, S);
-}
+// Pixel corners of the console frame (inclusive)
+static int frame_px1() { return col(frame_x1()); }
+static int frame_px2() { return col(frame_x2() + 1) - 1; }
 
 // ---------------------------------------------------------------------------
 // CUI_LuaConsole constructor / destructor
 // ---------------------------------------------------------------------------
-
-CUI_LuaConsole::CUI_LuaConsole()
-{
-    UI = nullptr;  // No widget system needed
-}
-
-CUI_LuaConsole::~CUI_LuaConsole()
-{
-}
+CUI_LuaConsole::CUI_LuaConsole()  { UI = nullptr; }
+CUI_LuaConsole::~CUI_LuaConsole() {}
 
 // ---------------------------------------------------------------------------
 // enter / leave
 // ---------------------------------------------------------------------------
-
 void CUI_LuaConsole::enter()
 {
     s_input[0] = '\0';
@@ -72,44 +64,52 @@ void CUI_LuaConsole::enter()
     g_lua.scroll_off = 0;
     need_refresh++;
     cur_state = STATE_LUA_CONSOLE;
+
+    if (!s_welcomed) {
+        g_lua.print_line("zTracker Lua Console — Lua 5.4");
+        g_lua.print_line("Type Lua code, press Enter to execute.");
+        g_lua.print_line("Up/Down = history   PgUp/PgDn = scroll   Esc = exit");
+        g_lua.print_line("Try:  print('hello')   or   for i=1,3 do print(i) end");
+        g_lua.print_line("");
+        s_welcomed = 1;
+    }
+
+    zt_text_input_start();
 }
 
 void CUI_LuaConsole::leave()
 {
+    zt_text_input_stop();
 }
 
 // ---------------------------------------------------------------------------
-// update — handle keyboard input
+// update — keyboard input
 // ---------------------------------------------------------------------------
-
 void CUI_LuaConsole::update()
 {
     if (!Keys.size()) return;
 
-    KBKey key   = Keys.getkey();
-    KBKey kstate= Keys.getstate();
+    KBKey key    = Keys.getkey();
+    KBKey kstate = Keys.getstate();
     (void)kstate;
 
-    int rows = console_rows();
+    int page = scrollback_rows();
 
     switch (key) {
-    // -- Execute ----------------------------------------------------------------
     case SDLK_RETURN:
         if (s_input[0]) {
             g_lua.execute(s_input);
             s_input[0] = '\0';
             s_cursor   = 0;
-            g_lua.scroll_off = 0;  // snap back to bottom
+            g_lua.scroll_off = 0;
         }
         break;
 
-    // -- Leave page -------------------------------------------------------------
     case SDLK_ESCAPE:
     case SDLK_F2:
         switch_page(UIP_Patterneditor);
         break;
 
-    // -- History navigation (Up/Down) -------------------------------------------
     case SDLK_UP:
         if (g_lua.history_count > 0) {
             if (g_lua.history_pos < 0)
@@ -139,19 +139,17 @@ void CUI_LuaConsole::update()
         }
         break;
 
-    // -- Scroll scrollback ------------------------------------------------------
     case SDLK_PAGEUP:
-        g_lua.scroll_off += rows;
+        g_lua.scroll_off += page;
         if (g_lua.scroll_off > g_lua.line_count - 1)
             g_lua.scroll_off = (g_lua.line_count > 0) ? g_lua.line_count - 1 : 0;
         break;
 
     case SDLK_PAGEDOWN:
-        g_lua.scroll_off -= rows;
+        g_lua.scroll_off -= page;
         if (g_lua.scroll_off < 0) g_lua.scroll_off = 0;
         break;
 
-    // -- Text editing -----------------------------------------------------------
     case SDLK_BACKSPACE:
         if (s_cursor > 0) {
             int len = (int)strlen(s_input);
@@ -185,7 +183,6 @@ void CUI_LuaConsole::update()
         break;
 
     default: {
-        // Use the actual_char field set by the SDL event handler
         unsigned char ch = Keys.getactualchar();
         if (ch >= 0x20 && ch < 0x7F) {
             int len = (int)strlen(s_input);
@@ -207,60 +204,104 @@ void CUI_LuaConsole::update()
 // ---------------------------------------------------------------------------
 // draw
 // ---------------------------------------------------------------------------
-
 void CUI_LuaConsole::draw(Drawable *S)
 {
     if (S->lock() != 0) return;
 
-    TColor fg   = COLORS.EditText;
-    TColor bg   = COLORS.EditBG;
-    TColor hfg  = COLORS.Data;      // highlight (prompt text)
-    TColor ibg  = COLORS.EditBGhigh; // input row bg
+    const TColor page_bg    = COLORS.Background;
+    const TColor console_bg = COLORS.EditBG;
+    const TColor console_fg = COLORS.EditText;
+    const TColor prompt_fg  = COLORS.Data;
+    const TColor input_bg   = COLORS.EditBGhigh;
+    const TColor title_fg   = COLORS.Text;
+    const TColor accent     = COLORS.Highlight;
 
-    // Title
-    printtitle(PAGE_TITLE_ROW_Y, "Lua Console (Esc/F2 to close)", COLORS.Text, COLORS.Background, S);
+    const int fx1 = frame_px1();
+    const int fx2 = frame_px2();
 
-    int rows    = console_rows();
-    int start_y = TRACKS_ROW_Y;
+    // --- Clear the whole console area first ---
+    S->fillRect(fx1, row(PAGE_TITLE_ROW_Y),
+                fx2, row(input_row() + 1) - 1, page_bg);
 
-    // --- Scrollback area ---
-    // We render from (line_count - scroll_off - rows) upward
-    int bottom = g_lua.line_count - g_lua.scroll_off;  // index of first line below view
-    int top    = bottom - rows;
+    // --- Title ---
+    printtitle(PAGE_TITLE_ROW_Y, "Lua Console (Esc/F2 to close)",
+               title_fg, page_bg, S);
 
-    for (int i = 0; i < rows; i++) {
-        int line_idx = top + i;
-        const char *text = "";
+    // --- Scrollback background (distinct shade, so the console area is
+    //     visually separate from the empty page background) ---
+    const int sb_top = scrollback_top();
+    const int sb_rows = scrollback_rows();
+    S->fillRect(fx1, row(sb_top),
+                fx2, row(sb_top + sb_rows) - 1, console_bg);
+
+    // --- Scrollback lines (newest at bottom) ---
+    const int bottom_idx = g_lua.line_count - g_lua.scroll_off;
+    const int top_idx    = bottom_idx - sb_rows;
+    for (int i = 0; i < sb_rows; i++) {
+        int line_idx = top_idx + i;
         if (line_idx >= 0 && line_idx < g_lua.line_count) {
             int ring = line_idx % LUA_CONSOLE_MAX_LINES;
-            text = g_lua.lines[ring];
+            const char *text = g_lua.lines[ring];
+            if (text && text[0]) {
+                printBG(col(frame_x1() + 1), row(sb_top + i),
+                        text, console_fg, console_bg, S);
+            }
         }
-        int cy = start_y + i;
-        draw_text_row(text, 1, cy, fg, bg, S);
     }
 
-    // --- Separator line ---
-    int sep_y = start_y + rows;
-    S->fillRect(col(1), row(sep_y), (CHARS_X - 2) * CHARACTER_SIZE_X, CHARACTER_SIZE_Y, COLORS.Lowlight);
+    // --- Scroll indicator ---
+    if (g_lua.scroll_off > 0) {
+        char ind[32];
+        snprintf(ind, sizeof(ind), " [-%d] ", g_lua.scroll_off);
+        int ind_len = (int)strlen(ind);
+        printBG(col(frame_x2() - ind_len), row(sb_top),
+                ind, prompt_fg, console_bg, S);
+    }
+
+    // --- Separator (just above input line) ---
+    printlineBG(col(frame_x1()), row(sep_row()), 0x81,
+                frame_x2() - frame_x1() + 1, accent, page_bg, S);
 
     // --- Input line ---
-    int inp_y = sep_y + 1;
-    S->fillRect(col(1), row(inp_y), (CHARS_X - 2) * CHARACTER_SIZE_X, CHARACTER_SIZE_Y, ibg);
+    const int iy = input_row();
+    S->fillRect(fx1, row(iy), fx2, row(iy + 1) - 1, input_bg);
 
-    // Draw prompt ">"
-    printcharBG(col(1), row(inp_y), '>', hfg, ibg, S);
-    // Draw input text
-    printBG(col(2), row(inp_y), s_input, fg, ibg, S);
+    printcharBG(col(frame_x1()    ), row(iy), '>', prompt_fg, input_bg, S);
+    printcharBG(col(frame_x1() + 1), row(iy), ' ', prompt_fg, input_bg, S);
 
-    // Draw cursor block
-    int cur_x = 2 + s_cursor;
-    unsigned char cur_ch = s_input[s_cursor] ? (unsigned char)s_input[s_cursor] : ' ';
-    printcharBG(col(cur_x), row(inp_y), cur_ch, ibg, hfg, S);
+    const int text_x1   = frame_x1() + 2;
+    const int max_chars = frame_x2() - text_x1;
+    const int len       = (int)strlen(s_input);
+    int view_off = 0;
+    if (s_cursor >= max_chars) view_off = s_cursor - max_chars + 1;
+    if (view_off < 0)   view_off = 0;
+    if (view_off > len) view_off = len;
+    char view[512];
+    {
+        int n = len - view_off;
+        if (n > max_chars) n = max_chars;
+        if (n > (int)sizeof(view) - 1) n = (int)sizeof(view) - 1;
+        memcpy(view, s_input + view_off, (size_t)n);
+        view[n] = '\0';
+    }
+    printBG(col(text_x1), row(iy), view, console_fg, input_bg, S);
 
+    // Cursor block (inverse)
+    int cur_col = text_x1 + (s_cursor - view_off);
+    if (cur_col < text_x1)      cur_col = text_x1;
+    if (cur_col > frame_x2())   cur_col = frame_x2();
+    unsigned char cur_ch = (s_cursor < len) ? (unsigned char)s_input[s_cursor] : ' ';
+    printcharBG(col(cur_col), row(iy), cur_ch, input_bg, prompt_fg, S);
+
+    // Top-of-screen info (Song Name etc.) last so it wins.
     draw_status(S);
 
     need_refresh = 0;
     updated = 2;
 
     S->unlock();
+
+    // Tell screenmanager the frame is dirty so the backbuffer actually
+    // gets blitted to the SDL texture.
+    screenmanager.UpdateAll();
 }

--- a/src/lua_engine.cpp
+++ b/src/lua_engine.cpp
@@ -311,7 +311,7 @@ bool ZtLuaEngine::init()
     registerBindings();
 
     print_line("[Lua] Lua 5.4 ready. Type Lua code and press Enter.");
-    print_line("[Lua] API: zt.get_note/set_note, zt.play/stop, zt.get_bpm/set_bpm, ...");
+    print_line("[Lua] Tab completes; type 'zt.' and press Tab to list the API.");
 
     return true;
 }
@@ -422,4 +422,244 @@ void ZtLuaEngine::registerBindings()
     lua_pushcfunction(L, l_zt_print_fn);       lua_setfield(L, -2, "print");
 
     lua_setglobal(L, "zt");
+}
+
+// ---------------------------------------------------------------------------
+// API listing + tab completion
+// ---------------------------------------------------------------------------
+
+// Lua identifier char? (incl. digits after first pos; we treat '.' specially)
+static bool is_ident_char(char c)
+{
+    return (c >= 'A' && c <= 'Z') ||
+           (c >= 'a' && c <= 'z') ||
+           (c >= '0' && c <= '9') ||
+            c == '_';
+}
+
+// Push the table whose dotted path is `path` (may be empty, meaning _G) onto
+// the Lua stack. Returns true if the path resolved to a table; otherwise the
+// stack is unchanged and false is returned.
+static bool push_table_by_path(lua_State *L, const char *path)
+{
+    if (!path || !path[0]) {
+        lua_pushglobaltable(L);
+        return true;
+    }
+    lua_pushglobaltable(L);
+    const char *p = path;
+    while (*p) {
+        const char *dot = strchr(p, '.');
+        size_t n = dot ? (size_t)(dot - p) : strlen(p);
+        lua_pushlstring(L, p, n);
+        lua_gettable(L, -2);
+        lua_remove(L, -2);
+        if (!lua_istable(L, -1)) {
+            lua_pop(L, 1);
+            return false;
+        }
+        if (!dot) break;
+        p = dot + 1;
+    }
+    return true;
+}
+
+// Collect string keys in the table on top of the stack that start with
+// `prefix`. Table is left on the stack. `out` is a caller-owned buffer of
+// capacity `cap`; returns number of candidates written (may be less than
+// cap if truncated).
+static int collect_keys(lua_State *L, const char *prefix,
+                        char out[][64], int cap)
+{
+    int n = 0;
+    size_t plen = strlen(prefix);
+    lua_pushnil(L);
+    while (lua_next(L, -2) != 0) {
+        if (lua_type(L, -2) == LUA_TSTRING) {
+            const char *k = lua_tostring(L, -2);
+            if (strncmp(k, prefix, plen) == 0) {
+                if (n < cap) {
+                    strncpy(out[n], k, 63);
+                    out[n][63] = '\0';
+                    n++;
+                }
+            }
+        }
+        lua_pop(L, 1); // value
+    }
+    return n;
+}
+
+static int qsort_strcmp(const void *a, const void *b)
+{
+    return strcmp((const char *)a, (const char *)b);
+}
+
+void ZtLuaEngine::print_api_list()
+{
+    if (!L) return;
+
+    // Print the zt.* table contents first.
+    lua_getglobal(L, "zt");
+    if (lua_istable(L, -1)) {
+        static char keys[64][64];
+        int n = collect_keys(L, "", keys, 64);
+        qsort(keys, (size_t)n, 64, qsort_strcmp);
+
+        print_line("[Lua] zt.* API:");
+        char buf[LUA_CONSOLE_LINE_LEN];
+        buf[0] = ' '; buf[1] = ' '; buf[2] = '\0';
+        int col = 2;
+        for (int i = 0; i < n; i++) {
+            int klen = (int)strlen(keys[i]);
+            if (col > 2 && col + klen + 2 > 76) {
+                print_line(buf);
+                buf[0] = ' '; buf[1] = ' '; buf[2] = '\0';
+                col = 2;
+            }
+            strcat(buf, "zt.");
+            strcat(buf, keys[i]);
+            strcat(buf, "  ");
+            col += klen + 5;
+        }
+        if (col > 2) print_line(buf);
+    }
+    lua_pop(L, 1);
+
+    print_line("[Lua] Globals (selected): print, pairs, ipairs, math, string, table");
+    print_line("[Lua] Tab to complete any identifier. Esc/F2 to close.");
+}
+
+bool ZtLuaEngine::tab_complete(char *input, int cap, int *pcursor)
+{
+    if (!L || !input || !pcursor) return false;
+
+    int cursor = *pcursor;
+    int len = (int)strlen(input);
+    if (cursor < 0) cursor = 0;
+    if (cursor > len) cursor = len;
+
+    // Walk backward from cursor over identifier/dot characters.
+    int start = cursor;
+    while (start > 0 && (is_ident_char(input[start - 1]) || input[start - 1] == '.'))
+        start--;
+
+    // Portion to complete is input[start..cursor-1].
+    int span = cursor - start;
+    char word[128];
+    if (span > (int)sizeof(word) - 1) span = (int)sizeof(word) - 1;
+    memcpy(word, input + start, (size_t)span);
+    word[span] = '\0';
+
+    // Split on last dot.
+    char table_path[128] = "";
+    const char *key_prefix = word;
+    char *last_dot = strrchr(word, '.');
+    if (last_dot) {
+        size_t tn = (size_t)(last_dot - word);
+        if (tn >= sizeof(table_path)) tn = sizeof(table_path) - 1;
+        memcpy(table_path, word, tn);
+        table_path[tn] = '\0';
+        key_prefix = last_dot + 1;
+    }
+
+    // If the user typed "zt." alone and hit Tab, show the full API.
+    bool prefix_empty = (key_prefix[0] == '\0');
+
+    if (!push_table_by_path(L, table_path)) {
+        char msg[LUA_CONSOLE_LINE_LEN];
+        snprintf(msg, sizeof(msg), "[tab] '%s' is not a table", table_path);
+        print_line(msg);
+        return false;
+    }
+
+    static char keys[128][64];
+    int n = collect_keys(L, key_prefix, keys, 128);
+
+    // If completion target is an empty prefix and it's the zt.* table, redirect
+    // to full API listing (nicer output).
+    if (prefix_empty && table_path[0] == 'z' && table_path[1] == 't' && table_path[2] == '\0') {
+        lua_pop(L, 1);
+        print_api_list();
+        return false;
+    }
+
+    if (n == 0) {
+        lua_pop(L, 1);
+        char msg[LUA_CONSOLE_LINE_LEN];
+        snprintf(msg, sizeof(msg), "[tab] no match for '%s'", word);
+        print_line(msg);
+        return false;
+    }
+
+    qsort(keys, (size_t)n, 64, qsort_strcmp);
+
+    // Compute longest common prefix among matches.
+    int lcp = (int)strlen(keys[0]);
+    for (int i = 1; i < n; i++) {
+        int j = 0;
+        while (j < lcp && keys[0][j] && keys[i][j] && keys[0][j] == keys[i][j]) j++;
+        lcp = j;
+    }
+
+    // Determine the full replacement — "table.prefix"
+    char replacement[256];
+    if (n == 1) {
+        // Single match: check if it's a function → append "(".
+        lua_getfield(L, -1, keys[0]);
+        bool is_fn = lua_isfunction(L, -1);
+        lua_pop(L, 1);
+
+        if (table_path[0])
+            snprintf(replacement, sizeof(replacement), "%s.%s%s",
+                     table_path, keys[0], is_fn ? "(" : "");
+        else
+            snprintf(replacement, sizeof(replacement), "%s%s",
+                     keys[0], is_fn ? "(" : "");
+    } else {
+        // Multiple — apply the longest common prefix only.
+        char common[64];
+        if (lcp > (int)sizeof(common) - 1) lcp = (int)sizeof(common) - 1;
+        memcpy(common, keys[0], (size_t)lcp);
+        common[lcp] = '\0';
+
+        if (table_path[0])
+            snprintf(replacement, sizeof(replacement), "%s.%s", table_path, common);
+        else
+            snprintf(replacement, sizeof(replacement), "%s", common);
+
+        // Print the candidates so the user sees what's available.
+        char line[LUA_CONSOLE_LINE_LEN];
+        line[0] = ' '; line[1] = ' '; line[2] = '\0';
+        int col = 2;
+        for (int i = 0; i < n; i++) {
+            int klen = (int)strlen(keys[i]);
+            if (col > 2 && col + klen + 2 > 76) {
+                print_line(line);
+                line[0] = ' '; line[1] = ' '; line[2] = '\0';
+                col = 2;
+            }
+            strcat(line, keys[i]);
+            strcat(line, "  ");
+            col += klen + 2;
+        }
+        if (col > 2) print_line(line);
+    }
+    lua_pop(L, 1); // the table we walked
+
+    // Apply replacement in `input`: replace bytes [start..cursor-1] with
+    // `replacement`, preserving everything after the original cursor.
+    int repl_len = (int)strlen(replacement);
+    int tail_len = len - cursor;
+    int new_len  = start + repl_len + tail_len;
+    if (new_len >= cap) return false;
+
+    if (tail_len > 0)
+        memmove(input + start + repl_len, input + cursor, (size_t)tail_len + 1);
+    else
+        input[start + repl_len] = '\0';
+    memcpy(input + start, replacement, (size_t)repl_len);
+
+    *pcursor = start + repl_len;
+    return (repl_len != span);
 }

--- a/src/lua_engine.h
+++ b/src/lua_engine.h
@@ -41,6 +41,19 @@ public:
     // Append a line of text to the scrollback
     void print_line(const char *text);
 
+    // Print the full API (all zt.* bindings + selected globals) to scrollback.
+    void print_api_list();
+
+    // Tab completion.
+    //
+    // Given `input` of length `len` with the cursor at byte `cursor`, try to
+    // complete the identifier ending at the cursor. If a unique completion is
+    // found, `input` and `*cursor` are rewritten in place (caller guarantees
+    // at least `cap` bytes in `input`). If multiple candidates exist, the
+    // common prefix is applied and the candidate list is printed to the
+    // scrollback. Returns true if `input`/`*cursor` were modified.
+    bool tab_complete(char *input, int cap, int *cursor);
+
 private:
     void registerBindings();
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2456,7 +2456,14 @@ void keyhandler(SDL_KeyboardEvent *e) {
                  id == SDLK_BACKSPACE || id == SDLK_DELETE || id == SDLK_RETURN ||
                  id == SDLK_TAB || id == SDLK_HOME || id == SDLK_END ||
                  id == SDLK_PAGEUP || id == SDLK_PAGEDOWN);
-            if (!is_edit_or_nav) {
+            // Modifier combos (Ctrl/Alt/Cmd+X) are shortcuts, not text input
+            // — they must flow through to global_keys / page update, not be
+            // swallowed in favor of SDL_TEXTINPUT. Without this, Ctrl+Alt+Q
+            // (quit), Ctrl+L (load), etc. stop working on any text-input
+            // page (Lua Console, Song Message).
+            const bool has_cmd_mod =
+                (mod & (SDL_KMOD_CTRL | SDL_KMOD_ALT | SDL_KMOD_GUI)) != 0;
+            if (!is_edit_or_nav && !has_cmd_mod) {
                 if (id >= 0x20 && id < 0x7f) {
                     return;
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3479,7 +3479,13 @@ int main(int argc, char *argv[])
       } else {
         focus_page = ActivePage;
       }
-      if (focus_page && focus_page->UI && focus_page->UI->has_text_focus()) {
+      bool want_text_input =
+          (focus_page && focus_page->UI && focus_page->UI->has_text_focus());
+      // Lua console has no UI widget system but still needs text input
+      // (SDL_TEXTINPUT events are the only path that delivers typed
+      // characters with a valid actual_char; plain key-downs give 0).
+      if (cur_state == STATE_LUA_CONSOLE) want_text_input = true;
+      if (want_text_input) {
         if (!zt_text_input_is_active) {
           zt_text_input_start();
         }


### PR DESCRIPTION
## Summary

Fixes the Lua console (Ctrl+Alt+L) which has been unusable since the SDL3 port — screen was nearly blank, typing did nothing, Ctrl+Alt+Q didn't show the quit dialog, and there was no API discovery. Closes the Lua-console portion of #28 (that issue can be closed after this lands).

Four things:

### 1. Rectangles were drawn to the wrong regions

`Drawable::fillRect` takes `(x1, y1, x2, y2)` — two corner points (see `lc_sdl_wrapper.cpp:93`) — but `CUI_LuaConsole::draw` was passing `(x, y, w, h)` as if it were `SDL_FillRect`. Every fill landed somewhere other than intended: the title row, scrollback backdrop, separator, and input-line background all drew off-viewport or in slivers at the window edges. Only the `>` prompt was visible because `printcharBG` doesn't take rectangle args. Every fill now uses correct two-corner coordinates.

### 2. Typing did nothing

The main loop (`main.cpp:3482`) only enables SDL text input when `ActivePage->UI->has_text_focus()` is true, but `CUI_LuaConsole` has `UI = nullptr`. With text input disabled, plain character keydowns deliver `actual_char = 0`, so `Keys.getactualchar()` always returned 0 in the console's `default:` branch and nothing ever landed in the input buffer.

Fix:
- `main.cpp`: also enable text input when `cur_state == STATE_LUA_CONSOLE`.
- `CUI_LuaConsole::enter`/`leave`: call `zt_text_input_start`/`zt_text_input_stop` symmetrically (same pattern as `CUI_SongMessage`).

### 3. Ctrl+Alt+Q (quit dialog) stopped working on text-input pages

While `zt_text_input_is_active` is true, `keyhandler` returns early for any printable-ascii keydown that isn't a nav/edit key, yielding to SDL_TEXTINPUT. That was swallowing shortcut combos like Ctrl+Alt+Q, Ctrl+L, Ctrl+S — they're still in the 0x20-0x7F range, so the Q/L/S never reached `Keys.insert` → `global_keys`. On the Lua Console, Ctrl+Alt+Q produced no "Sure to quit?" dialog.

Fix: skip only when **no** Ctrl/Alt/Cmd modifier is held. Plain letters still route through SDL_TEXTINPUT; Shift+letter still produces the correct uppercase; shortcut combos now reach `global_keys` as on any other page.

### 4. Tab completion + full API listing

The previous welcome line listed three bindings and `...` — not useful. Now:
- First entry prints the complete `zt.*` API, enumerated directly from the Lua state with `lua_next`, word-wrapped into columns. Stays in sync with whatever `registerBindings()` actually installed, no manual list to drift.
- **Tab** completes the identifier under the cursor. Walks back over `[A-Za-z0-9_.]`, splits on the last `.` into table path + key prefix, then walks the table.
  - Single match: input is rewritten in place; if the target is a function, `(` is appended so the next keystroke goes into the args.
  - Multiple: longest common prefix is applied and candidates are printed, sorted, in columns.
  - Bare `zt.<Tab>` prints the whole API list.
  - No match: `[tab] no match for '<word>'`.

### Polish

- Reserves 8 rows at the bottom so the input line sits above the skin toolbar strip instead of being clipped behind it.
- `screenmanager.UpdateAll()` at end of `draw` so the backbuffer actually blits to the SDL texture (non-widget pages like `CUI_PaletteEditor` already do the same).
- Horizontal view-scroll for the input line so long commands don't overflow the frame.
- Drops the confusing local `draw_text_row`/`fill_row` helpers that were feeding the wrong args to `fillRect`.

## Related issues

- #28 — the Lua-console portion ("lua console is especially broken. doesn't even take keyboard input") is addressed here. Safe to close after this PR lands; the other graphics glitches in #28 were fixed by earlier PRs (#32 / #33 / #39).

## Test plan

- [x] Builds clean on macOS arm64 (AppleClang) — `cmake -G "Unix Makefiles" && make -j8`
- [ ] CI: Linux x86_64, macOS x86_64, Windows x64 MSVC, Windows x86 MinGW
- [ ] Manual: Ctrl+Alt+L opens console; title + full API listing visible; scrollback and input area clearly framed
- [ ] Manual: typing a Lua expression + Enter prints to scrollback; Up/Down browses history; PgUp/PgDn scrolls
- [ ] Manual: `zt.<Tab>` prints the full API; `zt.get_<Tab>` lists the `get_*` entries; single-match Tab completes + appends `(`
- [ ] Manual: Ctrl+Alt+Q while on the Lua Console shows the "Sure to quit?" dialog
- [ ] Manual: Esc / F2 returns to Pattern editor; text-input correctly re-disables

Generated with Claude Code.
