### PR TITLE
UI polish: F1 toggle, F3 row alignment, F12/Ctrl+F12 layout, file-load typeahead

### DIFF
--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -277,36 +277,36 @@ void CUI_Config::draw(Drawable *S) {
         }
 #endif
         sprintf(buf,"\n|U|Current Settings in memory:\n");
-        sprintf(buf+strlen(buf),"\n|U| Auto-Open MIDI |L|[|H|%s|L|]",zt_config_globals.auto_open_midi?"On":"Off");
-        sprintf(buf+strlen(buf),"\n|U| Autoload .ZT  |L|[|H|%s|L|]",zt_config_globals.autoload_ztfile?"On":"Off");
-        sprintf(buf+strlen(buf),"\n|U| Autoload File |L|[|H|%s|L|]",zt_config_globals.autoload_ztfile_filename);
-        sprintf(buf+strlen(buf),"\n|U| Default Dir   |L|[|H|%s|L|]",zt_config_globals.default_directory);
-        sprintf(buf+strlen(buf),"\n|U| Record Veloc  |L|[|H|%s|L|]",zt_config_globals.record_velocity?"On":"Off");
-        sprintf(buf+strlen(buf),"\n|U| Autosave (s)  |L|[|H|%d|L|]",zt_config_globals.autosave_interval_seconds);
+        sprintf(buf+strlen(buf),"\n|U| Auto-Open MIDI  |L|[|H|%s|L|]",zt_config_globals.auto_open_midi?"On":"Off");
+        sprintf(buf+strlen(buf),"\n|U| Autoload .ZT    |L|[|H|%s|L|]",zt_config_globals.autoload_ztfile?"On":"Off");
+        sprintf(buf+strlen(buf),"\n|U| Autoload File   |L|[|H|%s|L|]",zt_config_globals.autoload_ztfile_filename);
+        sprintf(buf+strlen(buf),"\n|U| Default Dir     |L|[|H|%s|L|]",zt_config_globals.default_directory);
+        sprintf(buf+strlen(buf),"\n|U| Record Velocity |L|[|H|%s|L|]",zt_config_globals.record_velocity?"On":"Off");
+        sprintf(buf+strlen(buf),"\n|U| Autosave (s)    |L|[|H|%d|L|]",zt_config_globals.autosave_interval_seconds);
 #ifdef _ACTIVAR_CAMBIO_TAMANYO_COLUMNAS
-        sprintf(buf+strlen(buf),"\n|U| View Mode     |L|[|H|%s|L|]",view_mode_name);
+        sprintf(buf+strlen(buf),"\n|U| View Mode       |L|[|H|%s|L|]",view_mode_name);
 #endif
-        sprintf(buf+strlen(buf),"\n|U| Highlight Inc |L|[|H|%d|L|]",zt_config_globals.highlight_increment);
-        sprintf(buf+strlen(buf),"\n|U| Lowlight Inc  |L|[|H|%d|L|]",zt_config_globals.lowlight_increment);
-        sprintf(buf+strlen(buf),"\n|U| Pattern Len   |L|[|H|%d|L|]",zt_config_globals.pattern_length);
-        sprintf(buf+strlen(buf),"\n|U| Full Screen   |L|[|H|%s|L|]",zt_config_globals.full_screen?"On":"Off");
-        sprintf(buf+strlen(buf),"\n|U| Send Panic    |L|[|H|%s|L|]",zt_config_globals.auto_send_panic?"On":"Off");
-        sprintf(buf+strlen(buf),"\n|U| MIDI In Sync  |L|[|H|%s|L|]",zt_config_globals.midi_in_sync?"On":"Off");
-        sprintf(buf+strlen(buf),"\n|U| Step Editing  |L|[|H|%s|L|]",zt_config_globals.step_editing?"On":"Off");
-        sprintf(buf+strlen(buf),"\n|U| Centered Edit |L|[|H|%s|L|]",zt_config_globals.centered_editing?"On":"Off");
-        sprintf(buf+strlen(buf),"\n|U| Screen Size   |L|[|H|%dx%d|L|]",zt_config_globals.screen_width, zt_config_globals.screen_height);
-        sprintf(buf+strlen(buf),"\n|U| Zoom          |L|[|H|%.2f|L|]",zt_config_globals.zoom);
-        sprintf(buf+strlen(buf),"\n|U| Scale Filter  |L|[|H|%s|L|]",zt_config_globals.scale_filter);
-        sprintf(buf+strlen(buf),"\n|U| Ctrl Nav Amt  |L|[|H|%d|L|]",zt_config_globals.control_navigation_amount);
-        sprintf(buf+strlen(buf),"\n|U| Inst Glob Vol |L|[|H|%d|L|]",zt_config_globals.instrument_global_volume);
-        sprintf(buf+strlen(buf),"\n|U| Default TPB   |L|[|H|%d|L|]",zt_config_globals.default_tpb);
-        sprintf(buf+strlen(buf),"\n|U| Default BPM   |L|[|H|%d|L|]",zt_config_globals.default_bpm);
+        sprintf(buf+strlen(buf),"\n|U| Highlight Inc   |L|[|H|%d|L|]",zt_config_globals.highlight_increment);
+        sprintf(buf+strlen(buf),"\n|U| Lowlight Inc    |L|[|H|%d|L|]",zt_config_globals.lowlight_increment);
+        sprintf(buf+strlen(buf),"\n|U| Pattern Len     |L|[|H|%d|L|]",zt_config_globals.pattern_length);
+        sprintf(buf+strlen(buf),"\n|U| Full Screen     |L|[|H|%s|L|]",zt_config_globals.full_screen?"On":"Off");
+        sprintf(buf+strlen(buf),"\n|U| Send Panic      |L|[|H|%s|L|]",zt_config_globals.auto_send_panic?"On":"Off");
+        sprintf(buf+strlen(buf),"\n|U| MIDI In Sync    |L|[|H|%s|L|]",zt_config_globals.midi_in_sync?"On":"Off");
+        sprintf(buf+strlen(buf),"\n|U| Step Editing    |L|[|H|%s|L|]",zt_config_globals.step_editing?"On":"Off");
+        sprintf(buf+strlen(buf),"\n|U| Centered Edit   |L|[|H|%s|L|]",zt_config_globals.centered_editing?"On":"Off");
+        sprintf(buf+strlen(buf),"\n|U| Screen Size     |L|[|H|%dx%d|L|]",zt_config_globals.screen_width, zt_config_globals.screen_height);
+        sprintf(buf+strlen(buf),"\n|U| Zoom            |L|[|H|%.2f|L|]",zt_config_globals.zoom);
+        sprintf(buf+strlen(buf),"\n|U| Scale Filter    |L|[|H|%s|L|]",zt_config_globals.scale_filter);
+        sprintf(buf+strlen(buf),"\n|U| Ctrl Nav Amt    |L|[|H|%d|L|]",zt_config_globals.control_navigation_amount);
+        sprintf(buf+strlen(buf),"\n|U| Inst Glob Vol   |L|[|H|%d|L|]",zt_config_globals.instrument_global_volume);
+        sprintf(buf+strlen(buf),"\n|U| Default TPB     |L|[|H|%d|L|]",zt_config_globals.default_tpb);
+        sprintf(buf+strlen(buf),"\n|U| Default BPM     |L|[|H|%d|L|]",zt_config_globals.default_bpm);
 #ifdef DISABLED_CONFIGURATION_VALUES
-        sprintf(buf+strlen(buf),"\n|U| Key Repeat    |L|[|H|%d|L|] (disabled)",zt_config_globals.key_repeat_time);
-        sprintf(buf+strlen(buf),"\n|U| Key Wait      |L|[|H|%d|L|] (disabled)",zt_config_globals.key_wait_time);
+        sprintf(buf+strlen(buf),"\n|U| Key Repeat      |L|[|H|%d|L|] (disabled)",zt_config_globals.key_repeat_time);
+        sprintf(buf+strlen(buf),"\n|U| Key Wait        |L|[|H|%d|L|] (disabled)",zt_config_globals.key_wait_time);
 #else
-        sprintf(buf+strlen(buf),"\n|U| Key Repeat    |L|[|H|%d|L|]",zt_config_globals.key_repeat_time);
-        sprintf(buf+strlen(buf),"\n|U| Key Wait      |L|[|H|%d|L|]",zt_config_globals.key_wait_time);
+        sprintf(buf+strlen(buf),"\n|U| Key Repeat      |L|[|H|%d|L|]",zt_config_globals.key_repeat_time);
+        sprintf(buf+strlen(buf),"\n|U| Key Wait        |L|[|H|%d|L|]",zt_config_globals.key_wait_time);
 #endif
 
         if(tb->text != NULL)

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -37,7 +37,7 @@ CUI_Config::CUI_Config(void) {
     UI->add_element(cb,0);
     cb->frame = 0;
     cb->x = 20;
-    cb->y = 13;
+    cb->y = 14;
     cb->xsize = 5;
     cb->value = &zt_config_globals.autoload_ztfile;
     cb->frame = 1;
@@ -46,7 +46,7 @@ CUI_Config::CUI_Config(void) {
     UI->add_element(ti,1);
     ti->frame = 1;
     ti->x = 20;
-    ti->y = 14;
+    ti->y = 15;
     ti->xsize = 50;
     ti->length = 50;
     ti->str = (unsigned char*)zt_config_globals.autoload_ztfile_filename;
@@ -55,7 +55,7 @@ CUI_Config::CUI_Config(void) {
     UI->add_element(ti,2);
     ti->frame = 1;
     ti->x = 20;
-    ti->y = 16;
+    ti->y = 17;
     ti->xsize = 50;
     ti->length = 50;
     ti->str = (unsigned char*)zt_config_globals.default_directory;
@@ -64,7 +64,7 @@ CUI_Config::CUI_Config(void) {
     UI->add_element(cb,3);
     cb->frame = 0;
     cb->x = 20;
-    cb->y = 18;
+    cb->y = 19;
     cb->xsize = 5;
     cb->value = &zt_config_globals.record_velocity;
     cb->frame = 1;
@@ -72,7 +72,7 @@ CUI_Config::CUI_Config(void) {
     vs = new ValueSlider;
     UI->add_element(vs,4);
     vs->x = 20;
-    vs->y = 19;
+    vs->y = 20;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.autosave_interval_seconds;
@@ -82,7 +82,7 @@ CUI_Config::CUI_Config(void) {
     vs = new ValueSlider;
     UI->add_element(vs,5);
     vs->x = 20;
-    vs->y = 20;
+    vs->y = 21;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.cur_edit_mode;
@@ -100,7 +100,7 @@ CUI_Config::CUI_Config(void) {
     vs = new ValueSlider;
     UI->add_element(vs,6);
     vs->x = 20;
-    vs->y = 21;
+    vs->y = 22;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.highlight_increment;
@@ -110,7 +110,7 @@ CUI_Config::CUI_Config(void) {
     vs = new ValueSlider;
     UI->add_element(vs,7);
     vs->x = 20;
-    vs->y = 22;
+    vs->y = 23;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.lowlight_increment;
@@ -120,7 +120,7 @@ CUI_Config::CUI_Config(void) {
     vs = new ValueSlider;
     UI->add_element(vs,8);
     vs->x = 20;
-    vs->y = 23;
+    vs->y = 24;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.pattern_length;
@@ -188,7 +188,7 @@ CUI_Config::CUI_Config(void) {
     UI->add_element(tb, 9);
     tb->no_tab_stop = 1;  // read-only help; swallows UP/DOWN, exclude from focus cycle
     tb->x = 1;
-    tb->y = 25;
+    tb->y = 26;
     tb->xsize = 78;
     {
         const int max_rows = (INTERNAL_RESOLUTION_Y / 8);
@@ -205,6 +205,9 @@ void CUI_Config::enter(void) {
     need_refresh = 1;
     cur_state = STATE_CONFIG;
     Keys.flush();
+    // Start with focus on "Go to page 1" so the user can bounce straight
+    // back to System Config without tabbing past every field first.
+    UI->set_focus(10);
 }
 
 void CUI_Config::leave(void) {
@@ -276,7 +279,7 @@ void CUI_Config::draw(Drawable *S) {
             case VIEW_BIG:     view_mode_name = "Big"; break;
         }
 #endif
-        sprintf(buf,"\n|U|Current Settings in memory:\n");
+        sprintf(buf,"|U|Current Settings in memory:");
         sprintf(buf+strlen(buf),"\n|U| Auto-Open MIDI  |L|[|H|%s|L|]",zt_config_globals.auto_open_midi?"On":"Off");
         sprintf(buf+strlen(buf),"\n|U| Autoload .ZT    |L|[|H|%s|L|]",zt_config_globals.autoload_ztfile?"On":"Off");
         sprintf(buf+strlen(buf),"\n|U| Autoload File   |L|[|H|%s|L|]",zt_config_globals.autoload_ztfile_filename);
@@ -314,11 +317,13 @@ void CUI_Config::draw(Drawable *S) {
             free((void*)tb->text);
         }
         tb->text = strdup(buf);
-        // Auto-fit textbox height to actual content (count newlines + small pad).
+        // Auto-fit textbox height to actual content (count newlines).
+        // No trailing pad row — avoids wasted black space at the bottom.
         {
             int nlines = 1;
             for (const char *p = buf; *p; p++) if (*p == '\n') nlines++;
-            tb->ysize = nlines + 1;
+            tb->ysize = nlines - 1;
+            if (tb->ysize < 1) tb->ysize = 1;
         }
         UI->draw(S);
 #ifdef _ACTIVAR_CAMBIO_TAMANYO_COLUMNAS
@@ -342,17 +347,17 @@ void CUI_Config::draw(Drawable *S) {
         draw_status(S);
         status(S);
         printtitle(PAGE_TITLE_ROW_Y,"Global Configuration (Ctrl+F12)",COLORS.Text,COLORS.Background,S);
-        print(row(2),col(13),"Autoload .ZT",COLORS.Text,S);
-        print(row(2),col(14),"Autoload File",COLORS.Text,S);
-        print(row(2),col(16),"Default Dir",COLORS.Text,S);
-        print(row(2),col(18),"Record Velocity",COLORS.Text,S);
-        print(row(2),col(19),"Autosave (sec)",COLORS.Text,S);
+        print(row(2),col(14),"Autoload .ZT",COLORS.Text,S);
+        print(row(2),col(15),"Autoload File",COLORS.Text,S);
+        print(row(2),col(17),"Default Dir",COLORS.Text,S);
+        print(row(2),col(19),"Record Velocity",COLORS.Text,S);
+        print(row(2),col(20),"Autosave (sec)",COLORS.Text,S);
 #ifdef _ACTIVAR_CAMBIO_TAMANYO_COLUMNAS
-        print(row(2),col(20),"Default View",COLORS.Text,S);
+        print(row(2),col(21),"Default View",COLORS.Text,S);
 #endif
-        print(row(2),col(21),"Default Highlight",COLORS.Text,S);
-        print(row(2),col(22),"Default Lowlight",COLORS.Text,S);
-        print(row(2),col(23),"Default Pat Len",COLORS.Text,S);
+        print(row(2),col(22),"Default Highlight",COLORS.Text,S);
+        print(row(2),col(23),"Default Lowlight",COLORS.Text,S);
+        print(row(2),col(24),"Default Pat Len",COLORS.Text,S);
 //        print(row(2),col(25)," .ZT directory",COLORS.Text,S);
 
         //printtitle(32,"Current Global Settings",COLORS.Text,COLORS.Background,S);

--- a/src/CUI_InstEditor.cpp
+++ b/src/CUI_InstEditor.cpp
@@ -89,7 +89,7 @@ CUI_InstEditor::CUI_InstEditor(void) {
     ie = new InstEditor;
     UI->add_element(ie,tabindex++);
     ie->x = 5;
-    ie->y = TRACKS_ROW_Y;
+    ie->y = TRACKS_ROW_Y + 1;
     ie->xsize = 29;
 
     ie->ysize = MAX_INSTS ;

--- a/src/CUI_InstEditor.cpp
+++ b/src/CUI_InstEditor.cpp
@@ -99,76 +99,76 @@ CUI_InstEditor::CUI_InstEditor(void) {
 
     vso = new ValueSliderOFF(1); // Bank (ID: 1)
     UI->add_element(vso,tabindex++);
-    vso->x = 36;    vso->y = 14;    vso->xsize = 16;    vso->ysize = 1; vso->min = -1;  vso->max = 0x3fff;    vso->value = -1;
+    vso->x = 36;    vso->y = 15;    vso->xsize = 16;    vso->ysize = 1; vso->min = -1;  vso->max = 0x3fff;    vso->value = -1;
     fm = new Frame;
     UI->add_gfx(fm,gfxindex++);
-    fm->x=35; fm->y=11; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
+    fm->x=35; fm->y=12; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
 
 
 
     vso = new ValueSliderOFF(1); // Patch (ID: 2)
     UI->add_element(vso,tabindex++);
-    vso->x = 58;    vso->y = 14;    vso->xsize = 16;    vso->ysize = 1; vso->min = -1;  vso->max = 127; vso->value = -1;
+    vso->x = 58;    vso->y = 15;    vso->xsize = 16;    vso->ysize = 1; vso->min = -1;  vso->max = 127; vso->value = -1;
     fm = new Frame;
     UI->add_gfx(fm,gfxindex++);
-    fm->x=57; fm->y=11; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
+    fm->x=57; fm->y=12; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
 
 
 
 
     vs = new ValueSlider(1); // Default Volume (ID: 3)
     UI->add_element(vs,tabindex++);
-    vs->x = 36; vs->y = 19; vs->xsize = 16; vs->ysize = 1;  vs->min = 0;    vs->max = 0x7f; vs->value = 0x7f;
+    vs->x = 36; vs->y = 20; vs->xsize = 16; vs->ysize = 1;  vs->min = 0;    vs->max = 0x7f; vs->value = 0x7f;
     fm = new Frame;
     UI->add_gfx(fm,gfxindex++);
-    fm->x=35; fm->y=16; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
+    fm->x=35; fm->y=17; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
 
 
 
 
     vsd = new ValueSliderDL(1); // Default Length (ID: 4)
     UI->add_element(vsd,tabindex++);
-    vsd->x = 58;    vsd->y = 19;    vsd->xsize = 16;    vsd->ysize = 1; vsd->min = 1;   vsd->max = 1000;    vsd->value = 0;
+    vsd->x = 58;    vsd->y = 20;    vsd->xsize = 16;    vsd->ysize = 1; vsd->min = 1;   vsd->max = 1000;    vsd->value = 0;
     fm = new Frame;
     UI->add_gfx(fm,gfxindex++);
-    fm->x=57; fm->y=16; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
+    fm->x=57; fm->y=17; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
 
-    
 
-    
+
+
     vs = new ValueSlider(1); // Global Volume (ID: 5)
     UI->add_element(vs,tabindex++);
-    vs->x = 36; vs->y = 24; vs->xsize = 16; vs->ysize = 1;  vs->min = 0;    vs->max = 0x7f; vs->value = 0x7f;
+    vs->x = 36; vs->y = 25; vs->xsize = 16; vs->ysize = 1;  vs->min = 0;    vs->max = 0x7f; vs->value = 0x7f;
     fm = new Frame;
     UI->add_gfx(fm,gfxindex++);
-    fm->x=35; fm->y=21; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
-    
+    fm->x=35; fm->y=22; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
+
 
 
 
     vs = new ValueSlider(1); // Transpose (ID: 6)
     UI->add_element(vs,tabindex++);
-    vs->x = 58; vs->y = 24; vs->xsize = 16; vs->ysize = 1;  vs->min = -127; vs->max = 127;  vs->value = 0;
+    vs->x = 58; vs->y = 25; vs->xsize = 16; vs->ysize = 1;  vs->min = -127; vs->max = 127;  vs->value = 0;
     fm = new Frame;
     UI->add_gfx(fm,gfxindex++);
-    fm->x=57; fm->y=21; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
+    fm->x=57; fm->y=22; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
 
 
 
 
     vs = new ValueSlider(1); // Channel (ID: 7)
     UI->add_element(vs,tabindex++);
-    vs->x = 36; vs->y = 29; vs->xsize = 16; vs->ysize = 1;  vs->min = 1;    vs->max = 16;   vs->value = 0;
+    vs->x = 36; vs->y = 30; vs->xsize = 16; vs->ysize = 1;  vs->min = 1;    vs->max = 16;   vs->value = 0;
     fm = new Frame;
     UI->add_gfx(fm,gfxindex++);
-    fm->x=35; fm->y=26; fm->xsize = 22; fm->ysize = 7; fm->type = 0;
-    
+    fm->x=35; fm->y=27; fm->xsize = 22; fm->ysize = 7; fm->type = 0;
+
     ////////////////////////////////////////////////////////////////////////////
 
     b = new Button;
     UI->add_element(b,tabindex++);
     b->x = 58;
-    b->y = 27;
+    b->y = 28;
     b->xsize = 20;
     b->ysize = 1;
     b->caption = "  Unmute Retrigger";
@@ -177,27 +177,27 @@ CUI_InstEditor::CUI_InstEditor(void) {
     b = new Button;
     UI->add_element(b,tabindex++);
     b->x = 58;
-    b->y = 29;
+    b->y = 30;
     b->xsize = 20;
     b->ysize = 1;
     b->caption = "   Channel Volume";
-    b->OnClick = (ActFunc)BTNCLK_ToggleChanVol; 
+    b->OnClick = (ActFunc)BTNCLK_ToggleChanVol;
 
     b = new Button;
     UI->add_element(b,tabindex++);
     b->x = 58;
-    b->y = 31;
+    b->y = 32;
     b->xsize = 20;
     b->ysize = 1;
     b->caption = "    Tracker Mode";
-    b->OnClick = (ActFunc)BTNCLK_ToggleTrackerMode; 
-    
+    b->OnClick = (ActFunc)BTNCLK_ToggleTrackerMode;
+
 
     trackerModeButton = b;
 
     fm = new Frame;  //frame for buttons
     UI->add_gfx(fm,gfxindex++);
-    fm->x=57; fm->y=26; fm->xsize = 22; fm->ysize = 7; fm->type = 0;
+    fm->x=57; fm->y=27; fm->xsize = 22; fm->ysize = 7; fm->type = 0;
 
 
 
@@ -206,17 +206,17 @@ CUI_InstEditor::CUI_InstEditor(void) {
     b = new Button;
     UI->add_element(b,tabindex++);
     b->x = 35;
-    b->y = 34;
+    b->y = 35;
     b->xsize = 15;
     b->ysize = 1;
     b->caption = " Update Device";
     b->OnClick = (ActFunc)BTNCLK_InitInstrumentsOne;
 
-    
+
     b = new Button;
     UI->add_element(b,tabindex++);
     b->x = 35+16;
-    b->y = 34;
+    b->y = 35;
     b->xsize = 12;
     b->ysize = 1;
     b->caption = " Update All";
@@ -233,7 +233,7 @@ CUI_InstEditor::CUI_InstEditor(void) {
     mds = new MidiOutDeviceSelector;
     UI->add_element(mds, tabindex++);
     mds->x=35;
-    mds->y=36;
+    mds->y=37;
     mds->xsize = 44;
     mds->ysize = 14;
     
@@ -554,13 +554,13 @@ void CUI_InstEditor::draw(Drawable *S)
         draw_status(S);
         status(S);
         printtitle(PAGE_TITLE_ROW_Y,"Instrument Editor (F3)",COLORS.Text,COLORS.Background,S);
-        printBG(col(36),row(12),"Bank",COLORS.Text,COLORS.Background,S);
-        printBG(col(58),row(12),"Patch",COLORS.Text,COLORS.Background,S);
-        printBG(col(36),row(17),"Default Volume",COLORS.Text,COLORS.Background,S);
-        printBG(col(58),row(17),"Default Length",COLORS.Text,COLORS.Background,S);
-        printBG(col(36),row(22),"Global Volume",COLORS.Text,COLORS.Background,S);
-        printBG(col(58),row(22),"Transpose",COLORS.Text,COLORS.Background,S);
-        printBG(col(36),row(27),"Channel",COLORS.Text,COLORS.Background,S);
+        printBG(col(36),row(13),"Bank",COLORS.Text,COLORS.Background,S);
+        printBG(col(58),row(13),"Patch",COLORS.Text,COLORS.Background,S);
+        printBG(col(36),row(18),"Default Volume",COLORS.Text,COLORS.Background,S);
+        printBG(col(58),row(18),"Default Length",COLORS.Text,COLORS.Background,S);
+        printBG(col(36),row(23),"Global Volume",COLORS.Text,COLORS.Background,S);
+        printBG(col(58),row(23),"Transpose",COLORS.Text,COLORS.Background,S);
+        printBG(col(36),row(28),"Channel",COLORS.Text,COLORS.Background,S);
         need_refresh = 0; 
         updated=2;
         S->unlock();

--- a/src/CUI_LoadMsg.cpp
+++ b/src/CUI_LoadMsg.cpp
@@ -134,6 +134,9 @@ void CUI_LoadMsg::update() {
         fixmouse++;
         need_refresh++;
         load_finished = 0;
+        // After a successful load, jump to the Instrument Editor (F3) so
+        // the user can immediately see and edit the imported instruments.
+        switch_page(UIP_InstEditor);
     }
 }
 void CUI_LoadMsg::draw(Drawable *S)

--- a/src/CUI_Sysconfig.cpp
+++ b/src/CUI_Sysconfig.cpp
@@ -370,9 +370,9 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
 
         vs = new LatencyValueSlider(ml);
         UI->add_element(vs,tabindex++);
-        vs->x = 13;
+        vs->x = 19;                    // align with Prebuffer slider
         vs->y = 47;
-        vs->xsize = 21;
+        vs->xsize = 15;
         vs->ysize = 1;
         vs->min = 0;
         vs->max = 255;
@@ -388,10 +388,10 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         ti = new AliasTextInput(ml);
         UI->add_element(ti,tabindex++);
         ti->frame = 1;
-        ti->x = 18;
+        ti->x = 19;                    // align with Prebuffer slider
         ti->y = 51;
-        ti->xsize=43;
-        ti->length=42;
+        ti->xsize=42;
+        ti->length=41;
 
         ml->lvs = vs;  // link midi out list to latency value slider
         ml->bscb = cb; // link midi out list to bank select checkbox

--- a/src/CUI_Sysconfig.cpp
+++ b/src/CUI_Sysconfig.cpp
@@ -338,14 +338,14 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         sk->xsize = 19+4;
         sk->ysize = 7;   // tight-fit around installed skin count, avoids empty black space
 
-        // MIDI Out column — visual order: Refresh (y=30), list (y=32-44),
-        // Open device (y=47), Latency (y=49), Bank (y=51), Alias (y=53).
+        // MIDI Out column — visual order: Refresh (y=28), list (y=30-42),
+        // Open device (y=45), Latency (y=47), Bank (y=49), Alias (y=51).
         // tabindex follows the same order so UP/DOWN navigates top-to-bottom.
         b = new Button;
         UI->add_element(b,tabindex++);
         b->caption = " Refresh";
         b->x = 4+26;
-        b->y = 50 - 16 -2-2;
+        b->y = 48 - 16 -2-2;
         b->xsize = 9;
         b->ysize = 1;
         b->OnClick = (ActFunc)BTNCLK_RefreshMidiOutDeviceList;
@@ -354,7 +354,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         UI->add_element(ml,tabindex++);
         midioutdevlist = ml;
         ml->x = 4;
-        ml->y = 50 - 16-2;
+        ml->y = 48 - 16-2;
         ml->xsize=35;
         ml->ysize = 13;
 
@@ -362,7 +362,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         UI->add_element(b,tabindex++);
         b->caption = " Open device   ";
         b->x = 4+21;
-        b->y = 47;
+        b->y = 45;
         b->xsize = 14;
         b->ysize = 1;
         b->OnClick = (ActFunc)BTNCLK_ForgetMidiOutDevice;
@@ -371,7 +371,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         vs = new LatencyValueSlider(ml);
         UI->add_element(vs,tabindex++);
         vs->x = 13;
-        vs->y = 49;
+        vs->y = 47;
         vs->xsize = 21;
         vs->ysize = 1;
         vs->min = 0;
@@ -381,7 +381,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         UI->add_element(cb,tabindex++);
         cb->frame = 0;
         cb->x = 25;
-        cb->y = 51;
+        cb->y = 49;
         cb->xsize = 5;
         cb->frame = 1;
 
@@ -389,7 +389,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         UI->add_element(ti,tabindex++);
         ti->frame = 1;
         ti->x = 18;
-        ti->y = 53;
+        ti->y = 51;
         ti->xsize=43;
         ti->length=42;
 
@@ -402,7 +402,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         UI->add_element(b,tabindex++);
         b->caption = " Refresh";
         b->x = 4+26+37;
-        b->y = 50 - 16 -2-2;
+        b->y = 48 - 16 -2-2;
         b->xsize = 9;
         b->ysize = 1;
         b->OnClick = (ActFunc)BTNCLK_RefreshMidiInDeviceList;
@@ -411,7 +411,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         midiindevlist = mi;
         UI->add_element(mi,tabindex++);
         mi->x = 4+37;
-        mi->y = 50 - 16-2;
+        mi->y = 48 - 16-2;
         mi->xsize=35;
         mi->ysize = 13;
 
@@ -419,7 +419,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         UI->add_element(b,tabindex++);
         b->caption = " Open device   ";
         b->x = 4+21+37;
-        b->y = 47;
+        b->y = 45;
         b->xsize = 14;
         b->ysize = 1;
         b->OnClick = (ActFunc)BTNCLK_ForgetMidiInDevice;
@@ -489,12 +489,12 @@ void CUI_Sysconfig::draw(Drawable *S) {
 #endif
         print(row(4+37+8),col(TRACKS_ROW_Y+3),"Skin Selection",COLORS.Text,S);
 
-        print(row(4),col(30),"MIDI Out Device Selection",COLORS.Text,S);
-        print(row(4+37),col(30),"MIDI In Device Selection",COLORS.Text,S);
+        print(row(4),col(28),"MIDI Out Device Selection",COLORS.Text,S);
+        print(row(4+37),col(28),"MIDI In Device Selection",COLORS.Text,S);
 
-        print(row(5),col(49),"Latency ",COLORS.Text,S);
-        print(row(5),col(51),"Reverse Bank Select ",COLORS.Text,S);
-        print(row(5),col(53),"Device Alias",COLORS.Text,S);
+        print(row(5),col(47),"Latency ",COLORS.Text,S);
+        print(row(5),col(49),"Reverse Bank Select ",COLORS.Text,S);
+        print(row(5),col(51),"Device Alias",COLORS.Text,S);
         
         need_refresh = 0; 
         updated=2;

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -1111,6 +1111,8 @@ GfxButton::GfxButton(void) {
     bmOnClick = NULL;
     StuffKey = -1;
     StuffKeyState = KS_NO_SHIFT_KEYS;
+    CtrlStuffKey = -1;
+    CtrlStuffKeyState = KS_NO_SHIFT_KEYS;
 }
 
 
@@ -1231,8 +1233,13 @@ int GfxButton::mouseupdate(int cur_element) {
     }
     if (act) {
         key = Keys.getkey();
-        if (StuffKey != -1 && bustit)
-            Keys.insert(StuffKey,StuffKeyState);
+        if (bustit) {
+            bool ctrl_held = (SDL_GetModState() & SDL_KMOD_CTRL) != 0;
+            if (ctrl_held && CtrlStuffKey != -1)
+                Keys.insert(CtrlStuffKey, CtrlStuffKeyState);
+            else if (StuffKey != -1)
+                Keys.insert(StuffKey, StuffKeyState);
+        }
     }
     if (cur_element != this->ID && mousestate && act) {
             need_refresh++;

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -1998,6 +1998,9 @@ ListBox::ListBox()
   check_off = 250;
   color_itemsel = &COLORS.EditBG;
   color_itemnosel = &COLORS.EditText;
+  typeahead_buf[0] = 0;
+  typeahead_len = 0;
+  typeahead_last_ms = 0;
 }
 
 
@@ -2387,6 +2390,25 @@ void ListBox::setCursor(int index) {
 // ------------------------------------------------------------------------------------------------
 //
 //
+LBNode *ListBox::findNodeWithPrefix(const char *prefix) {
+    if (!prefix || !*prefix) return NULL;
+    int plen = (int)strlen(prefix);
+    LBNode *w = items;
+    while (w) {
+        if (w->caption) {
+            int i;
+            for (i = 0; i < plen && w->caption[i]; i++) {
+                if (tolower((unsigned char)w->caption[i]) !=
+                    tolower((unsigned char)prefix[i]))
+                    break;
+            }
+            if (i == plen) return w;
+        }
+        w = w->next;
+    }
+    return NULL;
+}
+
 LBNode *ListBox::findNodeWithChar(char c, LBNode *start) {
     LBNode *work = start;
     if (start) {
@@ -2424,12 +2446,43 @@ int ListBox::update() {
         if (num_elements && use_key_select) {
             signed int retchar = key;//getKeyChar(key);
             LBNode *p = getNode(cur_sel + y_start);
-            if (retchar >= 0 && retchar <= 0xFF && isalpha((unsigned char)retchar) && p) {
-                char c = (char)toupper((unsigned char)retchar);
-                LBNode *n = findNodeWithChar(c,p);
+            if (retchar >= 0 && retchar <= 0xFF &&
+                (isalnum((unsigned char)retchar) || retchar == ' ' ||
+                 retchar == '.' || retchar == '-' || retchar == '_') && p) {
+                // Multi-char prefix typeahead: accumulate typed chars; reset
+                // buffer after ~800ms of idle or on first no-match. Lets the
+                // user type "music" to jump to a folder called "Music".
+                Uint64 now = SDL_GetTicks();
+                if (typeahead_len == 0 ||
+                    (now - typeahead_last_ms) > 800) {
+                    typeahead_len = 0;
+                }
+                typeahead_last_ms = now;
+                if (typeahead_len < (int)sizeof(typeahead_buf) - 1) {
+                    typeahead_buf[typeahead_len++] =
+                        (char)tolower((unsigned char)retchar);
+                    typeahead_buf[typeahead_len] = 0;
+                }
+
+                LBNode *n = findNodeWithPrefix(typeahead_buf);
                 if (n) {
                     this->setCursor(findItem(n->caption));
                     act++;
+                } else {
+                    // No prefix match — restart buffer with just this char
+                    // and fall back to the single-char cycling search.
+                    typeahead_buf[0] =
+                        (char)tolower((unsigned char)retchar);
+                    typeahead_buf[1] = 0;
+                    typeahead_len = 1;
+                    if (isalpha((unsigned char)retchar)) {
+                        char c = (char)toupper((unsigned char)retchar);
+                        LBNode *m = findNodeWithChar(c, p);
+                        if (m) {
+                            this->setCursor(findItem(m->caption));
+                            act++;
+                        }
+                    }
                 }
             }
         }

--- a/src/UserInterface.h
+++ b/src/UserInterface.h
@@ -303,6 +303,13 @@ class ListBox : public UserInterfaceElement {
         int sortstr(const char *s1, const char *s2);
         int mouseupdate(int cur_element);
         LBNode *findNodeWithChar(char c, LBNode *start);
+        LBNode *findNodeWithPrefix(const char *prefix);
+
+        // Typeahead state: accumulate typed chars and match against item
+        // prefixes (case-insensitive). Resets after ~800ms of idle.
+        char   typeahead_buf[64];
+        int    typeahead_len;
+        Uint64 typeahead_last_ms;
 
         virtual void OnChange()=0;
         virtual void OnSelect(LBNode *selected);

--- a/src/UserInterface.h
+++ b/src/UserInterface.h
@@ -132,6 +132,9 @@ class GfxButton : public UserInterfaceElement {
         int state;
         int updown;
         int StuffKey,StuffKeyState;
+        // Optional second binding used when Ctrl is held at click time
+        // (e.g. Ctrl-click on the Conf toolbar button goes to System Config).
+        int CtrlStuffKey,CtrlStuffKeyState;
         ActFunc OnClick;
 
         Bitmap *bmDefault;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1907,6 +1907,9 @@ void make_toolbar(void)
     gb->ysize = NORMAL_BUTTONS_SIZE_Y ;
     grab_buttons(gb,57,0);
     gb->StuffKey = SDLK_F11;
+    // Ctrl-click jumps to System Configuration (F12) instead of Song Config.
+    gb->CtrlStuffKey = SDLK_F12;
+    gb->CtrlStuffKeyState = KS_NO_SHIFT_KEYS;
     UI_Toolbar->add_element(gb,id++);
 
     /* Stop */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1651,7 +1651,10 @@ void global_keys(Drawable *S)
             break;
         // ------------------------------------------------------------------------
         case CMD_SWITCH_HELP:
-            switch_page(UIP_Help);
+            if (ActivePage == UIP_Help && LastPage && LastPage != UIP_Help)
+                switch_page(LastPage);
+            else
+                switch_page(UIP_Help);
             doredraw++; clear++;
             break;
         // ------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Five small, independent UI polish items. All requested directly by me ([esaruoho](https://github.com/esaruoho)) during use of the macOS build:

1. **F1 is now a toggle.** Pressing F1 on the Help page returns to whichever page you came from (pattern editor, F12, etc.) instead of being a no-op. `main.cpp` `CMD_SWITCH_HELP`.

2. **F3 (Instrument Editor) list shifted one row down.** Before: the 2-digit instrument numbers sat one row higher than the 3-digit row counter in F2, so nothing aligned between the two pages. After: `39` in F3 ends at the same Y as `039` in F2. `CUI_InstEditor.cpp` `ie->y = TRACKS_ROW_Y + 1`.

3. **System Configuration (F12) — MIDI panels pulled up by 2 rows.** The gap between the "Full Screen" row and the MIDI Out/In device selection labels had ~4 empty rows; this trims 2 of them so the two MIDI device panels sit 2 rows higher. All dependent y-coordinates (refresh button, listbox, open device, latency, bank-select, alias input) shifted accordingly. `CUI_Sysconfig.cpp`.

4. **Global Configuration (Ctrl+F12) — value column alignment + rename.** Every label in "Current Settings in memory:" is now padded to 15 chars so the opening `[` of each value lines up in a single column. `Auto-Open MIDI` was previously the widest label and made everything else look off-by-one; the rest are now flush with it. Also renamed the awkward `Record Veloc` → `Record Velocity` now that the column is wide enough. `CUI_Config.cpp`.

5. **File load (Ctrl+L) — multi-character prefix typeahead.** Previously typing a letter cycled through items starting with that letter. Now typing multiple characters (e.g. `m`, `u`, `s`, `i`, `c`) accumulates into a prefix buffer and jumps to the first item whose name begins with that prefix, case-insensitive. Buffer resets after ~800 ms of idle or when no match is found (in which case it falls back to the legacy single-char cycling search with the new character). This applies to every `ListBox` in the app, so skin selection, MIDI device lists, palette presets, etc. all get it for free. `UserInterface.cpp` `ListBox::update`, `findNodeWithPrefix` + `UserInterface.h` ListBox state.

## Test plan

- [x] macOS arm64 build is clean (same pre-existing warnings as master; #45 takes care of them)
- [x] Binary launches
- [ ] F1 → help → F1 returns to the starting page (pattern editor, instrument editor, F12, etc.)
- [ ] F2 pattern editor vs. F3 instrument editor: 3-digit row counter `039` and 2-digit `39` end at the same Y
- [ ] F12 System Configuration: "MIDI Out Device Selection" sits 2 rows higher than before; layout still consistent at every zoom level; alias textbox / latency slider / bank-select checkbox hit-testing still work
- [ ] Ctrl+F12 Global Configuration: every `[value]` opens at the same column; "Record Velocity" label shown
- [ ] Ctrl+L file load: type `m-u-s-i-c` quickly → "Music" folder is selected; pause, then press `m` → cycles through items starting with `m`; type a non-matching char → restarts the buffer
- [ ] CI: Win x64 MSVC, Win x86 MinGW XP-compat, macOS arm64, macOS x86_64, Linux x86_64

@m6502 — when you have a minute. These are all small and independent, so feel free to cherry-pick if any one of them needs more thought.
