### PR TITLE
Order List: cycle focus back when Up is pressed at row 0

### DIFF
--- a/src/OrderEditor.cpp
+++ b/src/OrderEditor.cpp
@@ -85,11 +85,16 @@ int OrderEditor::update() {
                     list_start+=16;
                 act++;
                 break;
-            case SDLK_UP: 
-                cursor_y--; 
+            case SDLK_UP:
+                // At top of list: cycle focus to the previous element
+                // (so Up out of Order List reaches MIDI Stop/Start, etc.)
+                if (cursor_y == 0 && list_start == 0) {
+                    ret = -1; act++; break;
+                }
+                cursor_y--;
                 if (cursor_y<0)
                     list_start--;
-                act++; 
+                act++;
                 break;
             case SDLK_DOWN: 
                 cursor_y++; 


### PR DESCRIPTION
## Summary

Pressing Up while the order list cursor was at the very top did nothing. The user could enter the order list by pressing Down past MIDI Stop/Start, but the inverse path was blocked.

Return `ret = -1` in that case so the UserInterface focus walker moves to the previous selectable element on the page.

## Test plan

- [ ] Open Songconfig (F11), focus on Title field, Down repeatedly to enter Order List
- [ ] Press Up while at Order List row 0 — focus should move back to MIDI Stop/Start
- [ ] Up from cursor_y > 0 still moves the cursor within the list as before