### PR TITLE
About page: clamp text-box height so it never overlaps the toolbar

### DIFF
--- a/src/CUI_About.cpp
+++ b/src/CUI_About.cpp
@@ -12,8 +12,15 @@ CUI_About::CUI_About(void) {
     UI->add_element(l,0);
     l->x = 2;
     l->xsize = (int)((double)(38+3)*xscale);
-    l->ysize = (int)((double)26*yscale);
-    l->y = 25 + ((INTERNAL_RESOLUTION_Y-480)/8) - (l->ysize-26);
+    // Anchor below the bmAbout logo and clamp height so the box never
+    // overlaps the bottom toolbar (~7 rows of 55 px).
+    const int ROW_BELOW_LOGO = 20;
+    const int TOOLBAR_ROWS = 7;
+    int max_end_row = (INTERNAL_RESOLUTION_Y / 8) - TOOLBAR_ROWS - 1;
+    int avail = max_end_row - ROW_BELOW_LOGO;
+    if (avail < 6) avail = 6;
+    l->y = ROW_BELOW_LOGO;
+    l->ysize = avail;
     l->bWordWrap = true ;
     l->text =R"about_text(
 |H|About|U|


### PR DESCRIPTION
## Summary

The About page (Alt+F12) text box anchor was `25 + ((INTERNAL_RESOLUTION_Y-480)/8) - (ysize-26)`. At non-default heights the bottom edge crept past the start of the 55px toolbar (which occupies the bottom ~7 rows), so the help text visibly drew over the toolbar.

Anchor at row 20 (just below the bmAbout logo) and clamp `ysize` so the box always ends at least one row above the toolbar.

## Test plan

- [ ] Press Alt+F12 to open About page at default resolution
- [ ] Resize window to non-default heights and confirm the black box never overlaps the toolbar
- [ ] Confirm help text still renders fully readable, no clipping at the bottom