### PR TITLE
F5 Play Song: align pattern display rows with the Pattern Editor (F2)

### DIFF
--- a/src/CUI_Playsong.cpp
+++ b/src/CUI_Playsong.cpp
@@ -24,7 +24,7 @@ CUI_Playsong::CUI_Playsong(void)
 
     // <Manu> ¿Por qué 20?
     //p->y = 20 ;
-    pattern_display->y = 14 ;
+    pattern_display->y = 12 ;
     
     // <Manu> Control del número de líneas que se muestran mientras se reproduce una canción (30 por defecto)
     //p->ysize = 30 ;


### PR DESCRIPTION
## Summary

`pattern_display->y` was 14 (track headers at row 13, data at row 14+). The Pattern Editor draws its track headers at `TRACKS_ROW_Y = 11` with data at row 12. Switching between F2 and F5 made the pattern body visibly jump down by 2 rows.

Move the Play Song frame to `y=12` so header/data alignment matches.

## Test plan

- [ ] Open Pattern Editor (F2), note row positions of track headers and data
- [ ] Press F5 to enter Play Song view
- [ ] Confirm track headers and pattern data render at the same rows as in F2