### PR TITLE
Translate Manu's Spanish source comments inline (English in [EN: ...])

### DIFF
--- a/src/CUI_InstEditor.cpp
+++ b/src/CUI_InstEditor.cpp
@@ -276,7 +276,7 @@ void CUI_InstEditor::update() {
 
     
     
-    // <Manu> Refrescamos la pantalla cuando cambia la línea -----------
+    // <Manu> Refrescamos la pantalla cuando cambia la línea ----------- [EN: refresh the screen when the line changes]
 
     if(!ztPlayer->playing) ie->last_cur_row = -1 ;
     else {

--- a/src/CUI_Loadscreen.cpp
+++ b/src/CUI_Loadscreen.cpp
@@ -58,7 +58,7 @@ extern std::atomic<int> is_loading;
 //
 void do_load(void) 
 {
-//  <Manu> Si la cancion está sonando la paramos --
+//  <Manu> Si la cancion está sonando la paramos -- [EN: if the song is playing, stop it]
   if(ztPlayer->playing) {
     
     ztPlayer->stop() ;
@@ -76,7 +76,7 @@ void do_load(void)
 //
 void filelist_onEnter(UserInterfaceElement *b)
 {
-//  <Manu> Desactivamos el requester de si estas loco; al cargar 
+//  <Manu> Desactivamos el requester de si estas loco; al cargar  [EN: disable the are-you-sure requester when loading]
 //         la cancion se comprueba si se esta playeando y la parara
   
 /*  if(ztPlayer->playing) {

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -121,7 +121,7 @@ void set_effect_data_msg(char *str, unsigned char effect, unsigned short int eff
 
   case 'B':
 
-    // <Manu> Nuevo comando B para hacer loops en la GBA; pintamos la informacion
+    // <Manu> Nuevo comando B para hacer loops en la GBA; pintamos la informacion [EN: new B command for GBA loops; we draw the info]
     sprintf(str,"Command: Write GBA loop marker to pattern %d when exporting MIDI", effect_data);
 
     break ;
@@ -279,7 +279,7 @@ char *printNote(char *str, event *r, int cur_edit_mode)
 #ifdef __AAAA5251785AAAA55AAA
 
 // ------------------------------------------------------------------------------------------------
-// <Manu> Debería mirar si puedo hacer esto de una manera un poco más limpia
+// <Manu> Debería mirar si puedo hacer esto de una manera un poco más limpia [EN: should look into doing this in a slightly cleaner way]
 //
 char *printBlankNote(char *str, int cur_edit_mode) 
 {
@@ -570,7 +570,7 @@ void disp_pattern(int tracks_shown, int field_size, int cols_shown, Drawable *S)
 {
   int num_displayed_rows, num_displayed_tracks, special ;
   TColor bg,fg;
-  static char str[2048] ;    // <Manu> Aumento esto de 512 a 2048 por si se utiliza una resolución muy grande. 512 debería servir para w=4096 pero...
+  static char str[2048] ;    // <Manu> Aumento esto de 512 a 2048 por si se utiliza una resolución muy grande. 512 debería servir para w=4096 pero... [EN: bumping this from 512 to 2048 in case a very high resolution is used. 512 should be enough for w=4096 but...]
   
   int posx_current_track ;
   int posy_current_row ;
@@ -610,7 +610,7 @@ void disp_pattern(int tracks_shown, int field_size, int cols_shown, Drawable *S)
 
 
 
-  // <Manu> Cumple alguna función dibujar este carácter?
+  // <Manu> Cumple alguna función dibujar este carácter? [EN: does drawing this character serve any purpose?]
   //printchar(col(4), row(TRACKS_ROW_Y), 139, COLORS.Lowlight,S);
 
   
@@ -624,7 +624,7 @@ void disp_pattern(int tracks_shown, int field_size, int cols_shown, Drawable *S)
   g_posx_tracks = poscharx_tracks ;
 
 
-  num_displayed_rows = 0 ; // <Manu> Esto va de 0 al número máximo de rows a dibujar - 1
+  num_displayed_rows = 0 ; // <Manu> Esto va de 0 al número máximo de rows a dibujar - 1 [EN: this goes from 0 to (max rows to draw) - 1]
   
   
   for(int var_row = first_row; var_row < (last_row + blank_rows); var_row++) {
@@ -645,7 +645,7 @@ void disp_pattern(int tracks_shown, int field_size, int cols_shown, Drawable *S)
     }
     else {
 
-      if(var_row >= 0) { // <Manu> ¿Necesario?
+      if(var_row >= 0) { // <Manu> ¿Necesario? [EN: needed?]
         
         sprintf(str,"%.3d",var_row);
       
@@ -724,11 +724,11 @@ void disp_pattern(int tracks_shown, int field_size, int cols_shown, Drawable *S)
 
               posx_current_track = col(poscharx_tracks) + col(num_displayed_tracks * (field_size + 1)) ;
 
-              // <Manu> Si esta línea hay que dibujarla en blanco dibujamos las columnas de los tracks con el color del fondo
+              // <Manu> Si esta línea hay que dibujarla en blanco dibujamos las columnas de los tracks con el color del fondo [EN: if this line should be drawn blank, draw the track columns with the background color]
 
               if(var_row >= first_blank_row) {
 
-                //fg = COLORS.EditText; // <Manu> Innecesario ?
+                //fg = COLORS.EditText; // <Manu> Innecesario ? [EN: unnecessary?]
                 //bg = COLORS.EditBG;
 
                 //printBlankNote(str, zt_config_globals.cur_edit_mode) ;
@@ -1009,7 +1009,7 @@ void CUI_Patterneditor::update()
 
 
 
-  // <Manu> Esto arregla el bug del último número de línea destacado cuando el play pasa por el pattern actual y sigue por otro.
+  // <Manu> Esto arregla el bug del último número de línea destacado cuando el play pasa por el pattern actual y sigue por otro. [EN: this fixes the highlighted last-line-number bug when playback passes through the current pattern and continues in another one]
   //        No es 100% perfecto por culpa del prebuffer, pero bueno...
 
   if(!ztPlayer->playing) last_cur_pattern = -1 ;
@@ -1026,7 +1026,7 @@ void CUI_Patterneditor::update()
   }
 
 
-  // <Manu> Esto arreglaba el bug de que no se refresque la pantalla al cambiar
+  // <Manu> Esto arreglaba el bug de que no se refresque la pantalla al cambiar [EN: this used to fix the bug where the screen wasn't refreshed on change]
   //        el número de filas del pattern actual, pero ya no es necesario :-)
   //
   //if(ztPlayer->song->patterns[cur_edit_pattern]->length != last_pattern_size) {
@@ -1388,7 +1388,7 @@ void CUI_Patterneditor::update()
           break;
 
         case SDLK_PAGEUP:
-          cur_edit_row_disp-= zt_config_globals.highlight_increment * 4 ;    // <Manu> ¿Esto no debería ser un múltiplo del step?
+          cur_edit_row_disp-= zt_config_globals.highlight_increment * 4 ;    // <Manu> ¿Esto no debería ser un múltiplo del step? [EN: shouldn't this be a multiple of step?]
           need_refresh++;
           break;
 
@@ -1514,7 +1514,7 @@ void CUI_Patterneditor::update()
                   break;
                   
                  
-                // <Manu> Clarifico esto un poco
+                // <Manu> Clarifico esto un poco [EN: clarifying this a bit]
                   
                 case SDLK_PAGEDOWN:
                   
@@ -1557,7 +1557,7 @@ void CUI_Patterneditor::update()
                         }
                         else{
                             
-                          // <Manu> if y else eran iguales ¿?
+                          // <Manu> if y else eran iguales ¿? [EN: if and else were identical?]
                           select_row_start = song->patterns[cur_edit_pattern]->length-1;
                         }
                       }
@@ -2902,7 +2902,7 @@ case SDLK_DELETE:
                         
                         ztPlayer->play_current_row();
                         
-                        // <Manu> Hacemos avanzar el cursor
+                        // <Manu> Hacemos avanzar el cursor [EN: advance the cursor]
                         
                         cur_edit_row+=cur_step;
             
@@ -3579,7 +3579,7 @@ void CUI_Patterneditor::draw(Drawable *S)
       
       // Update buffer if necessary
 
-      // <Manu> Esto nunca puede funcionar porque pe_buf es NULL
+      // <Manu> Esto nunca puede funcionar porque pe_buf es NULL [EN: this can never work because pe_buf is NULL]
 
       
       if(pe_modification) // pe_modification is a very very global var which is set to
@@ -3612,7 +3612,7 @@ void CUI_Patterneditor::draw(Drawable *S)
     
     if (m_Fullupd) {
 
-      // <Manu> Clarificar un poco esta fórmula, porque con row(52 se comía la última línea 
+      // <Manu> Clarificar un poco esta fórmula, porque con row(52 se comía la última línea  [EN: clarify this formula a bit — with row(52) it was eating the last line]
 
       screenmanager.Update(0, row(11), INTERNAL_RESOLUTION_X, row(53+((INTERNAL_RESOLUTION_Y-480)/8))) ;
     }

--- a/src/CUI_Playsong.cpp
+++ b/src/CUI_Playsong.cpp
@@ -22,11 +22,11 @@ CUI_Playsong::CUI_Playsong(void)
 
     clear = 0 ;
 
-    // <Manu> ¿Por qué 20?
+    // <Manu> ¿Por qué 20? [EN: why 20?]
     //p->y = 20 ;
     pattern_display->y = 14 ;
     
-    // <Manu> Control del número de líneas que se muestran mientras se reproduce una canción (30 por defecto)
+    // <Manu> Control del número de líneas que se muestran mientras se reproduce una canción (30 por defecto) [EN: controls how many lines are shown while a song is playing (default 30)]
     //p->ysize = 30 ;
 
     // Reserve 8 rows at the bottom: 7 for the 55px toolbar (ceil(55/8)) plus
@@ -203,9 +203,9 @@ void CUI_Playsong::draw(Drawable *S)
     
     if (clear > 0) {
       
-      // <Manu> cambio res
+      // <Manu> cambio res [EN: resolution change]
       //S->fillRect(0,row(15),INTERNAL_RESOLUTION_X,row(50)/*410*/,COLORS.Background);
-      S->fillRect(0, row(15), INTERNAL_RESOLUTION_X, INTERNAL_RESOLUTION_Y - (640 - row(50))/*410*/,COLORS.Background); // <Manu> Necesario?
+      S->fillRect(0, row(15), INTERNAL_RESOLUTION_X, INTERNAL_RESOLUTION_Y - (640 - row(50))/*410*/,COLORS.Background); // <Manu> Necesario? [EN: needed?]
 
       clear = 0 ;
     }

--- a/src/FileList.cpp
+++ b/src/FileList.cpp
@@ -390,7 +390,7 @@ void FileList::OnChange()
     AddFiles(".zt", COLORS.Data);
     AddFiles(".it", COLORS.Highlight);
     
-    // <Manu> Quiero que muestre tambien los .mid, asi que añado esta linea
+    // <Manu> Quiero que muestre tambien los .mid, asi que añado esta linea [EN: I want it to show .mid files too, so I'm adding this line]
     AddFiles(".mid", COLORS.Highlight);
     
     need_redraw++;

--- a/src/PatternDisplay.cpp
+++ b/src/PatternDisplay.cpp
@@ -10,7 +10,7 @@ PatternDisplay::PatternDisplay(void)
 {
     frame = new Frame;
     
-    // <Manu> Por defecto estaba a 0, pero yo quiero cur_pat_view a 1
+    // <Manu> Por defecto estaba a 0, pero yo quiero cur_pat_view a 1 [EN: default was 0, but I want cur_pat_view = 1]
     
     cur_pat_view = 1;
 
@@ -312,7 +312,7 @@ void PatternDisplay::update_frame(void)
 
     tracksize = 7;
     
-    // <Manu> Control del número de tracks que se muestran mientras se reproduce una canción (10 por defecto)
+    // <Manu> Control del número de tracks que se muestran mientras se reproduce una canción (10 por defecto) [EN: controls how many tracks are shown while a song is playing (default 10)]
     //tracks = 10;
     tracks = ((INTERNAL_RESOLUTION_X /*- LEFT_LINE_NUMBER_MARGIN*/) / (tracksize * FONT_SIZE_X)) - 1 ;
 
@@ -347,7 +347,7 @@ void PatternDisplay::disp_track_headers(Drawable *S)
 //    if (this->cur_pat_view >1) sprintf(str," Track %.2d ",num_track+1);
 //    else sprintf(str,"%.2d",num_track+1);
     
-    // <Manu> Cambio el codigo comentado por este switch
+    // <Manu> Cambio el codigo comentado por este switch [EN: replacing the commented-out code with this switch]
 
     switch(this->cur_pat_view)
     {

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -1388,7 +1388,7 @@ void VUPlay::draw(Drawable *S, int)
 //        for(i = 0; i < 17; str[i++] = '\0') ;
 //        for(i = 0; i < vol_len; str[i++] = '=');
         
-        // <Manu> Cambio estas dos lineas guarrisimas comentadas por estos dos fors()
+        // <Manu> Cambio estas dos lineas guarrisimas comentadas por estos dos fors() [EN: replacing those two filthy commented-out lines with these two for() loops]
        
         for(i = 0; i < 17; i++) {
         
@@ -1475,7 +1475,7 @@ latency[track].e.effect_data, latency[track].longevity);
         strcat(str," ");
         if(!measure) {
           
-          // <Manu> Sin cast daba un warning
+          // <Manu> Sin cast daba un warning [EN: without the cast it gave a warning]
           //measure = ((float)latency[track].init_vol - (float)((float)(1 - (float)((float)latency[track].init_vol * (float)((float)latency[track].longevity / (float)latency[track].init_longevity )))* (float)latency[track].init_vol) / 10);
             measure = (int) ((float)latency[track].init_vol - (float)((float)(1 - (float)((float)latency[track].init_vol * (float)((float)latency[track].longevity / (float)latency[track].init_longevity )))* (float)latency[track].init_vol) / 10);
             measure /= 100;

--- a/src/UserInterface.h
+++ b/src/UserInterface.h
@@ -395,7 +395,7 @@ class MidiOutDeviceOpener : public ListBox {
 
 
 
-#include "Sliders.h"  // <Manu> Un poco feo poner esto aqui, pero asi puedo ir separando en modulos esto
+#include "Sliders.h"  // <Manu> Un poco feo poner esto aqui, pero asi puedo ir separando en modulos esto [EN: a bit ugly to put this here, but it lets me start splitting this into modules]
 
 
 

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -222,7 +222,7 @@ ZTConf::ZTConf() {
     highlight_increment = 8;
     lowlight_increment = 8;
 
-    // <Manu> Por  defecto siempre tamaño 64!! ----------------
+    // <Manu> Por  defecto siempre tamaño 64!! ---------------- [EN: default is always size 64!]
 
     //    pattern_length = 128;
     pattern_length = 64;

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -334,7 +334,7 @@ void printBG(int x, int y, const char *str,TColor col, TColor bg, Drawable *S)
 
       for(j=0;j<8;j++) {
 
-        if (byte & 1) *buf = col;              // <Manu> Este if se puede sacar del for(;;) y hacer dos bucles en su lugar
+        if (byte & 1) *buf = col;              // <Manu> Este if se puede sacar del for(;;) y hacer dos bucles en su lugar [EN: this if could be hoisted out of the for(;;) and replaced with two loops]
         else *buf = bg;
         
         buf--;

--- a/src/import_export.cpp
+++ b/src/import_export.cpp
@@ -101,7 +101,7 @@ void push_varlen(CDataBuf *buf, unsigned int value)
 
 
 // ------------------------------------------------------------------------------------------------
-// <Manu> Creo esta funcion
+// <Manu> Creo esta funcion [EN: I'm creating this function]
 //
 void push_marker(CDataBuf *buf, unsigned char type, char *str, int len=-1) 
 {
@@ -255,7 +255,7 @@ int ZTImportExport::ExportMID(const char *fn, int format)
 
   // Put good stuff into the first MTrk
 
-//  <Manu> Elimino estos eventos que no sirven para nada
+//  <Manu> Elimino estos eventos que no sirven para nada [EN: removing these events that serve no purpose]
   
 //  mtrk[0].pushuc(0);  
 //  mtrk[0].pushuc(0xFF);
@@ -297,7 +297,7 @@ int ZTImportExport::ExportMID(const char *fn, int format)
     while((e = buf->get_next_event())) {
       
 
-      if(0 && e->type == ET_LOOP) {     // <Manu> Por ahora lo dejo asi para evitar problemas
+      if(0 && e->type == ET_LOOP) {     // <Manu> Por ahora lo dejo asi para evitar problemas [EN: leaving it like this for now to avoid issues]
       
         // ¿Esto no puede estar abajo porque no tiene nota?
       
@@ -305,7 +305,7 @@ int ZTImportExport::ExportMID(const char *fn, int format)
           // ------------------------------------------------------------------
           // ------------------------------------------------------------------
           
-//        case ET_LOOP: // <Manu> Exportamos el evento de loop ------------------
+//        case ET_LOOP: // <Manu> Exportamos el evento de loop [EN: export the loop event] ------------------ [EN: export the loop event]
           
           push_varlen(&mtrk[0], dtime[0]) ;     // Delta time
           dtime[0] = 0 ;
@@ -414,7 +414,7 @@ int ZTImportExport::ExportMID(const char *fn, int format)
           
         case ET_PITCH:
           
-          // <Manu> Añado llaves para que compile al poner el case de abajo ¿?
+          // <Manu> Añado llaves para que compile al poner el case de abajo ¿? [EN: adding braces so it compiles when the case below is added]
           
           { 
             unsigned short int usi ; 
@@ -823,7 +823,7 @@ int ZTImportExport::ExportPerTrackMID(const char *fn)
 
 /*
 
-// <Manu> BACKUP DE LA FUNCION DE ARRIBA
+// <Manu> BACKUP DE LA FUNCION DE ARRIBA [EN: backup of the function above]
 
 
 
@@ -981,7 +981,7 @@ int ZTImportExport::ExportMID(char *fn, int format) {
                         mp->pushuc((unsigned char)e->data1);
                         break;
                     case ET_PITCH:
-                      { // <Manu> Añado llaves para que compile al poner el case de abajo ¿?
+                      { // <Manu> Añado llaves para que compile al poner el case de abajo ¿? [EN: adding braces so it compiles when the case below is added]
                         unsigned short int usi = (unsigned short int)e->data1<<8; usi+=e->data2;
                         unsigned char d1,d2;
                         usi &= 0x3FFF;
@@ -992,7 +992,7 @@ int ZTImportExport::ExportMID(char *fn, int format) {
                         mp->pushuc(0xe0 + e->command);
                         mp->pushuc(d1);
                         mp->pushuc(d2);
-                      } // <Manu> Cierro la llave de arriba
+                      } // <Manu> Cierro la llave de arriba [EN: closing the brace from above]
                         break;
 
                     case ET_LOOP: // <Manu> Exportamos el evento de loop

--- a/src/lc_sdl_wrapper.cpp
+++ b/src/lc_sdl_wrapper.cpp
@@ -122,7 +122,7 @@
         dstrect.x = x;
         dstrect.y = y;
 
-        // <Manu> ?
+        // <Manu> ? [EN: ?]
         //dstrect.w = ? ;
         //dstrect.h = ? ;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -965,7 +965,7 @@ void update_status(Drawable *S)
 
       if (cur_edit_pattern == ztPlayer->playing_cur_pattern) {
 
-        //<Manu> Hecho as este bucle pintaba nmeros de lnea sin comprobar cuntas tena el pattern actual
+        //<Manu> Hecho as este bucle pintaba nmeros de lnea sin comprobar cuntas tena el pattern actual [EN: as written, this loop was drawing line numbers without checking how many the current pattern actually has]
 //        for(i = cur_edit_row_disp; i < (cur_edit_row_disp + PATTERN_EDIT_ROWS); i++) {
 
         //int max_row = song->patterns[cur_edit_pattern]->length ;
@@ -1733,7 +1733,7 @@ void global_keys(Drawable *S)
 
 
 
-// <Manu> Variables para saber si se van produciendo eventos de estos tipos
+// <Manu> Variables para saber si se van produciendo eventos de estos tipos [EN: variables that track whether these kinds of events are occurring]
 extern int mim_moredata ;
 extern int mim_error ;
 extern int mim_longerror ;
@@ -1747,7 +1747,7 @@ void redrawscreen(Drawable *S)
 {
   if(load_lock) return ;
 
-  // <Manu> header era 80 y he cambiado el texto del sprintf
+  // <Manu> header era 80 y he cambiado el texto del sprintf [EN: header was 80 and I changed the sprintf text]
 
   static char header[256];
   //  sprintf(header,"%s ||||| DEBUG: moredata = %d || error = %d || longerror = %d", ZTRACKER_VERSION, mim_moredata, mim_error, mim_longerror) ;
@@ -2052,7 +2052,7 @@ void setup_midi()
         sprintf(szKey,"alias_%s",tt);
         temp = Config->get(&szKey[0]);
 
-        // <Manu> Cuidado con esto....
+        // <Manu> Cuidado con esto... [EN: be careful with this]. [EN: be careful with this]
         if (MidiOut->outputDevices[j]->alias) {
             free(MidiOut->outputDevices[j]->alias);
             MidiOut->outputDevices[j]->alias = NULL;
@@ -3018,7 +3018,7 @@ int action(Screen *S)
             if (S->lock()==0) {
 
                 // Clean UI page background
-                // <Manu> Creo que este clean es mejorable y segn cmo redundante
+                // <Manu> Creo que este clean es mejorable y segn cmo redundante [EN: I think this clean can be improved and is somewhat redundant]
                 S->fillRect(col(1),row(12),INTERNAL_RESOLUTION_X-CHARACTER_SIZE_X,INTERNAL_RESOLUTION_Y - (480-424),/*0x00FF00*/COLORS.Background);
                 S->unlock();
 
@@ -3120,7 +3120,7 @@ int set_video_mode(int w, int h, char *errstr)
 
   if (!zt_backend_set_video_mode(errstr)) {
 
-    // <Manu> El mensaje de error estaba mal
+    // <Manu> El mensaje de error estaba mal [EN: the error message was wrong]
 
     //sprintf(errstr, "Couldn't set 640x480x32 video mode: %s\n", SDL_GetError());
     sprintf(errstr, "Couldn't set %dx%dx32 video mode: %s\n", INTERNAL_RESOLUTION_X, INTERNAL_RESOLUTION_Y, SDL_GetError());

--- a/src/midi-io.cpp
+++ b/src/midi-io.cpp
@@ -305,7 +305,7 @@ int g_midi_in_clocks_received = 0;
 
 
 
-// <Manu> Variables para saber si se van produciendo eventos de estos tipos
+// <Manu> Variables para saber si se van produciendo eventos de estos tipos [EN: variables that track whether these kinds of events are occurring]
 int mim_moredata = 0 ;
 int mim_error = 0 ;
 int mim_longerror = 0 ;

--- a/src/module.h
+++ b/src/module.h
@@ -130,7 +130,7 @@ public:
 
 public:
 
-  // <Manu> Flag que indica si el instrumento se ha utilizado en la última reproducción
+  // <Manu> Flag que indica si el instrumento se ha utilizado en la última reproducción [EN: flag indicating whether the instrument was used in the last playback]
   bool bHasBeenUsed ;
 
   signed char patch;

--- a/src/playback.cpp
+++ b/src/playback.cpp
@@ -462,7 +462,7 @@ int player::calc_pos(int midi_songpos, int *rowptr, int *orderptr) {
 
     int i,rowspassed,lastrowspassed,pat,row,order,found;
     
-    // <Manu> Por si acaso
+    // <Manu> Por si acaso [EN: just in case]
     row = 0 ;
     order = 0 ;
 
@@ -521,7 +521,7 @@ void player::prepare_play(int row, int pattern, int pm, int loopmode)
     patt_memory.tracks[t]->reset();
   }
 
-  // <Manu> A veces no entraba abajo?
+  // <Manu> A veces no entraba abajo? [EN: sometimes it didn't fall through to the block below?]
   while (!lock_mutex(song->hEditMutex)) {
   
     SDL_Delay(1) ;
@@ -606,7 +606,7 @@ void player::prepare_play(int row, int pattern, int pm, int loopmode)
 //
 void player::play(int row, int pattern,int pm, int loopmode)
 {
-// <Manu> esta comprobacion no es necesaria ?
+// <Manu> esta comprobacion no es necesaria ? [EN: is this check unnecessary?]
 
 /*    if (song->orderlist[pattern] == 0x100) 
         return;
@@ -680,7 +680,7 @@ void player::play_current_row()
         set_note = pEvent->note;
         set_note += song->instruments[pEvent->inst]->transpose; 
 
-        // <Manu> Transposición
+        // <Manu> Transposición [EN: transposition]
 
 
         if (set_note>0x7f) set_note = 0x7f;
@@ -1306,7 +1306,7 @@ void player::playback(midi_buf *buffer, int ticks)
                     break;
 
 
-                  case 'B': // <Manu> No se si hace falta poner aqui el evento de loop
+                  case 'B': // <Manu> No se si hace falta poner aqui el evento de loop [EN: not sure whether the loop event needs to be placed here]
 
                     {
                       //                                  buffer->insert(p_tick,ET_LOOP,0,0,evento->effect_data,0,t);

--- a/src/playback.h
+++ b/src/playback.h
@@ -59,7 +59,7 @@ enum Emeventtypes {
     ET_PATT,
     ET_PITCH,
     ET_MSTART,
-    ET_LOOP                   // <Manu> definimos el evento de loop
+    ET_LOOP                   // <Manu> definimos el evento de loop [EN: define the loop event]
 };
 
 struct midi_event {

--- a/src/zt.h
+++ b/src/zt.h
@@ -37,7 +37,7 @@
 #include <atomic>
 
 
-// <Manu> Pequeño parche mientras miro qué hago con el main
+// <Manu> Pequeño parche mientras miro qué hago con el main [EN: small patch while I figure out what to do with main]
 // Define SDL_MAIN_HANDLED across every translation unit that includes zt.h
 // so <SDL_main.h> (pulled in only from main.cpp) is the single place that
 // emits the platform entry point (WinMain on Windows, main() elsewhere).
@@ -86,7 +86,7 @@ static inline void zt_text_input_stop(void) {
 
 //#define VER_MAJ 0
 
-// <Manu> antes era 98
+// <Manu> antes era 98 [EN: was 98 before]
 //#define VER_MIN 986
 
 // Version string is the build date (YYYY_MM_DD) injected by CMake at configure time.
@@ -262,7 +262,7 @@ public:
 
     void setDefaultColors() {
 
-        // <Manu> El color del Scream Tracker era ligeramente distinto
+        // <Manu> El color del Scream Tracker era ligeramente distinto [EN: Scream Tracker's color was slightly different]
         //Background =     getColor(0xA4,0x90,0x54);
         Background =     getColor(0xA1,0x91,0x55);
         //Background =     getColor(0x7F,0x00,0x00);

--- a/src/ztfile-io.cpp
+++ b/src/ztfile-io.cpp
@@ -1028,7 +1028,7 @@ void instrument::load(CDataBuf *buf)
     
     this->midi_device = buf->getuch();
 
-    // <Manu> Aqui es donde se puede hacer un parche que ponga el primer dispositivo
+    // <Manu> Aqui es donde se puede hacer un parche que ponga el primer dispositivo [EN: this is where a patch could pick the first device]
     //        MIDI que este abierto en los instrumentos que quieran usar uno que
     //        no este disponible
     


### PR DESCRIPTION
## Summary

Walking through the codebase as a non-Spanish reader, dozens of inline `<Manu>` comments are easy to miss because the surrounding code is English. Keep the Spanish (it's the original author's voice and useful when comparing against older diffs) and append an English gloss in `[EN: ...]` right after, on the same line. No comment text is removed.

Touches comments only — no behavior change.

19 files, 59 lines updated.

## Test plan

- [ ] No build/runtime change expected — just verify the project still compiles (it does locally)