### PR TITLE
macOS: capture F1/F2/F5..F12 via NSEvent aux-control monitor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,9 @@ if(APPLE)
   list(APPEND ZT_SOURCES ${ZT_MACOSX_ICON})
   set_source_files_properties(${ZT_MACOSX_ICON} PROPERTIES
     MACOSX_PACKAGE_LOCATION "Resources")
+  # Objective-C++ shim that captures media/brightness aux-key events
+  # and feeds them to keyhandler() as synthesized SDL F-key events.
+  list(APPEND ZT_SOURCES src/macos_fkeys.mm)
 endif()
 
 if(WIN32)
@@ -301,7 +304,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 endif()
 
 if(APPLE)
-  target_link_libraries(zt PRIVATE "-framework CoreMIDI" "-framework CoreFoundation")
+  target_link_libraries(zt PRIVATE "-framework CoreMIDI" "-framework CoreFoundation" "-framework AppKit" "-framework IOKit")
   # Turn the macOS build into a proper .app bundle with icon + Info.plist.
   set_target_properties(zt PROPERTIES
     MACOSX_BUNDLE TRUE

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,25 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_04_22 (macOS F-key capture)
+-----------------------------------
+
+        + macOS: F1..F12 now fire zTracker bindings regardless of the
+          System Settings toggle "Use F1, F2 etc. keys as standard
+          function keys". A local NSEvent monitor watches aux-control
+          events (NSSystemDefined subtype 8) from the frontmost app and
+          feeds them to keyhandler() as synthesized SDL F-key events.
+          Covers F1/F2 (brightness), F5/F6 (keyboard illumination), and
+          F7..F12 (media). F3 (Mission Control) and F4 (Launchpad) are
+          symbolic hotkeys handled by WindowServer and cannot be
+          captured without Accessibility permission — disable them in
+          System Settings > Keyboard > Keyboard Shortcuts if you need
+          them in zt.
+        ! No Accessibility permission required. The OS default action
+          (volume/brightness change) still fires alongside the
+          zTracker binding — that is the tradeoff for avoiding a
+          CGEventTap.
+
 zt 2026_04_18 (MIDI timer robustness — POSIX path)
 --------------------------------------------------
 

--- a/src/macos_fkeys.mm
+++ b/src/macos_fkeys.mm
@@ -1,0 +1,106 @@
+// macos_fkeys.mm — macOS-only. Capture aux-control key events
+// (NSEventTypeSystemDefined, subtype 8) delivered to the frontmost
+// app when the System Settings toggle "Use F1, F2, etc. keys as
+// standard function keys" is OFF. Map them to synthesized SDL
+// F-key events so zTracker's F1..F12 bindings work regardless of
+// that setting.
+//
+// Scope and limitations:
+//   * F3 (Mission Control) and F4 (Launchpad/Spotlight) are
+//     symbolic hotkeys handled by WindowServer before they reach
+//     the app. They cannot be captured via NSEvent and are not
+//     handled here. User can disable those shortcuts in
+//     System Settings > Keyboard > Keyboard Shortcuts if desired.
+//   * Because this uses a local event monitor (no Accessibility
+//     permission), the OS media daemon will still perform its
+//     default action (volume/brightness change) in addition to the
+//     zTracker F-key handler firing. That is the expected tradeoff
+//     for avoiding a CGEventTap + Accessibility prompt.
+//   * The monitor is local: it only fires while zt.app is
+//     frontmost, which is the desired behavior.
+
+#import <AppKit/AppKit.h>
+#import <IOKit/hidsystem/ev_keymap.h>
+#include <SDL3/SDL.h>
+#include <cstring>
+
+void keyhandler(SDL_KeyboardEvent *e);
+
+static id g_fkey_monitor = nil;
+
+static SDL_Keycode aux_to_fkey(int auxKey) {
+  switch (auxKey) {
+    case NX_KEYTYPE_BRIGHTNESS_DOWN:   return SDLK_F1;
+    case NX_KEYTYPE_BRIGHTNESS_UP:     return SDLK_F2;
+    case NX_KEYTYPE_ILLUMINATION_DOWN: return SDLK_F5;
+    case NX_KEYTYPE_ILLUMINATION_UP:   return SDLK_F6;
+    case NX_KEYTYPE_PREVIOUS:          return SDLK_F7;
+    case NX_KEYTYPE_PLAY:              return SDLK_F8;
+    case NX_KEYTYPE_NEXT:              return SDLK_F9;
+    case NX_KEYTYPE_MUTE:              return SDLK_F10;
+    case NX_KEYTYPE_SOUND_DOWN:        return SDLK_F11;
+    case NX_KEYTYPE_SOUND_UP:          return SDLK_F12;
+    default:                           return SDLK_UNKNOWN;
+  }
+}
+
+static SDL_Scancode fkey_to_scancode(SDL_Keycode k) {
+  switch (k) {
+    case SDLK_F1:  return SDL_SCANCODE_F1;
+    case SDLK_F2:  return SDL_SCANCODE_F2;
+    case SDLK_F5:  return SDL_SCANCODE_F5;
+    case SDLK_F6:  return SDL_SCANCODE_F6;
+    case SDLK_F7:  return SDL_SCANCODE_F7;
+    case SDLK_F8:  return SDL_SCANCODE_F8;
+    case SDLK_F9:  return SDL_SCANCODE_F9;
+    case SDLK_F10: return SDL_SCANCODE_F10;
+    case SDLK_F11: return SDL_SCANCODE_F11;
+    case SDLK_F12: return SDL_SCANCODE_F12;
+    default:       return SDL_SCANCODE_UNKNOWN;
+  }
+}
+
+void zt_macos_install_fkey_monitor(void) {
+  if (g_fkey_monitor) return;
+  g_fkey_monitor = [NSEvent
+      addLocalMonitorForEventsMatchingMask:NSEventMaskSystemDefined
+      handler:^NSEvent * _Nullable (NSEvent * _Nonnull ev) {
+    if ([ev subtype] != 8) return ev;
+
+    int data1    = (int)[ev data1];
+    int auxKey   = (data1 & 0xFFFF0000) >> 16;
+    int keyFlags = (data1 & 0x0000FFFF);
+    int keyState = (keyFlags & 0xFF00) >> 8;  // 0x0A=down, 0x0B=up
+    bool isDown  = (keyState == 0x0A);
+    bool isUp    = (keyState == 0x0B);
+    if (!isDown && !isUp) return ev;
+
+    SDL_Keycode k = aux_to_fkey(auxKey);
+    if (k == SDLK_UNKNOWN) return ev;
+
+    NSEventModifierFlags mflags = [ev modifierFlags];
+    SDL_Keymod mod = SDL_KMOD_NONE;
+    if (mflags & NSEventModifierFlagShift)   mod = (SDL_Keymod)(mod | SDL_KMOD_SHIFT);
+    if (mflags & NSEventModifierFlagControl) mod = (SDL_Keymod)(mod | SDL_KMOD_CTRL);
+    if (mflags & NSEventModifierFlagOption)  mod = (SDL_Keymod)(mod | SDL_KMOD_ALT);
+    if (mflags & NSEventModifierFlagCommand) mod = (SDL_Keymod)(mod | SDL_KMOD_GUI);
+
+    SDL_KeyboardEvent k_ev;
+    std::memset(&k_ev, 0, sizeof(k_ev));
+    k_ev.type     = isDown ? SDL_EVENT_KEY_DOWN : SDL_EVENT_KEY_UP;
+    k_ev.key      = k;
+    k_ev.scancode = fkey_to_scancode(k);
+    k_ev.mod      = mod;
+    k_ev.down     = isDown;
+    k_ev.repeat   = false;
+    keyhandler(&k_ev);
+    return nil;
+  }];
+}
+
+void zt_macos_remove_fkey_monitor(void) {
+  if (g_fkey_monitor) {
+    [NSEvent removeMonitor:g_fkey_monitor];
+    g_fkey_monitor = nil;
+  }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3161,6 +3161,11 @@ int set_video_mode(int w, int h, char *errstr)
   return 1;
 }
 
+#ifdef __APPLE__
+void zt_macos_install_fkey_monitor(void);
+void zt_macos_remove_fkey_monitor(void);
+#endif
+
 static int zt_backend_init_runtime(char *errstr)
 {
   if (!SDL_Init(SDL_INIT_VIDEO|SDL_INIT_AUDIO)) {
@@ -3168,6 +3173,12 @@ static int zt_backend_init_runtime(char *errstr)
     zt_show_error("Error", errstr);
     return 0;
   }
+#ifdef __APPLE__
+  // Translate media/brightness aux-key events into SDL F-key events so
+  // F1..F12 bindings fire regardless of the "Use F1, F2 etc. as standard
+  // function keys" toggle in System Settings.
+  zt_macos_install_fkey_monitor();
+#endif
   return 1;
 }
 
@@ -3382,6 +3393,9 @@ static void zt_backend_release_frame_resources(void)
 
 static void zt_backend_shutdown_runtime(void)
 {
+#ifdef __APPLE__
+  zt_macos_remove_fkey_monitor();
+#endif
   if (zt_renderer) {
     SDL_DestroyRenderer(zt_renderer);
     zt_renderer = NULL;


### PR DESCRIPTION
## What

Adds a small Objective-C++ shim (`src/macos_fkeys.mm`, ~100 LOC) that installs an `NSEvent` local monitor for `NSEventTypeSystemDefined` subtype 8 events (aux-control / media buttons). When the user has **"Use F1, F2, etc. keys as standard function keys"** OFF in System Settings > Keyboard, macOS maps F-keys to media / brightness / illumination actions instead of delivering `SDLK_F1..F12` to the app. The monitor decodes those aux events and feeds synthesized SDL key events back into `keyhandler()`, so zTracker's F-key bindings fire regardless of that toggle.

## Key mapping

| F-key | Aux event              | Works? |
|-------|------------------------|:------:|
| F1    | brightness down        |   yes  |
| F2    | brightness up          |   yes  |
| F3    | Mission Control        |   no   |
| F4    | Launchpad / Spotlight  |   no   |
| F5    | keyboard illum. down   |   yes  |
| F6    | keyboard illum. up     |   yes  |
| F7    | previous track         |   yes  |
| F8    | play / pause           |   yes  |
| F9    | next track             |   yes  |
| F10   | mute                   |   yes  |
| F11   | volume down            |   yes  |
| F12   | volume up              |   yes  |

**F3 / F4 limitation:** Mission Control and Launchpad are symbolic hotkeys handled by WindowServer *before* events reach the app. They cannot be captured via `NSEvent` without an Accessibility-permission `CGEventTap`. Users who need F3/F4 in zt can disable those shortcuts in System Settings > Keyboard > Keyboard Shortcuts.

**OS action still fires:** because this is a local monitor (no Accessibility prompt), the OS media daemon performs its default action (volume / brightness change) alongside the zTracker binding. That's the explicit tradeoff for keeping the install frictionless.

## Files

- `src/macos_fkeys.mm` (new) — monitor install/remove, aux-key to SDL F-key translation
- `src/main.cpp` — call `zt_macos_install_fkey_monitor()` after `SDL_Init`, remove at shutdown, `#ifdef __APPLE__` only
- `CMakeLists.txt` — add `.mm` to `ZT_SOURCES` on APPLE, link `-framework AppKit -framework IOKit`
- `doc/CHANGELOG.txt` — changelog entry

## Scope

- macOS-only. No changes to Linux / Windows build paths.
- Monitor is local: fires only while zt.app is frontmost.
- No Accessibility permission required, no prompts on first launch.
- 4 files, +143 / -1 LOC total.

## Test plan

- [ ] Build on macOS (arm64): `cmake .. && make -j8` — confirmed green locally
- [ ] Launch `zt.app`, verify F1/F2 switch pages (brightness toggle still fires too — expected)
- [ ] Verify F7..F12 don't change the song (zt binds, media daemon also fires — expected)
- [ ] Verify F3/F4 still invoke Mission Control/Launchpad (not captured — as documented)
- [ ] Quit — no crash (monitor removed cleanly)
- [ ] CI: macOS arm64 + x86_64, Win x64, Win x86, Linux x86_64

@m6502 — ready for review.

Generated with [Claude Code](https://claude.com/claude-code)
