### PR TITLE
use layout-independent scan codes for note keys

### DIFF
--- a/src/CUI_InstEditor.cpp
+++ b/src/CUI_InstEditor.cpp
@@ -265,6 +265,7 @@ void CUI_InstEditor::leave(void) {
 
 void CUI_InstEditor::update() {
     int key = 0,kstate=0;
+    unsigned int scancode = 0;
     int set_note = 0xff;
     int act = 0;
     InstEditor *ie;
@@ -294,17 +295,11 @@ void CUI_InstEditor::update() {
       if(Keys.size() || midiInQueue.size()) {
 
         if (Keys.size()) {
-
             key = Keys.getkey();
+            scancode = Keys.getcode();
             kstate = Keys.getstate();
         }
         const bool editing_name = (ie && ie->text_cursor < 24);
-
-        /*if (kstate & KS_ALT && kstate & KS_CTRL) {
-            switch(key) {
-                case SDLK_T: break;
-            }
-        }*/
 
         switch(kstate) {
             case KS_CTRL:
@@ -364,41 +359,41 @@ void CUI_InstEditor::update() {
                         act++; break;
                 }
                 if (!editing_name) {
-                    switch(key) {
-                        case SDLK_Q: set_note = 12*base_octave;         break;
-                        case SDLK_2: set_note = (12*base_octave)+1;     break;
-                        case SDLK_W: set_note = (12*base_octave)+2;     break;
-                        case SDLK_3: set_note = (12*base_octave)+3;     break;
-                        case SDLK_E: set_note = (12*base_octave)+4;     break;
-                        case SDLK_R: set_note = (12*base_octave)+5;     break;
-                        case SDLK_5: set_note = (12*base_octave)+6;     break;
-                        case SDLK_T: set_note = (12*base_octave)+7;     break;
-                        case SDLK_6: set_note = (12*base_octave)+8;     break;
-                        case SDLK_Y: set_note = (12*base_octave)+9;     break;
-                        case SDLK_7: set_note = (12*base_octave)+10;    break;
-                        case SDLK_U: set_note = (12*base_octave)+11;    break;
-                        case SDLK_I: set_note = (12*base_octave)+12;    break;
-                        case SDLK_9: set_note = (12*base_octave)+1+12;  break;
-                        case SDLK_O: set_note = (12*base_octave)+2+12;  break;
-                        case SDLK_0: set_note = (12*base_octave)+3+12;  break;
-                        case SDLK_P: set_note = (12*base_octave)+4+12;  break;
+                    switch(scancode) {
+                        case SDL_SCANCODE_Q: set_note = 12*base_octave;         break;
+                        case SDL_SCANCODE_2: set_note = (12*base_octave)+1;     break;
+                        case SDL_SCANCODE_W: set_note = (12*base_octave)+2;     break;
+                        case SDL_SCANCODE_3: set_note = (12*base_octave)+3;     break;
+                        case SDL_SCANCODE_E: set_note = (12*base_octave)+4;     break;
+                        case SDL_SCANCODE_R: set_note = (12*base_octave)+5;     break;
+                        case SDL_SCANCODE_5: set_note = (12*base_octave)+6;     break;
+                        case SDL_SCANCODE_T: set_note = (12*base_octave)+7;     break;
+                        case SDL_SCANCODE_6: set_note = (12*base_octave)+8;     break;
+                        case SDL_SCANCODE_Y: set_note = (12*base_octave)+9;     break;
+                        case SDL_SCANCODE_7: set_note = (12*base_octave)+10;    break;
+                        case SDL_SCANCODE_U: set_note = (12*base_octave)+11;    break;
+                        case SDL_SCANCODE_I: set_note = (12*base_octave)+12;    break;
+                        case SDL_SCANCODE_9: set_note = (12*base_octave)+1+12;  break;
+                        case SDL_SCANCODE_O: set_note = (12*base_octave)+2+12;  break;
+                        case SDL_SCANCODE_0: set_note = (12*base_octave)+3+12;  break;
+                        case SDL_SCANCODE_P: set_note = (12*base_octave)+4+12;  break;
 
                         // <Manu> Repurpose these keys
                         //case SDLK_LEFTBRACKET: set_note = (12*base_octave)+5+12;  break;
                         //case SDLK_RIGHTBRACKET: set_note = (12*base_octave)+6+12;  break;
 
-                        case SDLK_Z: set_note = 12*(base_octave-1);     break;
-                        case SDLK_S: set_note = (12*(base_octave-1))+1; break;
-                        case SDLK_X: set_note = (12*(base_octave-1))+2; break;
-                        case SDLK_D: set_note =(12*(base_octave-1))+3;  break;
-                        case SDLK_C: set_note =(12*(base_octave-1))+4;  break;
-                        case SDLK_V: set_note = (12*(base_octave-1))+5; break;
-                        case SDLK_G: set_note = (12*(base_octave-1))+6; break;
-                        case SDLK_B: set_note = (12*(base_octave-1))+7; break;
-                        case SDLK_H: set_note = (12*(base_octave-1))+8; break;
-                        case SDLK_N: set_note = (12*(base_octave-1))+9; break;
-                        case SDLK_J: set_note = (12*(base_octave-1))+10;break; 
-                        case SDLK_M: set_note = (12*(base_octave-1))+11;break;
+                        case SDL_SCANCODE_Z: set_note = 12*(base_octave-1);     break;
+                        case SDL_SCANCODE_S: set_note = (12*(base_octave-1))+1; break;
+                        case SDL_SCANCODE_X: set_note = (12*(base_octave-1))+2; break;
+                        case SDL_SCANCODE_D: set_note =(12*(base_octave-1))+3;  break;
+                        case SDL_SCANCODE_C: set_note =(12*(base_octave-1))+4;  break;
+                        case SDL_SCANCODE_V: set_note = (12*(base_octave-1))+5; break;
+                        case SDL_SCANCODE_G: set_note = (12*(base_octave-1))+6; break;
+                        case SDL_SCANCODE_B: set_note = (12*(base_octave-1))+7; break;
+                        case SDL_SCANCODE_H: set_note = (12*(base_octave-1))+8; break;
+                        case SDL_SCANCODE_N: set_note = (12*(base_octave-1))+9; break;
+                        case SDL_SCANCODE_J: set_note = (12*(base_octave-1))+10;break;
+                        case SDL_SCANCODE_M: set_note = (12*(base_octave-1))+11;break;
                         default: break;
                     }
                 }

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -929,6 +929,7 @@ void CUI_Patterneditor::update()
   int i,j,p=0,step=0,noplay=0,bump=0;
   unsigned char set_note=0xff,kstate;
   int key;
+  unsigned int scancode;
   int temp,oktogo=0/*,dontc=0*/;
   short int p1,p2,p3;
   //  char str[256];
@@ -1012,6 +1013,7 @@ void CUI_Patterneditor::update()
       
       clear++;
       key=Keys.getkey();
+      scancode=Keys.getcode();
       kstate = Keys.getstate();
     }
   }
@@ -1153,6 +1155,7 @@ void CUI_Patterneditor::update()
   if (Keys.size() || midiInQueue.size() > 0) {
     
     key=Keys.getkey();
+    scancode=Keys.getcode();
     kstate = Keys.getstate();
     
     set_note = 0xff;
@@ -2792,25 +2795,25 @@ case SDLK_DELETE:
                     }
                     break;
                     case T_NOTE: 
-                      switch(key) {
+                      switch(scancode) {
                         /* TOP ROW */
-                      case SDLK_Q: set_note = 12*base_octave;         break;
-                      case SDLK_2: set_note = (12*base_octave)+1;     break;
-                      case SDLK_W: set_note = (12*base_octave)+2;     break;
-                      case SDLK_3: set_note = (12*base_octave)+3;     break;
-                      case SDLK_E: set_note = (12*base_octave)+4;     break;
-                      case SDLK_R: set_note = (12*base_octave)+5;     break;
-                      case SDLK_5: set_note = (12*base_octave)+6;     break;
-                      case SDLK_T: set_note = (12*base_octave)+7;     break;
-                      case SDLK_6: set_note = (12*base_octave)+8;     break;
-                      case SDLK_Y: set_note = (12*base_octave)+9;     break;
-                      case SDLK_7: set_note = (12*base_octave)+10;    break;
-                      case SDLK_U: set_note = (12*base_octave)+11;    break;
-                      case SDLK_I: set_note = (12*base_octave)+12;    break;
-                      case SDLK_9: set_note = (12*base_octave)+1+12;  break;
-                      case SDLK_O: set_note = (12*base_octave)+2+12;  break;
-                      case SDLK_0: set_note = (12*base_octave)+3+12;  break;
-                      case SDLK_P: set_note = (12*base_octave)+4+12;  break;
+                      case SDL_SCANCODE_Q: set_note = 12*base_octave;         break;
+                      case SDL_SCANCODE_2: set_note = (12*base_octave)+1;     break;
+                      case SDL_SCANCODE_W: set_note = (12*base_octave)+2;     break;
+                      case SDL_SCANCODE_3: set_note = (12*base_octave)+3;     break;
+                      case SDL_SCANCODE_E: set_note = (12*base_octave)+4;     break;
+                      case SDL_SCANCODE_R: set_note = (12*base_octave)+5;     break;
+                      case SDL_SCANCODE_5: set_note = (12*base_octave)+6;     break;
+                      case SDL_SCANCODE_T: set_note = (12*base_octave)+7;     break;
+                      case SDL_SCANCODE_6: set_note = (12*base_octave)+8;     break;
+                      case SDL_SCANCODE_Y: set_note = (12*base_octave)+9;     break;
+                      case SDL_SCANCODE_7: set_note = (12*base_octave)+10;    break;
+                      case SDL_SCANCODE_U: set_note = (12*base_octave)+11;    break;
+                      case SDL_SCANCODE_I: set_note = (12*base_octave)+12;    break;
+                      case SDL_SCANCODE_9: set_note = (12*base_octave)+1+12;  break;
+                      case SDL_SCANCODE_O: set_note = (12*base_octave)+2+12;  break;
+                      case SDL_SCANCODE_0: set_note = (12*base_octave)+3+12;  break;
+                      case SDL_SCANCODE_P: set_note = (12*base_octave)+4+12;  break;
                       
                       
                       // <Manu> Repurpose these keys
@@ -2819,18 +2822,18 @@ case SDLK_DELETE:
 
 
                         /* BOTTOM ROW */
-                      case SDLK_Z: set_note = 12*(base_octave-1);     break;
-                      case SDLK_S: set_note = (12*(base_octave-1))+1; break;
-                      case SDLK_X: set_note = (12*(base_octave-1))+2; break;
-                      case SDLK_D: set_note =(12*(base_octave-1))+3;  break;
-                      case SDLK_C: set_note =(12*(base_octave-1))+4;  break;
-                      case SDLK_V: set_note = (12*(base_octave-1))+5; break;
-                      case SDLK_G: set_note = (12*(base_octave-1))+6; break;
-                      case SDLK_B: set_note = (12*(base_octave-1))+7; break;
-                      case SDLK_H: set_note = (12*(base_octave-1))+8; break;
-                      case SDLK_N: set_note = (12*(base_octave-1))+9; break;
-                      case SDLK_J: set_note = (12*(base_octave-1))+10;break; 
-                      case SDLK_M: set_note = (12*(base_octave-1))+11;break;
+                      case SDL_SCANCODE_Z: set_note = 12*(base_octave-1);     break;
+                      case SDL_SCANCODE_S: set_note = (12*(base_octave-1))+1; break;
+                      case SDL_SCANCODE_X: set_note = (12*(base_octave-1))+2; break;
+                      case SDL_SCANCODE_D: set_note =(12*(base_octave-1))+3;  break;
+                      case SDL_SCANCODE_C: set_note =(12*(base_octave-1))+4;  break;
+                      case SDL_SCANCODE_V: set_note = (12*(base_octave-1))+5; break;
+                      case SDL_SCANCODE_G: set_note = (12*(base_octave-1))+6; break;
+                      case SDL_SCANCODE_B: set_note = (12*(base_octave-1))+7; break;
+                      case SDL_SCANCODE_H: set_note = (12*(base_octave-1))+8; break;
+                      case SDL_SCANCODE_N: set_note = (12*(base_octave-1))+9; break;
+                      case SDL_SCANCODE_J: set_note = (12*(base_octave-1))+10;break;
+                      case SDL_SCANCODE_M: set_note = (12*(base_octave-1))+11;break;
                         /* EDITING KEYS */
                       case SDLK_1: set_note = 0x81; break;      
                       case SDLK_GRAVE: set_note = 0x82; break;  

--- a/src/keybuffer.cpp
+++ b/src/keybuffer.cpp
@@ -82,6 +82,7 @@ KBKey KeyBuffer::checkkey(void) {
         ret = buffer[a].key;
         this->cur_state = buffer[a].state;
         this->actual_char = buffer[a].actual_char;
+        this->actual_code = buffer[a].code;
     }
     return ret;
 }
@@ -94,6 +95,7 @@ KBKey KeyBuffer::getkey(void) {
         ret = buffer[tail].key;
         this->cur_state = buffer[tail].state;
         this->actual_char = buffer[tail].actual_char;
+        this->actual_code = buffer[tail].code;
     }
     return ret;
 }
@@ -103,6 +105,11 @@ KBMod KeyBuffer::getstate(void) {
 unsigned char KeyBuffer::getactualchar(void) {
     return this->actual_char;
 }
+
+unsigned int KeyBuffer::getcode() {
+    return this->actual_code;
+}
+
 unsigned char KeyBuffer::size(void) {
     return cursize;
 /*  if (head<tail)
@@ -111,7 +118,7 @@ unsigned char KeyBuffer::size(void) {
         return head-tail;
 */
 }
-void KeyBuffer::insert(KBKey key, KBMod state, unsigned char actual_char) {
+void KeyBuffer::insert(KBKey key, KBMod state, unsigned char actual_char, unsigned int code) {
     unsigned char ls;
     switch(key) {
         case SDLK_KP_0: key=SDLK_0; break;
@@ -138,6 +145,7 @@ void KeyBuffer::insert(KBKey key, KBMod state, unsigned char actual_char) {
 #endif
 
     buffer[head].key = key;
+    buffer[head].code = code;
     KBMod c = 0;
     if (state & SDL_KMOD_ALT)
         c |= KS_ALT;

--- a/src/keybuffer.h
+++ b/src/keybuffer.h
@@ -26,18 +26,19 @@ class KeyBuffer {
         ~KeyBuffer(void) = default ;
 
         KBKey getkey(void);
+        unsigned int getcode();
         KBMod getstate(void);
         unsigned char getactualchar(void);
         unsigned char size(void);
-        void insert(KBKey key, KBMod state = SDL_KMOD_NONE, unsigned char actual_char=0x0 );
+        void insert(KBKey key, KBMod state = SDL_KMOD_NONE, unsigned char actual_char = 0, unsigned int code = 0);
 //        void insert(unsigned char key, Keyboard &K);
         void flush(void);
 
         KBKey checkkey(void);
 
-        //unsigned char buffer[256];
         struct c {
             KBKey key;
+            unsigned int code;
             unsigned char  state;
             unsigned char actual_char;
         } buffer[256];
@@ -47,8 +48,7 @@ class KeyBuffer {
         unsigned char tail;
         unsigned char maxsize,cursize;
         unsigned char last_actual_char,actual_char;
-
-        
+        unsigned int actual_code;
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,6 +197,7 @@ int keypress=0;
 int keywait = 0;
 zt_timer_handle keytimer = 0;
 unsigned int keyID = 0;
+static unsigned int keyCode = 0;
 
 int status_change = 0;
 
@@ -2336,7 +2337,7 @@ void TP_Keyboard_Repeat(void) {
         if ((!key_jazz) || !active_jazz_note)
             if (!(active_jazz_note && cur_state==STATE_IEDIT))
                 if (!bDontKeyRepeat && keyID != SDLK_8 && keyID != SDLK_4)
-                    Keys.insert(keyID,KS_LAST_STATE);
+                    Keys.insert(keyID,KS_LAST_STATE,0,keyCode);
         if (active_jazz_note && !key_jazz) {
             if (cur_state!=STATE_IEDIT) {
                 const mbuf st = jazz_get_state(keyID);
@@ -2361,6 +2362,7 @@ void TP_Keyboard_Repeat(void) {
 
 void keyhandler(SDL_KeyboardEvent *e) {
     KBKey id = (KBKey)e->key;
+    unsigned int scancode = e->scancode;
     KBMod mod = (KBMod)e->mod;
     unsigned char actual_ch = 0;
     int pressed = e->down ? 1 : 0;
@@ -2474,6 +2476,7 @@ void keyhandler(SDL_KeyboardEvent *e) {
             }
             if (id == keyID) {
                 keyID = 0;
+                keyCode = 0;
                 zt_timer_stop(keytimer);
             }
             if (jazz_note_is_active((int)id)) {
@@ -2485,7 +2488,7 @@ void keyhandler(SDL_KeyboardEvent *e) {
                 jazz_clear_state((int)id);
             }
         } else  {
-            Keys.insert(id, mod, actual_ch);
+            Keys.insert(id, mod, actual_ch, scancode);
             const bool allow_repeat = (!zt_text_input_is_active) ||
                 (id == SDLK_BACKSPACE || id == SDLK_DELETE ||
                  id == SDLK_LEFT || id == SDLK_RIGHT ||
@@ -2495,10 +2498,12 @@ void keyhandler(SDL_KeyboardEvent *e) {
                 keytimer = zt_timer_start(keytimer, zt_config_globals.key_wait_time, TP_Keyboard_Repeat);
                 keywait = 1;
                 keyID = id;
+                keyCode = scancode;
             } else if (!allow_repeat) {
                 zt_timer_stop(keytimer);
                 keywait = 0;
                 keyID = 0;
+                keyCode = 0;
             }
         }
     }
@@ -2536,7 +2541,7 @@ void textinputhandler(const SDL_Event *e) {
         }
     }
     if (ch >= 0x20 || ch == 10 || ch == 9) {
-        Keys.insert(SDLK_SPACE, SDL_KMOD_NONE, ch);
+        Keys.insert(SDLK_SPACE, SDL_KMOD_NONE, ch, SDL_SCANCODE_SPACE);
     }
 }
 


### PR DESCRIPTION
International users with keyboard layouts other than QWERTY can now enter notes more intuitively, because scancodes refer to the physical position of a key rather than the symbol it produces. A French keyboard's 'A' and a US keyboard's 'Q' now both produce the same note C.

This restores the behavior from the original ztracker versions. Fixes #36.