### PR TITLE
Fix -Winconsistent-missing-override warnings on macOS AppleClang

### DIFF
--- a/src/InstEditor.h
+++ b/src/InstEditor.h
@@ -18,9 +18,9 @@ class InstEditor : public UserInterfaceElement
         ~InstEditor();
 
         void strc(char *dst, char *src);
-        int update();
-        void draw(Drawable *S, int active);
-        int mouseupdate(int cur_element);
+        int update() override;
+        void draw(Drawable *S, int active) override;
+        int mouseupdate(int cur_element) override;
         bool is_text_input() const override { return text_cursor < 24; }
         void on_focus() override { text_cursor = (g_ui_tab_dir < 0) ? 24 : 0; }
 };

--- a/src/UserInterface.h
+++ b/src/UserInterface.h
@@ -111,12 +111,12 @@ class TextInput : public UserInterfaceElement {
         unsigned char *str;
         TextInput();
         ~TextInput() = default ;
-        int update();
-        void draw(Drawable *S, int active);
+        int update() override;
+        void draw(Drawable *S, int active) override;
         bool is_text_input() const override { return true; }
 
-        void auto_anchor_at_current_pos(int how) ;
-        void auto_update_anchor() ;
+        void auto_anchor_at_current_pos(int how) override;
+        void auto_update_anchor() override;
 };
 
 
@@ -333,10 +333,10 @@ class MidiOutDeviceSelector : public ListBox {
 //        virtual int update();
 //        virtual void draw(Drawable *S, int active);
 
-        virtual void OnChange();
-        virtual void OnSelect(LBNode *selected);
-        virtual void OnSelectChange() {}
-        virtual void enter(void);
+        void OnChange() override;
+        void OnSelect(LBNode *selected) override;
+        void OnSelectChange() override {}
+        void enter(void) override;
         bool is_tab_stop() const override { return num_elements > 0; }
 
 };


### PR DESCRIPTION
## Summary

Fixes all `-Winconsistent-missing-override` warnings on macOS AppleClang. Pure hygiene — no behavior change, no code path moved. The methods were already virtual overrides; they just weren't marked.

Eleven warnings across two headers:

### `src/UserInterface.h`

- `TextInput::update`, `draw`, `auto_anchor_at_current_pos`, `auto_update_anchor`
- `MidiOutDeviceSelector::OnChange`, `OnSelect`, `OnSelectChange`, `enter`

### `src/InstEditor.h`

- `InstEditor::update`, `draw`, `mouseupdate`

For the `MidiOutDeviceSelector` members I also dropped the redundant `virtual` keyword since `override` already implies it (style consistent with the rest of the file).

After this PR the macOS build log no longer shows the `"8 warnings generated"` / `"3 warnings generated"` blocks from these two headers. Unrelated warnings (`-Wunused-parameter`, `-Wempty-body`, `-Wunused-but-set-variable`, `-Wswitch`, etc.) remain — those are out of scope here and would be their own sweep.

## Test plan

- [x] Builds clean on macOS arm64 (AppleClang) — `cmake -G "Unix Makefiles" && make -j8`
- [x] Zero `inconsistent-missing-override` warnings remain
- [ ] CI: Linux x86_64, macOS x86_64, Windows x64 MSVC, Windows x86 MinGW

Generated with Claude Code.
