### PR TITLE
Global Config: configurable Post-Load destination page (F2 / F3 / F11)

### DIFF
--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -146,6 +146,19 @@ CUI_Config::CUI_Config(void) {
     cb->xsize = 5;
     cb->value = &zt_config_globals.midi_in_sync_chase_tempo;
 
+    // Post-Load Page: where to land after a successful song load.
+    // Slider with an inline label name (Inst/Pattern/Songconf) drawn
+    // by draw() — same idiom as View Mode above.
+    vs = new ValueSlider;
+    UI->add_element(vs, 13);
+    vs->x = 20;
+    vs->y = 27;
+    vs->xsize = 15;
+    vs->ysize = 1;
+    vs->value = zt_config_globals.post_load_page;
+    vs->min = 0;
+    vs->max = POST_LOAD_PAGE_COUNT - 1;
+
     b = new Button;
     UI->add_element(b,10);
     b->caption = "   Go to page 1   ";   // symmetric with Sysconfig's "Go to page 2" button (same x, y, xsize)
@@ -265,6 +278,11 @@ void CUI_Config::update() {
         zt_config_globals.pattern_length = vs->value;
     }
 
+    vs = (ValueSlider *)UI->get_element(13);
+    if (vs && vs->value != zt_config_globals.post_load_page) {
+        zt_config_globals.post_load_page = vs->value;
+    }
+
     ti = (TextInput *)UI->get_element(1);
     if (ti && ti->changed) {
         strncpy(zt_config_globals.autoload_ztfile_filename, (char *)ti->str, sizeof(zt_config_globals.autoload_ztfile_filename) - 1);
@@ -315,6 +333,14 @@ void CUI_Config::draw(Drawable *S) {
         sprintf(buf+strlen(buf),"\n|U| Send Panic      |L|[|H|%s|L|]",zt_config_globals.auto_send_panic?"On":"Off");
         sprintf(buf+strlen(buf),"\n|U| MIDI In Sync    |L|[|H|%s|L|]",zt_config_globals.midi_in_sync?"On":"Off");
         sprintf(buf+strlen(buf),"\n|U| Chase MIDI Tempo|L|[|H|%s|L|]",zt_config_globals.midi_in_sync_chase_tempo?"On":"Off");
+        const char *post_load_name = "Inst Editor";
+        switch (zt_config_globals.post_load_page) {
+            case POST_LOAD_PATTERN_EDIT: post_load_name = "Pattern Edit"; break;
+            case POST_LOAD_SONG_CONFIG:  post_load_name = "Song Config";  break;
+            case POST_LOAD_INST_EDIT:
+            default:                     post_load_name = "Inst Editor";  break;
+        }
+        sprintf(buf+strlen(buf),"\n|U| Post-Load Page  |L|[|H|%s|L|]",post_load_name);
         sprintf(buf+strlen(buf),"\n|U| Step Editing    |L|[|H|%s|L|]",zt_config_globals.step_editing?"On":"Off");
         sprintf(buf+strlen(buf),"\n|U| Centered Edit   |L|[|H|%s|L|]",zt_config_globals.centered_editing?"On":"Off");
         sprintf(buf+strlen(buf),"\n|U| Screen Size     |L|[|H|%dx%d|L|]",zt_config_globals.screen_width, zt_config_globals.screen_height);
@@ -364,6 +390,25 @@ void CUI_Config::draw(Drawable *S) {
             }
         }
 #endif
+        // Inline label for the Post-Load Page slider (mirrors the View
+        // Mode pattern above — slider value alone reads as 0/1/2 which
+        // is meaningless to the user without the page name beside it).
+        {
+            ValueSlider *vs = (ValueSlider *)UI->get_element(13);
+            if (vs) {
+                const char *post_load_name = "Inst Editor";
+                switch (zt_config_globals.post_load_page) {
+                    case POST_LOAD_PATTERN_EDIT: post_load_name = "Pattern Edit"; break;
+                    case POST_LOAD_SONG_CONFIG:  post_load_name = "Song Config";  break;
+                    case POST_LOAD_INST_EDIT:
+                    default:                     post_load_name = "Inst Editor";  break;
+                }
+                char label[20];
+                snprintf(label, sizeof(label), " %-12s", post_load_name);
+                printBG(col(vs->x + vs->xsize), row(vs->y), "             ", COLORS.Text, COLORS.Background, S);
+                printBG(col(vs->x + vs->xsize), row(vs->y), label, COLORS.Text, COLORS.Background, S);
+            }
+        }
         draw_status(S);
         status(S);
         printtitle(PAGE_TITLE_ROW_Y,"Global Configuration (Ctrl+F12)",COLORS.Text,COLORS.Background,S);
@@ -380,6 +425,7 @@ void CUI_Config::draw(Drawable *S) {
         print(row(2),col(24),"Default Pat Len",COLORS.Text,S);
         print(row(2),col(25),"MIDI In Sync",COLORS.Text,S);
         print(row(2),col(26),"Chase MIDI Tempo",COLORS.Text,S);
+        print(row(2),col(27),"Post-Load Page",COLORS.Text,S);
 //        print(row(2),col(25)," .ZT directory",COLORS.Text,S);
 
         //printtitle(32,"Current Global Settings",COLORS.Text,COLORS.Background,S);

--- a/src/CUI_LoadMsg.cpp
+++ b/src/CUI_LoadMsg.cpp
@@ -133,9 +133,17 @@ void CUI_LoadMsg::update() {
         fixmouse++;
         need_refresh++;
         load_finished = 0;
-        // After a successful load, jump to the Instrument Editor (F3) so
-        // the user can immediately see and edit the imported instruments.
-        switch_page(UIP_InstEditor);
+        // Jump to the user-configured post-load destination (Global Config
+        // > Post-Load Page). Default is Instrument Editor (F3), matching
+        // the long-standing behaviour. Pattern Editor (F2) suits arrangers
+        // who want to start writing notes; Song Configuration (F11) suits
+        // people who want to verify BPM/TPB/order list before anything else.
+        switch (zt_config_globals.post_load_page) {
+            case POST_LOAD_PATTERN_EDIT: switch_page(UIP_Patterneditor); break;
+            case POST_LOAD_SONG_CONFIG:  switch_page(UIP_Songconfig);    break;
+            case POST_LOAD_INST_EDIT:
+            default:                     switch_page(UIP_InstEditor);   break;
+        }
     }
 }
 void CUI_LoadMsg::draw(Drawable *S)

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -252,6 +252,7 @@ ZTConf::ZTConf() {
     control_navigation_amount = 2;
     default_directory[0] = '\0';
     record_velocity = 1;
+    post_load_page = POST_LOAD_INST_EDIT;
 }
 
 ZTConf::~ZTConf() {
@@ -298,6 +299,11 @@ int ZTConf::load()
   if(Config->get("default_highlight_increment"))      highlight_increment = atoi(Config->get("default_highlight_increment"));
   if(Config->get("default_lowlight_increment"))       lowlight_increment = atoi(Config->get("default_lowlight_increment"));
   if(Config->get("default_view_mode"))                cur_edit_mode = atoi(Config->get("default_view_mode"));
+  if(Config->get("post_load_page")) {
+      post_load_page = atoi(Config->get("post_load_page"));
+      if (post_load_page < 0 || post_load_page >= POST_LOAD_PAGE_COUNT)
+          post_load_page = POST_LOAD_INST_EDIT;
+  }
   
   ////////////////////////////////////////////////
   
@@ -388,6 +394,9 @@ int ZTConf::save() {
     Config->set("prebuffer_rows", s);
     sprintf(s, "%d", cur_edit_mode);
     Config->set("default_view_mode", s);
+
+    sprintf(s, "%d", post_load_page);
+    Config->set("post_load_page", s);
 
     Config->set("skin", skin);
 

--- a/src/conf.h
+++ b/src/conf.h
@@ -11,6 +11,13 @@
 
 enum E_edit_viewmode { VIEW_SQUISH, VIEW_REGULAR, VIEW_FX, VIEW_BIG }; //, VIEW_EXTEND };
 
+// Where to land after a successful song load. Default is Instrument
+// Editor (F3) — matches the long-standing behaviour. Pattern Editor
+// (F2) suits arrangers who go straight to writing notes; Song Config
+// (F11) suits people who want to verify BPM/TPB/order list first.
+enum E_post_load_page { POST_LOAD_INST_EDIT = 0, POST_LOAD_PATTERN_EDIT, POST_LOAD_SONG_CONFIG };
+#define POST_LOAD_PAGE_COUNT 3
+
 
 //  New class ZTConf puts all global variables in one place
 //  with convenient high level functions to handle I/O
@@ -80,6 +87,7 @@ class ZTConf {
         int control_navigation_amount;
         char default_directory[MAX_PATH + 1];
         int record_velocity;
+        int post_load_page;        // E_post_load_page — page to switch to after a successful load
         char window_icon[MAX_PATH + 1];
 };
 


### PR DESCRIPTION
## Summary

Addresses Manu's suggestion: *"Maybe we could have an option to select the place where the program should go after loading a file and give the user the option to go to the pattern editor too."*

Adds a new Global Config setting (Ctrl+F12, row 27) **Post-Load Page** with three choices:

| Value | Lands on | Suits |
|------:|----------|-------|
| 0 | Instrument Editor (F3) | default — matches today's behaviour |
| 1 | Pattern Editor (F2)    | arrangers who go straight to writing notes |
| 2 | Song Configuration (F11) | users who verify BPM / TPB / order list first |

## Implementation

- New field `int post_load_page` on `ZTConf` plus `enum E_post_load_page` in `conf.h`.
- Persists to `zt.conf` as `post_load_page=N`, default 0, range-clamped on load so a stale or hand-edited value falls back to the safe default.
- `CUI_LoadMsg::update` — the `load_finished` branch — switches via `zt_config_globals.post_load_page` instead of the hardcoded `switch_page(UIP_InstEditor)`.
- UI on Global Config (Ctrl+F12 page 2) is a 0..2 slider with an inline label name drawn beside it, mirroring the existing View Mode slider idiom.

## Files

- `src/conf.h`, `src/conf.cpp` — config field, enum, load/save
- `src/CUI_LoadMsg.cpp` — dispatch switch
- `src/CUI_Config.cpp` — slider, value capture, label readout

4 files, +74 / -3.

## Test plan

- [ ] Open Ctrl+F12, scroll to Post-Load Page, set to 1 (Pattern Edit), save (Ctrl+S)
- [ ] Ctrl+L, load a song → lands on F2 instead of F3
- [ ] Restart, confirm value persisted
- [ ] Try value 2 (Song Config) → lands on F11 after load
- [ ] Set back to 0 (Inst Editor) → matches old default behaviour
- [ ] Hand-edit `zt.conf` to `post_load_page=99`, restart → falls back to 0 silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)