### PR TITLE
Fix remaining macOS build warnings

### DIFF
--- a/src/CUI_LoadMsg.cpp
+++ b/src/CUI_LoadMsg.cpp
@@ -47,11 +47,10 @@ std::atomic<int> is_loading(0);
 
 unsigned long ZT_THREAD_CALL load_thread(void *) {
     char *sstr;
-    int ret;
 
     is_loading = 1;
     load_finished = 0;
-    ret=song->load(load_filename);
+    song->load(load_filename);
 
     /* if there was a status message, display it */
     if ((sstr=song->getstatusstr())) {

--- a/src/CUI_PENature.cpp
+++ b/src/CUI_PENature.cpp
@@ -9,9 +9,11 @@ CUI_PENature::CUI_PENature(void) {
     int window_width = 40 * col(1);
     int window_height = 12 * row(1);
     int start_x = (INTERNAL_RESOLUTION_X / 2) - (window_width / 2);
-    for(;start_x % 8;start_x--);
+    for(;start_x % 8;start_x--)
+        ;
     int start_y = (INTERNAL_RESOLUTION_Y / 2) - (window_height / 2);
-    for(;start_y % 8;start_y--);
+    for(;start_y % 8;start_y--)
+        ;
     
     /* Initialize Naturalization percent Slider */
         vs = new ValueSlider;

--- a/src/CUI_PEParms.cpp
+++ b/src/CUI_PEParms.cpp
@@ -9,9 +9,11 @@ CUI_PEParms::CUI_PEParms(void) {
     int window_width = 54 * col(1);
     int window_height = 20 * row(1);
     int start_x = (INTERNAL_RESOLUTION_X / 2) - (window_width / 2);
-    for(;start_x % 8;start_x--);
+    for(;start_x % 8;start_x--)
+        ;
     int start_y = (INTERNAL_RESOLUTION_Y / 2) - (window_height / 2);
-    for(;start_y % 8;start_y--);
+    for(;start_y % 8;start_y--)
+        ;
     
     /* Initialize BPM Slider */
         vs_step = new ValueSlider;
@@ -187,9 +189,11 @@ void CUI_PEParms::draw(Drawable *S) {
     int window_width = 54 * col(1);
     int window_height = 20 * row(1);
     int start_x = (INTERNAL_RESOLUTION_X / 2) - (window_width / 2);
-    for(;start_x % 8;start_x--);
+    for(;start_x % 8;start_x--)
+        ;
     int start_y = (INTERNAL_RESOLUTION_Y / 2) - (window_height / 2);
-    for(;start_y % 8;start_y--);
+    for(;start_y % 8;start_y--)
+        ;
 
     vs_step->x = (start_x / 8) + 14;
     vs_step->y = (start_y / 8) + 6; 

--- a/src/CUI_PEVol.cpp
+++ b/src/CUI_PEVol.cpp
@@ -6,9 +6,11 @@ CUI_PEVol::CUI_PEVol(void) {
     int window_width = 40 * col(1);
     int window_height = 12 * row(1);
     int start_x = (INTERNAL_RESOLUTION_X / 2) - (window_width / 2);
-    for(;start_x % 8;start_x--);
+    for(;start_x % 8;start_x--)
+        ;
     int start_y = (INTERNAL_RESOLUTION_Y / 2) - (window_height / 2);
-    for(;start_y % 8;start_y--);
+    for(;start_y % 8;start_y--)
+        ;
     
     /* Initialize Volume percent Slider */
         vs = new ValueSlider;

--- a/src/CUI_PaletteEditor.cpp
+++ b/src/CUI_PaletteEditor.cpp
@@ -525,16 +525,6 @@ static void global_slider_rect(int which, int *x0, int *y0, int *x1, int *y1) {
     *x1 = *x0 + col(PE_GLOBAL_BAR_W);
 }
 
-static int preset_row_rect(int idx, int top_y, int *x0, int *y0, int *x1, int *y1) {
-    int ppx = col(PE_PRESET_X);
-    int ppw = col(PE_PRESET_W);
-    *x0 = ppx;
-    *x1 = ppx + ppw;
-    *y0 = top_y + row(2 + idx);                  // 1-row pitch (denser list)
-    *y1 = *y0 + row(1);
-    return 1;
-}
-
 void CUI_PaletteEditor::update(void) {
     static int digit_accum = -1;
     static int digit_channel = 0;

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -625,19 +625,17 @@ void disp_pattern(int tracks_shown, int field_size, int cols_shown, Drawable *S)
 
 
     {
-      unsigned long Background, Highlight, Lowlight ;
+      unsigned long Background, Highlight ;
 
       if(song->patterns[cur_edit_pattern]->custom_colors) {
 
           Background = song->patterns[cur_edit_pattern]->Background ;
           Highlight = song->patterns[cur_edit_pattern]->Highlight ;
-          Lowlight = song->patterns[cur_edit_pattern]->Lowlight ;
       }
       else {
 
           Background = COLORS.Background ;
           Highlight = COLORS.Highlight ;
-          Lowlight = COLORS.Lowlight ;
       }
 
 
@@ -655,7 +653,6 @@ void disp_pattern(int tracks_shown, int field_size, int cols_shown, Drawable *S)
 
                 Background = song->patterns[cur_edit_pattern]->Background ;
                 Highlight = song->patterns[cur_edit_pattern]->Highlight ;
-                Lowlight = song->patterns[cur_edit_pattern]->Lowlight ;
               }
               else {
 

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -2825,7 +2825,7 @@ void MidiOutDeviceOpener::OnChange() {
         const std::string &name = *it;
         int found_dev = -1;
         for (unsigned int i=0; i<MidiOut->numOuputDevices; i++) {
-            if (MidiOut->outputDevices[i] && MidiOut->outputDevices[i]->szName && zcmp((char *)MidiOut->outputDevices[i]->szName, (char *)name.c_str())) {
+            if (MidiOut->outputDevices[i] && zcmp((char *)MidiOut->outputDevices[i]->szName, (char *)name.c_str())) {
                 found_dev = (int)i;
                 break;
             }
@@ -3090,10 +3090,10 @@ AliasTextInput::AliasTextInput(MidiOutDeviceOpener *m) {
 
 	for(int i = 0; i < 1024; i++)
 		alias[i] = '\0';
-    this->str = (alias != NULL)?(unsigned char*)alias:(unsigned char*)"";
+    this->str = (unsigned char*)alias;
     listbox = m;
     cursor = 0;
-    length = 1023 ;//(alias != NULL)?strlen(alias):0;
+    length = 1023 ;
     sel = -1;
     sync();
 }

--- a/src/import_export.cpp
+++ b/src/import_export.cpp
@@ -173,12 +173,13 @@ void find_insts(unsigned char iflag[MAX_INSTS], zt_module *song)
 //
 int ZTImportExport::ExportMID(const char *fn, int format)
 {
+  (void)format;
   CDataBuf buffer, mtrk[MAX_INSTS+1], *mp;
   midi_buf *buf;
   int bpm, i, rstatus[MAX_INSTS+1], stat;
   FILE *fp;
   midi_event *e;
-  int dtime[MAX_INSTS+1], total_mtrks=1, trk, chn;
+  int dtime[MAX_INSTS+1], total_mtrks=1, trk;
   int mtrk_imap[MAX_INSTS];
   unsigned char iflag[MAX_INSTS];
   char* midiOutName;
@@ -335,9 +336,8 @@ int ZTImportExport::ExportMID(const char *fn, int format)
         
         trk = mtrk_imap[e->inst+1];
         mp = &mtrk[trk];
-        chn = e->device;
-        
-        switch(e->type) 
+
+        switch(e->type)
         {
           // ------------------------------------------------------------------
           // ------------------------------------------------------------------
@@ -1148,8 +1148,7 @@ int ZTImportExport::ImportIT(const char *fn, zt_module* zt)
       if (zt->instruments[i]->patch <-1 || zt->instruments[i]->patch >0x7F) zt->instruments[i]->patch = -1;
       
       //strcpy((char *)&zt->instruments[i]->title[0], mod.Instruments(i).name);
-      if (mod.Instruments(i).name) memcpy(&zt->instruments[i]->title[0], mod.Instruments(i).name,24);
-      else memset(&zt->instruments[i]->title[0], 0, 24);
+      memcpy(&zt->instruments[i]->title[0], mod.Instruments(i).name, 24);
       
       for (int z=0;z<23;z++) {
         
@@ -1173,8 +1172,7 @@ int ZTImportExport::ImportIT(const char *fn, zt_module* zt)
     
     for (int i = 0; i < mod.header.numSamples; i++) {
       
-      if (mod.Samples(i).name) memcpy(&zt->instruments[i]->title[0], mod.Samples(i).name,24);
-      else memset(&zt->instruments[i]->title[0], 0, 24);
+      memcpy(&zt->instruments[i]->title[0], mod.Samples(i).name, 24);
       
       zt->instruments[i]->default_volume = mod.Samples(i).defaultVolume*2;
       

--- a/src/lc_sdl_wrapper.cpp
+++ b/src/lc_sdl_wrapper.cpp
@@ -158,4 +158,5 @@
             *screen = c;
     };
     void Drawable::drawVLine(int x, int y, int y2, TColor c) {
+        (void)x; (void)y; (void)y2; (void)c;
     };

--- a/src/lua_engine.cpp
+++ b/src/lua_engine.cpp
@@ -20,19 +20,6 @@
 ZtLuaEngine g_lua;
 
 // ---------------------------------------------------------------------------
-// Internal helper: append a printf-formatted line to the scrollback
-// ---------------------------------------------------------------------------
-static void lua_engine_printf(const char *fmt, ...)
-{
-    char buf[LUA_CONSOLE_LINE_LEN];
-    va_list ap;
-    va_start(ap, fmt);
-    vsnprintf(buf, sizeof(buf), fmt, ap);
-    va_end(ap);
-    g_lua.print_line(buf);
-}
-
-// ---------------------------------------------------------------------------
 // Lua print() replacement — redirects to our scrollback
 // ---------------------------------------------------------------------------
 static int l_zt_print(lua_State *L)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3568,13 +3568,10 @@ int main(int argc, char *argv[])
 
 	      zt_autosave_tick();
 
-	      static int debug_contador = 0;
 	      if(screenmanager.Refresh(screen_buffer)) {
-	        debug_contador = 0;
         zt_backend_present_frame();
       }
       else {
-        debug_contador++;
         SDL_Delay(1);
       }
     }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -466,8 +466,13 @@ pattern::pattern(void) {
 }
 pattern::pattern(int len) {
     int i;
+    length = len;
     for(i=0;i<ZTM_MAX_TRACKS;i++)
         tracks[i] = new track(length);
+
+    Background = COLORS.Background ;
+    Highlight = COLORS.Highlight ;
+    Lowlight = COLORS.Lowlight ;
 }
 pattern::~pattern(void) {
     int i;

--- a/src/playback.cpp
+++ b/src/playback.cpp
@@ -976,6 +976,9 @@ void player::callback(void) {
         while(e) {
             if (e->tick == playing_tick) {
                 switch(e->type) {
+                    case ET_LOOP:
+                        // loop markers are consumed by the pattern loop logic elsewhere
+                        break;
                     case ET_MSTART:
                         if (song->flag_SendMidiStopStart)
                             MidiOut->sendGlobal(0xFA);

--- a/src/playback.h
+++ b/src/playback.h
@@ -95,7 +95,9 @@ class player {
     private:
         MMRESULT wTimerID;
         zt_timer_handle ztTimerID;
+#ifdef _WIN32
         TIMECAPS tc;
+#endif
         UINT SetTimerCallback(UINT msInterval);
 
         struct s_note_off {

--- a/src/skins.cpp
+++ b/src/skins.cpp
@@ -284,15 +284,6 @@ static inline void unpack_color(TColor c, int *r, int *g, int *b) {
     *b = (c      ) & 0xFF;
 }
 
-static inline void lerp_rgb(int t, int *r0, int *g0, int *b0,
-                            int r1, int g1, int b1) {
-    // t in [0..255]
-    int inv = 255 - t;
-    *r0 = (*r0 * inv + r1 * t) / 255;
-    *g0 = (*g0 * inv + g1 * t) / 255;
-    *b0 = (*b0 * inv + b1 * t) / 255;
-}
-
 static inline int clamp_byte(int v) {
     if (v < 0)   return 0;
     if (v > 255) return 255;

--- a/src/ztfile-io.cpp
+++ b/src/ztfile-io.cpp
@@ -988,9 +988,8 @@ void zt_module::load_ZT_pattern_lengths(CDataBuf *buf) {
 //
 //
 void zt_module::load_ZT_pattern_properties(CDataBuf *buf) {
-    unsigned short int size;
     for (int i=0;i<256;i++) {
-        size = buf->getusi();
+        (void)buf->getusi();
         //this->patterns[i]->resize(size);
     }
 }


### PR DESCRIPTION
## Summary

Cleans up the compiler warnings that were still emitted on macOS after #27 and #42. After this, the build has no compiler warnings — only the external pkg-config-injected `/usr/local/opt/zlib/lib` linker search-path warning remains, which isn't sourced from this repo.

Highlights per file:

- `src/lc_sdl_wrapper.cpp` — silence unused params in the empty `Drawable::drawVLine` stub.
- `src/CUI_PEVol.cpp`, `src/CUI_PEParms.cpp`, `src/CUI_PENature.cpp` — move the trailing `;` off the `for` head for `-Wempty-body`.
- `src/ztfile-io.cpp` — drop set-but-unused `size` in `load_ZT_pattern_properties`.
- `src/playback.cpp` — add `case ET_LOOP: break;` to the tick switch (already ignored in `import_export.cpp` the same way).
- `src/skins.cpp` — remove unused static `lerp_rgb`.
- `src/module.cpp` — **real bug fix:** `pattern::pattern(int len)` was discarding `len` and passing the uninitialized `length` member to `new track(length)`. Assign `length = len;` and initialize `Background/Highlight/Lowlight` to match the default ctor. Called from `CUI_Patterneditor.cpp:1692`.
- `src/CUI_Patterneditor.cpp` — drop set-but-unused local `Lowlight`.
- `src/CUI_LoadMsg.cpp` — drop unused `ret` in `load_thread`.
- `src/playback.h` — wrap `TIMECAPS tc` in `#ifdef _WIN32` (it's only read inside a `_WIN32` block in `player::init`).
- `src/UserInterface.cpp` — drop a redundant `szName` null-check (it's `char szName[MAX_DEVICE_NAME]`, always non-null) and the `alias != NULL` check in `AliasTextInput` ctor (also an array member).
- `src/main.cpp` — drop unused `debug_contador` counter.
- `src/CUI_PaletteEditor.cpp` — drop unused static `preset_row_rect`.
- `src/import_export.cpp` — cast unused `format` param in `ExportMID`, drop set-but-unused `chn`, and remove dead `.name` null-checks on arrays.
- `src/lua_engine.cpp` — drop unused static `lua_engine_printf`.

The `module.cpp` change is the only behavioral one and fixes a latent bug where the alternative `pattern(int)` constructor was using uninitialized memory for the pattern length.

## Test plan

- [x] macOS arm64 build is clean (apart from the external zlib linker search-path warning)
- [x] Binary links and launches (`Program/zt.app/Contents/MacOS/zt`)
- [ ] CI: Win x64 MSVC, Win x86 MinGW, macOS x86_64, Linux x86_64
- [ ] Quick smoke: pattern clone path (`CUI_Patterneditor.cpp:1692` → `pattern(int)` ctor) still works after the ctor fix

@m6502 — ready when you are.
