### PR TITLE
CI: tag-triggered cross-platform release packaging

### DIFF
--- a/.github/release-notes/README-MAC.txt
+++ b/.github/release-notes/README-MAC.txt
@@ -1,0 +1,61 @@
+zTracker Prime — macOS
+=======================
+
+WHY DOES IT SAY "zt.app IS DAMAGED AND CAN'T BE OPENED"?
+--------------------------------------------------------
+
+It is not damaged. macOS quarantines anything downloaded from the
+internet that is not signed by an Apple Developer ID. zTracker Prime
+is currently distributed unsigned (no $99/yr Apple Developer Program
+account), so Gatekeeper refuses to launch it on first run.
+
+
+HOW TO RUN IT
+-------------
+
+1. Drag zt.app out of this DMG to wherever you want it (e.g. /Applications,
+   ~/Desktop, ~/Downloads — anywhere you have write access).
+
+2. Open Terminal (Applications > Utilities > Terminal, or press Cmd+Space
+   and type "Terminal").
+
+3. Run:
+
+       xattr -cr /path/to/zt.app
+
+   ...replacing /path/to/ with wherever you put it. Examples:
+
+       xattr -cr /Applications/zt.app
+       xattr -cr ~/Desktop/zt.app
+       xattr -cr ~/Downloads/zt.app
+
+   Tip: you can drag zt.app onto the Terminal window and it will paste
+   the full path for you.
+
+4. Double-click zt.app. It launches normally from now on.
+
+
+ALTERNATIVE (sometimes works)
+-----------------------------
+
+Right-click zt.app, choose Open, then click Open in the dialog that
+appears. On some macOS versions this bypasses the quarantine without
+needing Terminal. If it does not work and you still see "damaged",
+fall back to the xattr -cr method above.
+
+
+WHY NOT JUST SIGN AND NOTARIZE THE APP?
+---------------------------------------
+
+That requires the paid Apple Developer Program ($99/yr) plus the
+Developer ID Application certificate and notarytool credentials wired
+into CI. It is a planned follow-up; until then, the xattr -cr step
+above is a one-time fix per copy of the app.
+
+
+WHAT'S IN THIS DMG?
+-------------------
+
+  zt.app           the application (skins, docs, default config are
+                   embedded inside the bundle)
+  README-MAC.txt   this file

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ jobs:
           if-no-files-found: error
 
       - name: Package release tarball
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
           set -euo pipefail
@@ -168,7 +168,7 @@ jobs:
           tar -czf "ztrackerprime-${TAG}-linux-x86_64.tar.gz" ztrackerprime-linux-x86_64
 
       - name: Upload release asset (linux)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: release-linux-x86_64
@@ -221,7 +221,7 @@ jobs:
           if-no-files-found: error
 
       - name: Package release (zip + unsigned DMG)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
           set -euo pipefail
@@ -243,7 +243,7 @@ jobs:
             "ztrackerprime-${TAG}-macos-${ARCH}.dmg"
 
       - name: Upload release asset (macos-arm64)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: release-macos-arm64
@@ -300,7 +300,7 @@ jobs:
           if-no-files-found: error
 
       - name: Package release (zip + unsigned DMG)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
           set -euo pipefail
@@ -317,7 +317,7 @@ jobs:
             "ztrackerprime-${TAG}-macos-${ARCH}.dmg"
 
       - name: Upload release asset (macos-x86_64)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: release-macos-x86_64
@@ -432,7 +432,7 @@ jobs:
           if-no-files-found: error
 
       - name: Package release zip
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
           set -euo pipefail
@@ -441,7 +441,7 @@ jobs:
           zip -r "ztrackerprime-${TAG}-windows-x86-xp.zip" ztrackerprime-windows-x86-xp
 
       - name: Upload release asset (windows-x86-xp)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: release-windows-x86-xp
@@ -532,7 +532,7 @@ jobs:
           if-no-files-found: error
 
       - name: Package release zip
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         shell: pwsh
         run: |
           $tag = $env:RELEASE_TAG
@@ -541,7 +541,7 @@ jobs:
             -DestinationPath "ztrackerprime-$tag-windows-x64.zip" -Force
 
       - name: Upload release asset (windows-x64)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: release-windows-x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ jobs:
           if-no-files-found: error
 
       - name: Package release tarball
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         shell: bash
         run: |
           set -euo pipefail
@@ -168,7 +168,7 @@ jobs:
           tar -czf "ztrackerprime-${TAG}-linux-x86_64.tar.gz" ztrackerprime-linux-x86_64
 
       - name: Upload release asset (linux)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         uses: actions/upload-artifact@v4
         with:
           name: release-linux-x86_64
@@ -224,7 +224,7 @@ jobs:
           if-no-files-found: error
 
       - name: Package release (zip + unsigned DMG)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         shell: bash
         run: |
           set -euo pipefail
@@ -248,7 +248,7 @@ jobs:
             "ztrackerprime-${TAG}-macos-${ARCH}.dmg"
 
       - name: Upload release asset (macos-arm64)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         uses: actions/upload-artifact@v4
         with:
           name: release-macos-arm64
@@ -306,7 +306,7 @@ jobs:
           if-no-files-found: error
 
       - name: Package release (zip + unsigned DMG)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         shell: bash
         run: |
           set -euo pipefail
@@ -326,7 +326,7 @@ jobs:
             "ztrackerprime-${TAG}-macos-${ARCH}.dmg"
 
       - name: Upload release asset (macos-x86_64)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         uses: actions/upload-artifact@v4
         with:
           name: release-macos-x86_64
@@ -441,7 +441,7 @@ jobs:
           if-no-files-found: error
 
       - name: Package release zip
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         shell: bash
         run: |
           set -euo pipefail
@@ -450,7 +450,7 @@ jobs:
           zip -r "ztrackerprime-${TAG}-windows-x86-xp.zip" ztrackerprime-windows-x86-xp
 
       - name: Upload release asset (windows-x86-xp)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         uses: actions/upload-artifact@v4
         with:
           name: release-windows-x86-xp
@@ -541,7 +541,7 @@ jobs:
           if-no-files-found: error
 
       - name: Package release zip
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         shell: pwsh
         run: |
           $tag = $env:RELEASE_TAG
@@ -550,7 +550,7 @@ jobs:
             -DestinationPath "ztrackerprime-$tag-windows-x64.zip" -Force
 
       - name: Upload release asset (windows-x64)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         uses: actions/upload-artifact@v4
         with:
           name: release-windows-x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,12 @@ on:
     tags: ['v*']
   pull_request:
     branches: [master]
+  workflow_dispatch:
+    inputs:
+      simulate_tag:
+        description: 'Synthetic tag for packaging filenames (e.g. v0.0.0-test). Triggers full packaging path; does NOT publish a GitHub Release.'
+        required: false
+        default: 'v0.0.0-test'
 
 # Allow only one concurrent run per branch / PR; cancel older runs.
 concurrency:
@@ -50,6 +56,9 @@ env:
   SDL3_VERSION: "3.4.4"
   LIBPNG_VERSION: "1.6.44"
   ZLIB_VERSION: "1.3.1"
+  # On tag push: the real tag (e.g. v1.2.3). On manual dispatch: the simulated
+  # tag input. On regular branch/PR pushes: empty (packaging steps skipped).
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.simulate_tag || (startsWith(github.ref, 'refs/tags/v') && github.ref_name || '') }}
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -150,16 +159,16 @@ jobs:
           if-no-files-found: error
 
       - name: Package release tarball
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
           set -euo pipefail
           cd dist
-          TAG="${GITHUB_REF_NAME}"
+          TAG="${RELEASE_TAG}"
           tar -czf "ztrackerprime-${TAG}-linux-x86_64.tar.gz" ztrackerprime-linux-x86_64
 
       - name: Upload release asset (linux)
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: release-linux-x86_64
@@ -212,12 +221,12 @@ jobs:
           if-no-files-found: error
 
       - name: Package release (zip + unsigned DMG)
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
           set -euo pipefail
           cd dist
-          TAG="${GITHUB_REF_NAME}"
+          TAG="${RELEASE_TAG}"
           ARCH="arm64"
           # Zip of the full staged dir (zt.app + zt.conf + skins + doc).
           # ditto preserves .app bundle structure and resource forks.
@@ -234,7 +243,7 @@ jobs:
             "ztrackerprime-${TAG}-macos-${ARCH}.dmg"
 
       - name: Upload release asset (macos-arm64)
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: release-macos-arm64
@@ -291,12 +300,12 @@ jobs:
           if-no-files-found: error
 
       - name: Package release (zip + unsigned DMG)
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
           set -euo pipefail
           cd dist
-          TAG="${GITHUB_REF_NAME}"
+          TAG="${RELEASE_TAG}"
           ARCH="x86_64"
           ditto -c -k --sequesterRsrc --keepParent \
             "ztrackerprime-macos-${ARCH}" \
@@ -308,7 +317,7 @@ jobs:
             "ztrackerprime-${TAG}-macos-${ARCH}.dmg"
 
       - name: Upload release asset (macos-x86_64)
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: release-macos-x86_64
@@ -423,16 +432,16 @@ jobs:
           if-no-files-found: error
 
       - name: Package release zip
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
           set -euo pipefail
           cd dist
-          TAG="${GITHUB_REF_NAME}"
+          TAG="${RELEASE_TAG}"
           zip -r "ztrackerprime-${TAG}-windows-x86-xp.zip" ztrackerprime-windows-x86-xp
 
       - name: Upload release asset (windows-x86-xp)
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: release-windows-x86-xp
@@ -523,16 +532,16 @@ jobs:
           if-no-files-found: error
 
       - name: Package release zip
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         shell: pwsh
         run: |
-          $tag = $env:GITHUB_REF_NAME
+          $tag = $env:RELEASE_TAG
           Set-Location dist
           Compress-Archive -Path ztrackerprime-windows-x64 `
             -DestinationPath "ztrackerprime-$tag-windows-x64.zip" -Force
 
       - name: Upload release asset (windows-x64)
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: release-windows-x64
@@ -552,6 +561,8 @@ jobs:
   # ---------------------------------------------------------------------------
   release:
     name: Publish GitHub Release (draft)
+    # Real-tag-only — manual dispatch exercises the packaging path but does NOT
+    # publish a Release (you can still download the release-* artifacts to inspect).
     if: startsWith(github.ref, 'refs/tags/v')
     needs:
       - linux-x86_64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ name: Build
 on:
   push:
     branches: ['**']
+    tags: ['v*']
   pull_request:
     branches: [master]
 
@@ -148,6 +149,23 @@ jobs:
           path: dist/ztrackerprime-linux-x86_64
           if-no-files-found: error
 
+      - name: Package release tarball
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          TAG="${GITHUB_REF_NAME}"
+          tar -czf "ztrackerprime-${TAG}-linux-x86_64.tar.gz" ztrackerprime-linux-x86_64
+
+      - name: Upload release asset (linux)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-linux-x86_64
+          path: dist/ztrackerprime-*-linux-x86_64.tar.gz
+          if-no-files-found: error
+
   # ---------------------------------------------------------------------------
   # macOS arm64 (Apple Silicon)
   # ---------------------------------------------------------------------------
@@ -191,6 +209,38 @@ jobs:
         with:
           name: ztrackerprime-macos-arm64
           path: dist/ztrackerprime-macos-arm64
+          if-no-files-found: error
+
+      - name: Package release (zip + unsigned DMG)
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          TAG="${GITHUB_REF_NAME}"
+          ARCH="arm64"
+          # Zip of the full staged dir (zt.app + zt.conf + skins + doc).
+          # ditto preserves .app bundle structure and resource forks.
+          ditto -c -k --sequesterRsrc --keepParent \
+            "ztrackerprime-macos-${ARCH}" \
+            "ztrackerprime-${TAG}-macos-${ARCH}.zip"
+          # Unsigned DMG containing just zt.app (self-contained — the bundle
+          # already has skins/doc/zt.conf copied into Contents/Resources/
+          # by the CMake POST_BUILD step).
+          hdiutil create \
+            -volname "zTracker ${TAG} (${ARCH})" \
+            -srcfolder "ztrackerprime-macos-${ARCH}/zt.app" \
+            -fs HFS+ -format UDZO -ov \
+            "ztrackerprime-${TAG}-macos-${ARCH}.dmg"
+
+      - name: Upload release asset (macos-arm64)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-macos-arm64
+          path: |
+            dist/ztrackerprime-*-macos-arm64.zip
+            dist/ztrackerprime-*-macos-arm64.dmg
           if-no-files-found: error
 
   # ---------------------------------------------------------------------------
@@ -238,6 +288,33 @@ jobs:
         with:
           name: ztrackerprime-macos-x86_64
           path: dist/ztrackerprime-macos-x86_64
+          if-no-files-found: error
+
+      - name: Package release (zip + unsigned DMG)
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          TAG="${GITHUB_REF_NAME}"
+          ARCH="x86_64"
+          ditto -c -k --sequesterRsrc --keepParent \
+            "ztrackerprime-macos-${ARCH}" \
+            "ztrackerprime-${TAG}-macos-${ARCH}.zip"
+          hdiutil create \
+            -volname "zTracker ${TAG} (${ARCH})" \
+            -srcfolder "ztrackerprime-macos-${ARCH}/zt.app" \
+            -fs HFS+ -format UDZO -ov \
+            "ztrackerprime-${TAG}-macos-${ARCH}.dmg"
+
+      - name: Upload release asset (macos-x86_64)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-macos-x86_64
+          path: |
+            dist/ztrackerprime-*-macos-x86_64.zip
+            dist/ztrackerprime-*-macos-x86_64.dmg
           if-no-files-found: error
 
   # ---------------------------------------------------------------------------
@@ -345,6 +422,23 @@ jobs:
           path: dist/ztrackerprime-windows-x86-xp
           if-no-files-found: error
 
+      - name: Package release zip
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          TAG="${GITHUB_REF_NAME}"
+          zip -r "ztrackerprime-${TAG}-windows-x86-xp.zip" ztrackerprime-windows-x86-xp
+
+      - name: Upload release asset (windows-x86-xp)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-windows-x86-xp
+          path: dist/ztrackerprime-*-windows-x86-xp.zip
+          if-no-files-found: error
+
   # ---------------------------------------------------------------------------
   # Windows x64 -- MSVC, modern Windows 10/11 target
   # ---------------------------------------------------------------------------
@@ -427,3 +521,64 @@ jobs:
           name: ztrackerprime-windows-x64
           path: dist/ztrackerprime-windows-x64
           if-no-files-found: error
+
+      - name: Package release zip
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: pwsh
+        run: |
+          $tag = $env:GITHUB_REF_NAME
+          Set-Location dist
+          Compress-Archive -Path ztrackerprime-windows-x64 `
+            -DestinationPath "ztrackerprime-$tag-windows-x64.zip" -Force
+
+      - name: Upload release asset (windows-x64)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-windows-x64
+          path: dist/ztrackerprime-*-windows-x64.zip
+          if-no-files-found: error
+
+  # ---------------------------------------------------------------------------
+  # Release — runs only on tag pushes (v*). Gathers the release-* artifacts
+  # from each platform job and publishes a draft GitHub Release. Draft, not
+  # published, so the maintainer reviews the asset list before announcing.
+  #
+  # Codesigning / notarization are intentionally skipped for this first pass
+  # (explicitly approved). macOS DMGs are ad-hoc signed only — users will see
+  # the Gatekeeper warning and can right-click > Open on first launch.
+  # Adding a Developer ID Application cert + notarytool + signing secrets
+  # is a follow-up PR once the basic tag-to-release flow is validated.
+  # ---------------------------------------------------------------------------
+  release:
+    name: Publish GitHub Release (draft)
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - linux-x86_64
+      - macos-arm64
+      - macos-x86_64
+      - windows-x86-xp
+      - windows-x64
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          pattern: release-*
+          merge-multiple: true
+
+      - name: List collected assets
+        run: |
+          set -euo pipefail
+          ls -la release-assets/
+
+      - name: Publish draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release-assets/*
+          fail_on_unmatched_files: true
+          draft: true
+          generate_release_notes: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ jobs:
           if-no-files-found: error
 
       - name: Package release tarball
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         shell: bash
         run: |
           set -euo pipefail
@@ -168,7 +168,7 @@ jobs:
           tar -czf "ztrackerprime-${TAG}-linux-x86_64.tar.gz" ztrackerprime-linux-x86_64
 
       - name: Upload release asset (linux)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         uses: actions/upload-artifact@v4
         with:
           name: release-linux-x86_64
@@ -221,7 +221,7 @@ jobs:
           if-no-files-found: error
 
       - name: Package release (zip + unsigned DMG)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         shell: bash
         run: |
           set -euo pipefail
@@ -243,7 +243,7 @@ jobs:
             "ztrackerprime-${TAG}-macos-${ARCH}.dmg"
 
       - name: Upload release asset (macos-arm64)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         uses: actions/upload-artifact@v4
         with:
           name: release-macos-arm64
@@ -300,7 +300,7 @@ jobs:
           if-no-files-found: error
 
       - name: Package release (zip + unsigned DMG)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         shell: bash
         run: |
           set -euo pipefail
@@ -317,7 +317,7 @@ jobs:
             "ztrackerprime-${TAG}-macos-${ARCH}.dmg"
 
       - name: Upload release asset (macos-x86_64)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         uses: actions/upload-artifact@v4
         with:
           name: release-macos-x86_64
@@ -432,7 +432,7 @@ jobs:
           if-no-files-found: error
 
       - name: Package release zip
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         shell: bash
         run: |
           set -euo pipefail
@@ -441,7 +441,7 @@ jobs:
           zip -r "ztrackerprime-${TAG}-windows-x86-xp.zip" ztrackerprime-windows-x86-xp
 
       - name: Upload release asset (windows-x86-xp)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         uses: actions/upload-artifact@v4
         with:
           name: release-windows-x86-xp
@@ -532,7 +532,7 @@ jobs:
           if-no-files-found: error
 
       - name: Package release zip
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         shell: pwsh
         run: |
           $tag = $env:RELEASE_TAG
@@ -541,7 +541,7 @@ jobs:
             -DestinationPath "ztrackerprime-$tag-windows-x64.zip" -Force
 
       - name: Upload release asset (windows-x64)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         uses: actions/upload-artifact@v4
         with:
           name: release-windows-x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,6 +212,9 @@ jobs:
           cp zt.conf                 dist/ztrackerprime-macos-arm64/
           cp -R skins                dist/ztrackerprime-macos-arm64/
           cp -R doc                  dist/ztrackerprime-macos-arm64/
+          # macOS users hit "zt.app is damaged" because the build is unsigned
+          # (no Apple Developer Program). README explains the xattr fix.
+          cp .github/release-notes/README-MAC.txt dist/ztrackerprime-macos-arm64/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -228,17 +231,19 @@ jobs:
           cd dist
           TAG="${RELEASE_TAG}"
           ARCH="arm64"
-          # Zip of the full staged dir (zt.app + zt.conf + skins + doc).
+          # Zip of the full staged dir (zt.app + zt.conf + skins + doc + README-MAC.txt).
           # ditto preserves .app bundle structure and resource forks.
           ditto -c -k --sequesterRsrc --keepParent \
             "ztrackerprime-macos-${ARCH}" \
             "ztrackerprime-${TAG}-macos-${ARCH}.zip"
-          # Unsigned DMG containing just zt.app (self-contained — the bundle
-          # already has skins/doc/zt.conf copied into Contents/Resources/
-          # by the CMake POST_BUILD step).
+          # Unsigned DMG: zt.app + README-MAC.txt side by side, so the user sees
+          # the quarantine-fix instructions immediately on mounting the DMG.
+          mkdir -p "dmg-staging-${ARCH}"
+          cp -R "ztrackerprime-macos-${ARCH}/zt.app"         "dmg-staging-${ARCH}/"
+          cp    "ztrackerprime-macos-${ARCH}/README-MAC.txt" "dmg-staging-${ARCH}/"
           hdiutil create \
             -volname "zTracker ${TAG} (${ARCH})" \
-            -srcfolder "ztrackerprime-macos-${ARCH}/zt.app" \
+            -srcfolder "dmg-staging-${ARCH}" \
             -fs HFS+ -format UDZO -ov \
             "ztrackerprime-${TAG}-macos-${ARCH}.dmg"
 
@@ -291,6 +296,7 @@ jobs:
           cp zt.conf                 dist/ztrackerprime-macos-x86_64/
           cp -R skins                dist/ztrackerprime-macos-x86_64/
           cp -R doc                  dist/ztrackerprime-macos-x86_64/
+          cp .github/release-notes/README-MAC.txt dist/ztrackerprime-macos-x86_64/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -310,9 +316,12 @@ jobs:
           ditto -c -k --sequesterRsrc --keepParent \
             "ztrackerprime-macos-${ARCH}" \
             "ztrackerprime-${TAG}-macos-${ARCH}.zip"
+          mkdir -p "dmg-staging-${ARCH}"
+          cp -R "ztrackerprime-macos-${ARCH}/zt.app"         "dmg-staging-${ARCH}/"
+          cp    "ztrackerprime-macos-${ARCH}/README-MAC.txt" "dmg-staging-${ARCH}/"
           hdiutil create \
             -volname "zTracker ${TAG} (${ARCH})" \
-            -srcfolder "ztrackerprime-macos-${ARCH}/zt.app" \
+            -srcfolder "dmg-staging-${ARCH}" \
             -fs HFS+ -format UDZO -ov \
             "ztrackerprime-${TAG}-macos-${ARCH}.dmg"
 


### PR DESCRIPTION
## What

Turns a `v*` tag push into a draft GitHub Release containing binaries for all 5 supported platforms. The existing Build workflow keeps running as before on every branch / PR; on a tag push it additionally packages each platform's staged artifact and hands them off to a new final `release` job that publishes the draft.

## Packages produced per tag

| Platform                 | Asset                                            |
|--------------------------|--------------------------------------------------|
| Linux x86_64             | `ztrackerprime-<tag>-linux-x86_64.tar.gz`        |
| macOS arm64              | `ztrackerprime-<tag>-macos-arm64.zip`            |
| macOS arm64              | `ztrackerprime-<tag>-macos-arm64.dmg`            |
| macOS x86_64             | `ztrackerprime-<tag>-macos-x86_64.zip`           |
| macOS x86_64             | `ztrackerprime-<tag>-macos-x86_64.dmg`           |
| Windows x86 (XP-compat)  | `ztrackerprime-<tag>-windows-x86-xp.zip`         |
| Windows x64              | `ztrackerprime-<tag>-windows-x64.zip`            |

## Design

- All packaging steps are gated on `if: startsWith(github.ref, 'refs/tags/v')`, so non-tag pushes keep their current `upload-artifact` behavior unchanged and don't pay the packaging cost on every master push.
- macOS uses `ditto -c -k` for the .zip (preserves the .app bundle structure + resource forks) and `hdiutil create -format UDZO` for the .dmg. The DMG ships just `zt.app` — the CMake POST_BUILD step already copies skins/doc/zt.conf into `Contents/Resources/` so the bundle is self-contained. The .zip ships the full staged directory for users who prefer the loose layout.
- The release is published as a **draft** so the maintainer can review the asset list before announcing. `generate_release_notes: true` fills in commits-since-last-tag automatically.
- Final `release` job has `permissions: contents: write` — the minimum needed to create releases via `softprops/action-gh-release@v2`.

## Explicit tradeoffs

- **Codesigning / notarization skipped for v1** (explicitly approved). macOS DMGs are ad-hoc signed; first-launch users will see the Gatekeeper warning and need to right-click > Open. Adding Developer ID + notarytool is a follow-up PR once the tag-to-release flow is validated and the maintainer has stored the required secrets.
- **No universal binary** — two single-arch macOS builds, same as the existing non-tag workflow. Homebrew SDL3 is single-arch; building SDL3 from source twice just to lipo the output is not worth it for v1.
- **Windows x86 remains XP-compatible** — packaging respects the existing MinGW cross build, so the zip still runs on XP through 11.

## Test plan

- [ ] Push a throwaway tag on a personal fork: `git tag v0.0.1-test && git push origin v0.0.1-test`
- [ ] Verify the workflow runs all 5 build jobs + the `release` job
- [ ] Verify the draft release contains all 6 assets with the expected names
- [ ] Verify asset file contents: extract one zip, confirm zt/zt.exe + skins/ + doc/
- [ ] Mount one macOS DMG, drag zt.app to /Applications, right-click > Open, confirm it launches
- [ ] Delete the draft release and tag when done
- [ ] Non-tag push to master still produces the existing 5 per-platform artifacts and nothing else

## Files

- `.github/workflows/build.yml` — one file, +155 LOC. Adds `tags: ['v*']` trigger, packaging + release-upload steps to each job, and a new `release` job.

@m6502 — ready for review. Suggest we validate the tag-push flow on a fork first, then land this as-is; signing can come later.

Generated with [Claude Code](https://claude.com/claude-code)
