### PR TITLE
Hotfixes: ESC handling, shortcut format, playhead consistency, page-layout polish

### DIFF
--- a/build-mac.sh
+++ b/build-mac.sh
@@ -87,6 +87,13 @@ EOF
   exit 1
 fi
 
+# zlib/libpng are vendored under extlibs/, so we don't need (and don't want)
+# any inherited LDFLAGS/CPPFLAGS pointing at /usr/local/opt/* (Intel-Homebrew
+# leftovers on Apple Silicon machines). Clearing them avoids the
+#   ld: warning: search path '/usr/local/opt/zlib/lib' not found
+# warning during link.
+unset LDFLAGS CPPFLAGS
+
 configure_args=(
   -S "$script_dir"
   -B "$build_dir"

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -5,7 +5,7 @@
  Home/End    : Just try them
  PgUp/PgDn   : Up/down 16 rows
  Ins/Del     : Insert/delete row on current track
-              Hold CTRL for ALL tracks
+               Hold CTRL for ALL tracks
 
  Tab         : Next track
  SHIFT-TAB   : Previous track
@@ -27,11 +27,11 @@
  SHIFT-,     : Select previous instrument.
  SHIFT-.     : Select next instrument.
  SHIFT-~     : Switch between regular and effect-draw mode
-              Use TAB here to switch edit mode
+               Use TAB here to switch edit mode
 
  CTRL-1 => 0 : Change the step-value in the pattern editor
  ALT-`       : Set previous note's length to distance between
-              note and current cursor position
+               note and current cursor position
  ScrollLock  : Follow playback toggle (cursor follows playback position)
 
 |L|%==|H|Pattern Operations|L|==%|U|
@@ -52,27 +52,27 @@
  CTRL-B : Marks the beginning of a select block.
  CTRL-E : Marks the end of a select block.
  CTRL-L : Select whole track, pressing it again will select the entire
-              pattern.
+          pattern.
  CTRL-U : Unselect block
  ALT-D  : Select one beat (press multiple times to select next beats)
 
  CTRL-C : Copy the selected block to the clipboard.
  CTRL-P : Copy pattern, paste to next empty pattern,
-              and jump to new pattern
+          and jump to new pattern
  CTRL-V : Paste the contents of the clipboard to the cursor location.
  CTRL-O : Overwrite paste
  CTRL-M : Merge paste the contents of the clipboard with the contents
-              of the location you're pasting to.
+          of the location you're pasting to.
  CTRL-X : Cut the selected block. (remove and copy to clipboard)
  CTRL-Z : Clear block (hold this one)
 
  CTRL-N : Set length of first row of block to length of block
  CTRL-W : Clear unused volumes
  CTRL-I : Interpolate values through selection (note, vol, or fx param,
-              depending on which column the cursor is on; falls back to
-              effect-data interpolation when no selection column applies)
+          depending on which column the cursor is on; falls back to
+          effect-data interpolation when no selection column applies)
  CTRL-T : Set all effect and effect data fields of block to same
-              value as first row in block
+          value as first row in block
  CTRL-K : Interpolate volume (block)
  ALT-Q  : Transpose block up
  ALT-A  : Transpose block down
@@ -81,8 +81,8 @@
  CTRL-[ : Decrease all volumes in block by 8
  CTRL-] : Increase all volumes in block by 8
  CTRL-` : Set all note's lengths in selection to distance
-              between note and next note
- ALT-S  : Set instruments in block to current instrument
+          between note and next note
+ ALT-S      : Set instruments in block to current instrument
  SHIFT-move : Block selection (movements are arrows and PgUp/PgDn)
 
 
@@ -104,21 +104,21 @@
 
  F1             : Help (That is this text)
  F2             : Pattern editor - Pressing F2 again while in the pattern
-              editing screen brings up the pattern settings.
+                  editing screen brings up the pattern settings.
  F3             : Instrument editor
  F4             : Arpeggio editor
  CTRL-M         : Midimacro editor (works everywhere; SHIFT-F4 also works
-              on systems where F-keys are not eaten by the OS)
+                  on systems where F-keys are not eaten by the OS)
  CTRL-SHIFT-M   : Quick MIDI export of current song
  F10            : Song message editor
  F5             : Song play (F5 PatternDisplay widget,
-              left-right/space/alt-1 thru alt-0/alt-f9/alt-f10)
+                  left-right/space/alt-1 thru alt-0/alt-f9/alt-f10)
  F6             : Pattern Play - will play the current pattern being edited.
  F7             : Start the song at the current row -
-              If in the pattern edit mode, F7 will start at the current
-              row, at the first instance of the pattern in the pattern
-              order.  If in the pattern order screen, F7 will start the
-              song at the cursor position (by pattern).
+                  If in the pattern edit mode, F7 will start at the current
+                  row, at the first instance of the pattern in the pattern
+                  order.  If in the pattern order screen, F7 will start the
+                  song at the cursor position (by pattern).
  SHIFT-F11      : Set current order
  SHIFT-F7       : Play song from the current order
  F8             : Stop playback
@@ -139,17 +139,16 @@
 
  Up/Down   : Cycles through widgets
  TAB       : Cycles forwards through widgets
-              (in Help: jumps to next section)
+             (in Help: jumps to next section)
  SHIFT-TAB : Cycles backwards through widgets
-              (in Help: jumps to previous section)
+             (in Help: jumps to previous section)
  ENTER     : Confirms choice
  SPACE     : Toggles an option or clicks a button
 
  Sliders   : If you hold CTRL while using LEFT/RIGHT the slider will move in
-              bigger steps
+             bigger steps
  Listboxes : Up/Down scroll, Space toggles select-items in a list box
  Popups    : ESC closes, all other UI keys apply
-
 
 |L|%==|H|Effects|L|==%|U|
 
@@ -157,7 +156,7 @@
  B  00 : Set "[" in the midi file.
  B  01 : Set "]" in the midi file.
  Cxxxx : Pattern break - setting the C marker denotes the end of a
-              pattern.  ex: C0000 will skip to the next pattern, row 0
+         pattern.  ex: C0000 will skip to the next pattern, row 0
  D..xx : Delay note/volume/cut - by xxxx sub-ticks.
  Exxxx : Pitch slide down, E0000 will repeat the last portamento command.
  Fxxxx : Pitch slide up, F0000 will repeat the last portamento down command.
@@ -165,15 +164,14 @@
  Q..xx : Retrig note every xx subticks
  R..xx : Start arpeggio xx.  R0000 will continue the last arpeggio
  Sxxyy : xx is the CC (Continuous Controller) number, yy is the value (0-80).
-              ex. S0142 will set CC #01 (Mod Wheel) to a value of 42.
-              >=80 sends last value
+         ex. S0142 will set CC #01 (Mod Wheel) to a value of 42.
+         >=80 sends last value
  T..xx : Set tempo to xx bpm
  Wxxxx : Absolute pitch set, between 0 and 3FFF, 2000 is no pitch change,
-              0 is max down, 3FFF is max up
+         0 is max down, 3FFF is max up
  X..xx : Set panning, 00=left, 40=center, 7F=right
  Zxxyy : Send midimacro xx with parameter yy.  00 repeats the last used
-              value
-
+         value
 
 |L|%==|H|Troubleshooting|L|==%|U|
 
@@ -183,7 +181,6 @@
    A: If you have any other applications open, try closing them.  If this
  	   doesn't work, perhaps you're drunk.  If drunk, fall down.  end if.
 
-
  Display issues:
 
    Q: The screen is beige/gray and is displaying  "This unit is in accordance
@@ -191,14 +188,12 @@
    A: You are looking at the back of the monitor.  For best results, look at
       the front, or "screen" of your monitor.
 
-
    Q: The screen is black and zTracker is not responding to any key/mouse
       commands.
    A: Your computer is not turned on.  Press the "power" switch on the front
       of the housing and follow the resulting prompts.  You may also want to
       gently pat the front of your pants using two outstretched fingers, to
       ensure that you haven't wet yourself.
-
 
    Q: The screen is displaying a small cyan and red airplane on what appears
       to be an airfield surrounded by buildings.  Occasionally, a small red
@@ -209,49 +204,42 @@
       of your plane by pressing the "," and "/" keys.  The "." key will cause
       your plane to invert - up is down, and down is up - watch out!
 
-
 |L|%==|H|The Merits of zTracker|L|==%|U|
 
-
-  	Congratulations on your decision to use zTracker, the champagne of midi
+ Congratulations on your decision to use zTracker, the champagne of midi
  sequencers.  Simply by choosing to employ zTracker as your personal midi
  geisha, you've now moved yourself one notch further from "idiot" and
  closer to "ultra-smartass".  (Refer to fig 1.1)  However, the fact that
  you're reading the help file kicks you back one notch towards "idiot".  A
  pointless exercise or a profound metaphor for our existence?  Only
  continued use will tell - but if the rash persists, discontinue use
- immediately.  Otherwise:
+ immediately. Otherwise:
 
- 	You, like the zTracker development team, [see fig 1.2] feel that
+ You, like the zTracker development team, [see fig 1.2] feel that
  trackers are simply the best way to exert precise, megalomaniacal control
  over sound.  But you're addicted to the high-fidelity, knob twiddling,
  credit-card-maxed-out world of professional MIDI equipment.  Is there
  some common ground where these two worlds meet, an interdimensional
  portal sort of like the moongates first seen in Ultima IV? [see fig 1.3]
 
+ The answer is yes.  The answer is also zTracker.
 
- 	The answer is yes.  The answer is also zTracker.
+ To sum up: yes, zTracker.
 
- 	To sum up: yes, zTracker.
-
-
- 	In the past, those who exhibited proficiency with
+ In the past, those who exhibited proficiency with
  light-and-switch-adorned gadgetry coupled with the need for complete
  control of as many elements as possible were limited to careers in the
  already saturated mad science and evil genius fields.
 
+ Until zTracker.
 
- 	Until zTracker.
-
-
- 	In these volatile times of sugarfree sugar and piano-playing robots,
+ In these volatile times of sugarfree sugar and piano-playing robots,
  many people are changing careers as many as twelve times during their
  lifetime. An exciting career in the lucrative and burgeoning field of
  musicianship awaits you!  Are you ready to meet the challenge?  Then join
  in the cry:
 
- 	zTracker : it is a midi tracker for writing music!
-
+ zTracker : it is a midi tracker for writing music!
 
 |L|%==|H|Documentation Credits|L|==%|U|
 
@@ -260,4 +248,3 @@
    * Quasimojo/Chill
    * Opaque Fear
    * Daniel Kahlin
-

--- a/src/CUI_About.cpp
+++ b/src/CUI_About.cpp
@@ -36,7 +36,7 @@ CUI_About::CUI_About(void) {
     // Height: 75% of the available room, plus 1 extra row so the bottom
     // sits 2 rows lower than the previous setting (top moved down 1,
     // bottom moved down 2 → size grows by 1).
-    int box_size = ((max_end_row - box_top) * 75) / 100 + 5;
+    int box_size = ((max_end_row - box_top) * 75) / 100 + 8;
     if (box_size < 6) box_size = 6;
     l->y     = box_top;
     l->ysize = box_size;

--- a/src/CUI_About.cpp
+++ b/src/CUI_About.cpp
@@ -36,7 +36,7 @@ CUI_About::CUI_About(void) {
     // Height: 75% of the available room, plus 1 extra row so the bottom
     // sits 2 rows lower than the previous setting (top moved down 1,
     // bottom moved down 2 → size grows by 1).
-    int box_size = ((max_end_row - box_top) * 75) / 100 + 8;
+    int box_size = ((max_end_row - box_top) * 75) / 100 + 9;
     if (box_size < 6) box_size = 6;
     l->y     = box_top;
     l->ysize = box_size;

--- a/src/CUI_About.cpp
+++ b/src/CUI_About.cpp
@@ -36,7 +36,7 @@ CUI_About::CUI_About(void) {
     // Height: 75% of the available room, plus 1 extra row so the bottom
     // sits 2 rows lower than the previous setting (top moved down 1,
     // bottom moved down 2 → size grows by 1).
-    int box_size = ((max_end_row - box_top) * 75) / 100 + 9;
+    int box_size = ((max_end_row - box_top) * 75) / 100 + 5;
     if (box_size < 6) box_size = 6;
     l->y     = box_top;
     l->ysize = box_size;
@@ -122,7 +122,10 @@ void CUI_About::leave(void) {
 void CUI_About::update() {
     UI->update();
     if (Keys.size()) {
-        Keys.getkey();
+        int key = Keys.getkey();
+        if (key == SDLK_ESCAPE) {
+            switch_page(UIP_Patterneditor);
+        }
     }
     //need_refresh++;
 }

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -140,18 +140,21 @@ CUI_Config::CUI_Config(void) {
     // zt.conf but were previously only reachable via the Sysconfig page;
     // expose them here so Global Config (F12) covers the full config set.
     cb = new CheckBox;
-    UI->add_element(cb, 11);
+    UI->add_element(cb, 9);
     cb->frame = 1;
     cb->x = 20;
     cb->y = 24;
     cb->xsize = 5;
     cb->value = &zt_config_globals.midi_in_sync;
 
+    // Pair Chase MIDI Tempo on the same row as MIDI In Sync. "MIDI In
+    // Sync" label = 12 cols, slider at x=20 ends at col 25 (chip 3).
+    // Place "Chase MIDI Tempo" label at col 28, checkbox at x=46.
     cb = new CheckBox;
-    UI->add_element(cb, 12);
+    UI->add_element(cb, 10);
     cb->frame = 1;
-    cb->x = 20;
-    cb->y = 25;
+    cb->x = 46;
+    cb->y = 24;
     cb->xsize = 5;
     cb->value = &zt_config_globals.midi_in_sync_chase_tempo;
 
@@ -159,9 +162,9 @@ CUI_Config::CUI_Config(void) {
     // Slider with an inline label name (Inst/Pattern/Songconf) drawn
     // by draw() — same idiom as View Mode above.
     vs = new ValueSlider;
-    UI->add_element(vs, 13);
+    UI->add_element(vs, 11);
     vs->x = 20;
-    vs->y = 26;
+    vs->y = 25;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.post_load_page;
@@ -169,7 +172,10 @@ CUI_Config::CUI_Config(void) {
     vs->max = POST_LOAD_PAGE_COUNT - 1;
 
     b = new Button;
-    UI->add_element(b,10);
+    // Tab order: Page-switch button is the LAST element so DOWN-arrow
+    // from the bottom of the config list wraps cleanly back to Autoload
+    // .ZT (tabindex 0) instead of jumping past the MIDI rows.
+    UI->add_element(b,12);
     b->caption = "   Go to page 1   ";   // symmetric with Sysconfig's "Go to page 2" button (same x, y, xsize)
     b->xsize = 18;
     b->x = 2;
@@ -287,7 +293,7 @@ void CUI_Config::update() {
         zt_config_globals.pattern_length = vs->value;
     }
 
-    vs = (ValueSlider *)UI->get_element(13);
+    vs = (ValueSlider *)UI->get_element(11);
     if (vs && vs->value != zt_config_globals.post_load_page) {
         zt_config_globals.post_load_page = vs->value;
     }
@@ -403,7 +409,7 @@ void CUI_Config::draw(Drawable *S) {
         // Mode pattern above — slider value alone reads as 0/1/2 which
         // is meaningless to the user without the page name beside it).
         {
-            ValueSlider *vs = (ValueSlider *)UI->get_element(13);
+            ValueSlider *vs = (ValueSlider *)UI->get_element(11);
             if (vs) {
                 const char *post_load_name = "Inst Editor";
                 switch (zt_config_globals.post_load_page) {
@@ -433,8 +439,8 @@ void CUI_Config::draw(Drawable *S) {
         print(row(40),col(21),"Row highlight major",COLORS.Text,S);
         print(row(2),col(23),"Default Pat Len",COLORS.Text,S);
         print(row(2),col(24),"MIDI In Sync",COLORS.Text,S);
-        print(row(2),col(25),"Chase MIDI Tempo",COLORS.Text,S);
-        print(row(2),col(26),"Post-Load Page",COLORS.Text,S);
+        print(row(28),col(24),"Chase MIDI Tempo",COLORS.Text,S);
+        print(row(2),col(25),"Post-Load Page",COLORS.Text,S);
 //        print(row(2),col(25)," .ZT directory",COLORS.Text,S);
 
         //printtitle(32,"Current Global Settings",COLORS.Text,COLORS.Background,S);

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -45,9 +45,11 @@ CUI_Config::CUI_Config(void) {
     ti = new TextInput;
     UI->add_element(ti,1);
     ti->frame = 1;
-    ti->x = 20;
-    ti->y = 15;
-    ti->xsize = 50;
+    // Sit on the same row as the Autoload .ZT checkbox, to the right of
+    // the "Autoload File" label that draws at col 28 (label is 13 cols).
+    ti->x = 42;
+    ti->y = 14;
+    ti->xsize = 30;
     ti->length = 50;
     ti->str = (unsigned char*)zt_config_globals.autoload_ztfile_filename;
 
@@ -109,8 +111,10 @@ CUI_Config::CUI_Config(void) {
 
     vs = new ValueSlider;
     UI->add_element(vs,7);
-    vs->x = 20;
-    vs->y = 23;
+    // Pair with the highlight slider on the same row; "Default Lowlight"
+    // label draws at col 38 (16 chars), slider sits to its right.
+    vs->x = 56;
+    vs->y = 22;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.lowlight_increment;
@@ -413,7 +417,7 @@ void CUI_Config::draw(Drawable *S) {
         status(S);
         printtitle(PAGE_TITLE_ROW_Y,"Global Configuration (Ctrl+F12)",COLORS.Text,COLORS.Background,S);
         print(row(2),col(14),"Autoload .ZT",COLORS.Text,S);
-        print(row(2),col(15),"Autoload File",COLORS.Text,S);
+        print(row(28),col(14),"Autoload File",COLORS.Text,S);
         print(row(2),col(17),"Default Dir",COLORS.Text,S);
         print(row(2),col(19),"Record Velocity",COLORS.Text,S);
         print(row(2),col(20),"Autosave (sec)",COLORS.Text,S);
@@ -421,7 +425,7 @@ void CUI_Config::draw(Drawable *S) {
         print(row(2),col(21),"Default View",COLORS.Text,S);
 #endif
         print(row(2),col(22),"Default Highlight",COLORS.Text,S);
-        print(row(2),col(23),"Default Lowlight",COLORS.Text,S);
+        print(row(38),col(22),"Default Lowlight",COLORS.Text,S);
         print(row(2),col(24),"Default Pat Len",COLORS.Text,S);
         print(row(2),col(25),"MIDI In Sync",COLORS.Text,S);
         print(row(2),col(26),"Chase MIDI Tempo",COLORS.Text,S);

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -39,7 +39,7 @@ CUI_Config::CUI_Config(void) {
     cb->y = 14;
     cb->xsize = 3;
     cb->value = &zt_config_globals.autoload_ztfile;
-    cb->frame = 1;
+    cb->frame = 0;
 
     ti = new TextInput;
     UI->add_element(ti,1);
@@ -67,12 +67,14 @@ CUI_Config::CUI_Config(void) {
     cb->y = 18;
     cb->xsize = 3;
     cb->value = &zt_config_globals.record_velocity;
-    cb->frame = 1;
+    cb->frame = 0;
 
+    // Autosave (sec) shares row 18 with Record Velocity to the right of
+    // its checkbox.
     vs = new ValueSlider;
     UI->add_element(vs,4);
-    vs->x = 20;
-    vs->y = 19;
+    vs->x = 40;
+    vs->y = 18;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.autosave_interval_seconds;
@@ -266,6 +268,14 @@ void CUI_Config::update() {
             }
             pclose(p);
         }
+        // Pump SDL events + flush queued keys so the Enter the user
+        // pressed inside the Finder dialog (and any keystrokes that
+        // landed in zTracker's window while it was unfocused) don't
+        // leak through and re-open the picker on the next update().
+        SDL_PumpEvents();
+        SDL_FlushEvent(SDL_EVENT_KEY_DOWN);
+        SDL_FlushEvent(SDL_EVENT_KEY_UP);
+        Keys.flush();
     }
 #endif
     UI->update();
@@ -439,7 +449,9 @@ void CUI_Config::draw(Drawable *S) {
         print(row(28),col(14),"Autoload File",COLORS.Text,S);
         print(row(8),col(16),"Default Dir",COLORS.Text,S);
         print(row(4),col(18),"Record Velocity",COLORS.Text,S);
-        print(row(5),col(19),"Autosave (sec)",COLORS.Text,S);
+        // Autosave (sec) shares row 18 with Record Velocity. Label
+        // right-aligned to end col 38, slider starts col 40.
+        print(row(25),col(18),"Autosave (sec)",COLORS.Text,S);
 #ifdef _ACTIVAR_CAMBIO_TAMANYO_COLUMNAS
         print(row(7),col(20),"Default View",COLORS.Text,S);
 #endif

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -207,9 +207,12 @@ CUI_Config::CUI_Config(void) {
     tb = new TextBox;
     UI->add_element(tb, 11);
     tb->no_tab_stop = 1;  // read-only help; swallows UP/DOWN, exclude from focus cycle
-    tb->x = 1;
+    // Align left edge with the 'Go to page 1' button (x=4) above so the
+    // page balances visually. Right edge stays where it was — same column
+    // count, just shifted right by 3.
+    tb->x = 4;
     tb->y = 26;
-    tb->xsize = 78;
+    tb->xsize = 75;
     {
         const int max_rows = (INTERNAL_RESOLUTION_Y / 8);
         int remain = max_rows - tb->y - 1 - 9;

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -57,7 +57,7 @@ CUI_Config::CUI_Config(void) {
     ti->frame = 1;
     ti->x = 20;
     ti->y = 16;
-    ti->xsize = 50;
+    ti->xsize = 52;   // ends col 72 — matches Autoload File textfield right edge
     ti->length = 50;
     ti->str = (unsigned char*)zt_config_globals.default_directory;
 
@@ -236,46 +236,63 @@ void CUI_Config::leave(void) {
 
 void CUI_Config::update() {
 #ifdef __APPLE__
-    // Enter on Default Dir (tabindex 2) opens a native macOS folder
-    // picker via osascript. Peek the key first so UI->update() doesn't
-    // consume it. The result replaces the TextInput's buffer (which
-    // points at zt_config_globals.default_directory).
-    if (UI->cur_element == 2 && Keys.checkkey() == SDLK_RETURN) {
-        Keys.getkey();
-        FILE *p = popen(
-            "osascript -e 'try' "
-            "-e 'POSIX path of (choose folder with prompt \"Default Dir\")' "
-            "-e 'on error' -e 'return \"\"' -e 'end try'", "r");
+    // Pop a native macOS Finder picker. element_id selects between the
+    // Default Dir (folder picker) and Autoload File (file picker — basename
+    // only). Both share the same Enter-flush so keystrokes pressed inside
+    // the modal dialog don't bounce back into zTracker.
+    auto run_picker = [this](int element_id, char *target_buf, size_t target_size,
+                              bool basename_only, const char *osascript_cmd) {
+        FILE *p = popen(osascript_cmd, "r");
         if (p) {
             char picked[MAX_PATH + 1] = {0};
             if (fgets(picked, sizeof(picked), p)) {
                 size_t n = strlen(picked);
-                while (n > 0 && (picked[n-1] == '\n' || picked[n-1] == '\r' || picked[n-1] == '/')) {
+                while (n > 0 && (picked[n-1] == '\n' || picked[n-1] == '\r' ||
+                                 (!basename_only && picked[n-1] == '/'))) {
                     picked[--n] = '\0';
                 }
                 if (n > 0) {
-                    strncpy(zt_config_globals.default_directory, picked,
-                            sizeof(zt_config_globals.default_directory) - 1);
-                    zt_config_globals.default_directory[sizeof(zt_config_globals.default_directory) - 1] = '\0';
-                    TextInput *ti2 = (TextInput *)UI->get_element(2);
-                    if (ti2) {
-                        ti2->cursor = 0;
-                        ti2->changed = 1;
-                        ti2->need_redraw++;
+                    const char *src = picked;
+                    if (basename_only) {
+                        const char *slash = strrchr(picked, '/');
+                        if (slash) src = slash + 1;
+                    }
+                    strncpy(target_buf, src, target_size - 1);
+                    target_buf[target_size - 1] = '\0';
+                    TextInput *ti = (TextInput *)UI->get_element(element_id);
+                    if (ti) {
+                        ti->cursor = 0;
+                        ti->changed = 1;
+                        ti->need_redraw++;
                     }
                     need_refresh++;
                 }
             }
             pclose(p);
         }
-        // Pump SDL events + flush queued keys so the Enter the user
-        // pressed inside the Finder dialog (and any keystrokes that
-        // landed in zTracker's window while it was unfocused) don't
-        // leak through and re-open the picker on the next update().
         SDL_PumpEvents();
         SDL_FlushEvent(SDL_EVENT_KEY_DOWN);
         SDL_FlushEvent(SDL_EVENT_KEY_UP);
         Keys.flush();
+    };
+
+    // Enter on Default Dir (id 2) opens a folder picker.
+    if (UI->cur_element == 2 && Keys.checkkey() == SDLK_RETURN) {
+        Keys.getkey();
+        run_picker(2, zt_config_globals.default_directory,
+                   sizeof(zt_config_globals.default_directory), false,
+                   "osascript -e 'try' "
+                   "-e 'POSIX path of (choose folder with prompt \"Default Dir\")' "
+                   "-e 'on error' -e 'return \"\"' -e 'end try'");
+    }
+    // Enter on Autoload File (id 1) opens a file picker; basename only.
+    else if (UI->cur_element == 1 && Keys.checkkey() == SDLK_RETURN) {
+        Keys.getkey();
+        run_picker(1, zt_config_globals.autoload_ztfile_filename,
+                   sizeof(zt_config_globals.autoload_ztfile_filename), true,
+                   "osascript -e 'try' "
+                   "-e 'POSIX path of (choose file with prompt \"Autoload File\")' "
+                   "-e 'on error' -e 'return \"\"' -e 'end try'");
     }
 #endif
     UI->update();

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -61,19 +61,11 @@ CUI_Config::CUI_Config(void) {
     ti->length = 50;
     ti->str = (unsigned char*)zt_config_globals.default_directory;
 
-    cb = new CheckBox;
-    UI->add_element(cb,3);
-    cb->x = 20;
-    cb->y = 18;
-    cb->xsize = 3;
-    cb->value = &zt_config_globals.record_velocity;
-    cb->frame = 0;
-
-    // Autosave (sec) shares row 18 with Record Velocity to the right of
-    // its checkbox.
+    // Autosave (sec) — moved up to row 18 (was sharing row with Record
+    // Velocity, which has moved to F12 Sysconfig).
     vs = new ValueSlider;
-    UI->add_element(vs,4);
-    vs->x = 40;
+    UI->add_element(vs,3);
+    vs->x = 20;
     vs->y = 18;
     vs->xsize = 15;
     vs->ysize = 1;
@@ -82,7 +74,7 @@ CUI_Config::CUI_Config(void) {
     vs->max = 3600;
 
     vs = new ValueSlider;
-    UI->add_element(vs,5);
+    UI->add_element(vs,4);
     vs->x = 20;
     vs->y = 20;
     vs->xsize = 15;
@@ -99,32 +91,13 @@ CUI_Config::CUI_Config(void) {
     vs->no_tab_stop = 1;  // invisible stub; skip it in UP/DOWN cycling
 #endif
 
-    vs = new ValueSlider;
-    UI->add_element(vs,6);
-    // Row highlight + Row lowlight share row 21. Labels right-align to
-    // end col 18 / col 59 (1-char gap before each slider at x=20 / x=60).
-    vs->x = 20;
-    vs->y = 21;
-    vs->xsize = 13;
-    vs->ysize = 1;
-    vs->value = zt_config_globals.highlight_increment;
-    vs->min = 1;
-    vs->max = 64;
+    // Row Highlight / Row Lowlight live in F11 (Songconfig) only — they
+    // were duplicated here previously.
 
     vs = new ValueSlider;
-    UI->add_element(vs,7);
-    vs->x = 60;
-    vs->y = 21;
-    vs->xsize = 13;
-    vs->ysize = 1;
-    vs->value = zt_config_globals.lowlight_increment;
-    vs->min = 1;
-    vs->max = 64;
-
-    vs = new ValueSlider;
-    UI->add_element(vs,8);
+    UI->add_element(vs,5);
     vs->x = 20;
-    vs->y = 23;
+    vs->y = 22;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.pattern_length;
@@ -132,12 +105,10 @@ CUI_Config::CUI_Config(void) {
     vs->max = 256;
 
     // Post-Load Page: where to land after a successful song load.
-    // Slider with an inline label name (Inst/Pattern/Songconf) drawn
-    // by draw() — same idiom as View Mode above.
     vs = new ValueSlider;
-    UI->add_element(vs, 9);
+    UI->add_element(vs, 6);
     vs->x = 20;
-    vs->y = 24;
+    vs->y = 23;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.post_load_page;
@@ -148,7 +119,7 @@ CUI_Config::CUI_Config(void) {
     // Tab order: Page-switch button is the LAST tab-stop element so
     // DOWN-arrow from the bottom of the config list wraps cleanly back
     // to Autoload .ZT (tabindex 0).
-    UI->add_element(b,10);
+    UI->add_element(b,7);
     b->caption = "   Go to page 1   ";   // symmetric with Sysconfig's "Go to page 2" button (same x, y, xsize)
     b->xsize = 18;
     b->x = 4;   // matches Sysconfig F12 button x so the button doesn't jump on page switch
@@ -205,7 +176,7 @@ CUI_Config::CUI_Config(void) {
 */
 
     tb = new TextBox;
-    UI->add_element(tb, 11);
+    UI->add_element(tb, 8);
     tb->no_tab_stop = 1;  // read-only help; swallows UP/DOWN, exclude from focus cycle
     // Align left edge with the 'Go to page 1' button (x=4) above so the
     // page balances visually. Right edge stays where it was — same column
@@ -230,7 +201,7 @@ void CUI_Config::enter(void) {
     Keys.flush();
     // Start with focus on "Go to page 1" so the user can bounce straight
     // back to System Config without tabbing past every field first.
-    UI->set_focus(10);
+    UI->set_focus(7);   // 'Go to page 1' button (was 10 before renumbering)
 }
 
 void CUI_Config::leave(void) {
@@ -302,34 +273,24 @@ void CUI_Config::update() {
     ValueSlider *vs;
     TextInput *ti;
 
-    vs = (ValueSlider *)UI->get_element(4);
+    vs = (ValueSlider *)UI->get_element(3);   // Autosave (was 4)
     if (vs && vs->value != zt_config_globals.autosave_interval_seconds) {
         zt_config_globals.autosave_interval_seconds = vs->value;
     }
 
-    vs = (ValueSlider *)UI->get_element(5);
+    vs = (ValueSlider *)UI->get_element(4);   // View Mode (was 5)
 #ifdef _ACTIVAR_CAMBIO_TAMANYO_COLUMNAS
     if (vs && vs->value != zt_config_globals.cur_edit_mode) {
         zt_config_globals.cur_edit_mode = vs->value;
     }
 #endif
 
-    vs = (ValueSlider *)UI->get_element(6);
-    if (vs && vs->value != zt_config_globals.highlight_increment) {
-        zt_config_globals.highlight_increment = vs->value;
-    }
-
-    vs = (ValueSlider *)UI->get_element(7);
-    if (vs && vs->value != zt_config_globals.lowlight_increment) {
-        zt_config_globals.lowlight_increment = vs->value;
-    }
-
-    vs = (ValueSlider *)UI->get_element(8);
+    vs = (ValueSlider *)UI->get_element(5);   // Default Pat Len (was 8)
     if (vs && vs->value != zt_config_globals.pattern_length) {
         zt_config_globals.pattern_length = vs->value;
     }
 
-    vs = (ValueSlider *)UI->get_element(9);
+    vs = (ValueSlider *)UI->get_element(6);   // Post-Load Page (was 9)
     if (vs && vs->value != zt_config_globals.post_load_page) {
         zt_config_globals.post_load_page = vs->value;
     }
@@ -377,19 +338,20 @@ void CUI_Config::draw(Drawable *S) {
 #ifdef _ACTIVAR_CAMBIO_TAMANYO_COLUMNAS
         sprintf(buf+strlen(buf),"\n|U| View Mode       |L|[|H|%s|L|]",view_mode_name);
 #endif
-        sprintf(buf+strlen(buf),"\n|U| Row highlight   |L|[|H|%d|L|]",zt_config_globals.highlight_increment);
-        sprintf(buf+strlen(buf),"\n|U| Row lowlight    |L|[|H|%d|L|]",zt_config_globals.lowlight_increment);
+        // Row highlight / Row lowlight live in F11 only — not duplicated here.
         sprintf(buf+strlen(buf),"\n|U| Pattern Len     |L|[|H|%d|L|]",zt_config_globals.pattern_length);
         sprintf(buf+strlen(buf),"\n|U| Full Screen     |L|[|H|%s|L|]",zt_config_globals.full_screen?"On":"Off");
         sprintf(buf+strlen(buf),"\n|U| Send Panic      |L|[|H|%s|L|]",zt_config_globals.auto_send_panic?"On":"Off");
         sprintf(buf+strlen(buf),"\n|U| MIDI In Sync    |L|[|H|%s|L|]",zt_config_globals.midi_in_sync?"On":"Off");
         sprintf(buf+strlen(buf),"\n|U| Chase MIDI Tempo|L|[|H|%s|L|]",zt_config_globals.midi_in_sync_chase_tempo?"On":"Off");
-        const char *post_load_name = "Inst Editor";
+        const char *post_load_name = "Pattern Edit";
         switch (zt_config_globals.post_load_page) {
             case POST_LOAD_PATTERN_EDIT: post_load_name = "Pattern Edit"; break;
+            case POST_LOAD_INST_EDIT:    post_load_name = "Inst Editor";  break;
+            case POST_LOAD_PLAYSONG:     post_load_name = "Play Song";    break;
             case POST_LOAD_SONG_CONFIG:  post_load_name = "Song Config";  break;
-            case POST_LOAD_INST_EDIT:
-            default:                     post_load_name = "Inst Editor";  break;
+            case POST_LOAD_SONG_MESSAGE: post_load_name = "Song Message"; break;
+            default:                     post_load_name = "Pattern Edit"; break;
         }
         sprintf(buf+strlen(buf),"\n|U| Post-Load Page  |L|[|H|%s|L|]",post_load_name);
         sprintf(buf+strlen(buf),"\n|U| Step Editing    |L|[|H|%s|L|]",zt_config_globals.step_editing?"On":"Off");
@@ -425,7 +387,7 @@ void CUI_Config::draw(Drawable *S) {
         UI->draw(S);
 #ifdef _ACTIVAR_CAMBIO_TAMANYO_COLUMNAS
         {
-            ValueSlider *vs = (ValueSlider *)UI->get_element(5);
+            ValueSlider *vs = (ValueSlider *)UI->get_element(4);   // View Mode (was 5)
             if (vs) {
                 const char *view_mode_name = "Regular";
                 switch (zt_config_globals.cur_edit_mode) {
@@ -445,14 +407,16 @@ void CUI_Config::draw(Drawable *S) {
         // Mode pattern above — slider value alone reads as 0/1/2 which
         // is meaningless to the user without the page name beside it).
         {
-            ValueSlider *vs = (ValueSlider *)UI->get_element(9);
+            ValueSlider *vs = (ValueSlider *)UI->get_element(6);   // Post-Load Page (was 9)
             if (vs) {
-                const char *post_load_name = "Inst Editor";
+                const char *post_load_name = "Pattern Edit";
                 switch (zt_config_globals.post_load_page) {
                     case POST_LOAD_PATTERN_EDIT: post_load_name = "Pattern Edit"; break;
+                    case POST_LOAD_INST_EDIT:    post_load_name = "Inst Editor";  break;
+                    case POST_LOAD_PLAYSONG:     post_load_name = "Play Song";    break;
                     case POST_LOAD_SONG_CONFIG:  post_load_name = "Song Config";  break;
-                    case POST_LOAD_INST_EDIT:
-                    default:                     post_load_name = "Inst Editor";  break;
+                    case POST_LOAD_SONG_MESSAGE: post_load_name = "Song Message"; break;
+                    default:                     post_load_name = "Pattern Edit"; break;
                 }
                 char label[20];
                 snprintf(label, sizeof(label), " %-12s", post_load_name);
@@ -468,17 +432,14 @@ void CUI_Config::draw(Drawable *S) {
         print(row(7),col(14),"Autoload .ZT",COLORS.Text,S);
         print(row(28),col(14),"Autoload File",COLORS.Text,S);
         print(row(8),col(16),"Default Dir",COLORS.Text,S);
-        print(row(4),col(18),"Record Velocity",COLORS.Text,S);
-        // Autosave (sec) shares row 18 with Record Velocity. Label
-        // right-aligned to end col 38, slider starts col 40.
-        print(row(25),col(18),"Autosave (sec)",COLORS.Text,S);
+        // Record Velocity moved to F12 (Sysconfig).
+        print(row(5),col(18),"Autosave (sec)",COLORS.Text,S);
 #ifdef _ACTIVAR_CAMBIO_TAMANYO_COLUMNAS
         print(row(7),col(20),"Default View",COLORS.Text,S);
 #endif
-        print(row(6),col(21),"Row highlight",COLORS.Text,S);
-        print(row(48),col(21),"Row lowlight",COLORS.Text,S);
-        print(row(4),col(23),"Default Pat Len",COLORS.Text,S);
-        print(row(5),col(24),"Post-Load Page",COLORS.Text,S);
+        // Row Highlight / Row Lowlight live in F11 (Songconfig) only.
+        print(row(4),col(22),"Default Pat Len",COLORS.Text,S);
+        print(row(5),col(23),"Post-Load Page",COLORS.Text,S);
 //        print(row(2),col(25)," .ZT directory",COLORS.Text,S);
 
         //printtitle(32,"Current Global Settings",COLORS.Text,COLORS.Background,S);

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -260,6 +260,7 @@ void CUI_Config::leave(void) {
 }
 
 void CUI_Config::update() {
+#ifdef __APPLE__
     // Enter on Default Dir (tabindex 2) opens a native macOS folder
     // picker via osascript. Peek the key first so UI->update() doesn't
     // consume it. The result replaces the TextInput's buffer (which
@@ -293,6 +294,7 @@ void CUI_Config::update() {
             pclose(p);
         }
     }
+#endif
     UI->update();
     ValueSlider *vs;
     TextInput *ti;

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -139,24 +139,22 @@ CUI_Config::CUI_Config(void) {
     // MIDI realtime sync toggles. The underlying flags already exist in
     // zt.conf but were previously only reachable via the Sysconfig page;
     // expose them here so Global Config (F12) covers the full config set.
+    // MIDI In Sync + Chase MIDI Tempo moved to F11 (Songconfig). Keep
+    // the elements here as off-screen no-tab-stops so the existing
+    // get_element(N) index numbering in update()/draw() doesn't break.
     cb = new CheckBox;
     UI->add_element(cb, 9);
-    cb->frame = 1;
-    cb->x = 20;
-    cb->y = 24;
-    cb->xsize = 5;
+    cb->frame = 0;
+    cb->x = 0; cb->y = 0; cb->xsize = 0;
     cb->value = &zt_config_globals.midi_in_sync;
+    cb->no_tab_stop = 1;
 
-    // Pair Chase MIDI Tempo on the same row as MIDI In Sync. "MIDI In
-    // Sync" label = 12 cols, slider at x=20 ends at col 25 (chip 3).
-    // Place "Chase MIDI Tempo" label at col 28, checkbox at x=46.
     cb = new CheckBox;
     UI->add_element(cb, 10);
-    cb->frame = 1;
-    cb->x = 46;
-    cb->y = 24;
-    cb->xsize = 5;
+    cb->frame = 0;
+    cb->x = 0; cb->y = 0; cb->xsize = 0;
     cb->value = &zt_config_globals.midi_in_sync_chase_tempo;
+    cb->no_tab_stop = 1;
 
     // Post-Load Page: where to land after a successful song load.
     // Slider with an inline label name (Inst/Pattern/Songconf) drawn
@@ -164,7 +162,7 @@ CUI_Config::CUI_Config(void) {
     vs = new ValueSlider;
     UI->add_element(vs, 11);
     vs->x = 20;
-    vs->y = 25;
+    vs->y = 24;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.post_load_page;
@@ -438,9 +436,8 @@ void CUI_Config::draw(Drawable *S) {
         print(row(2),col(21),"Row highlight minor",COLORS.Text,S);
         print(row(40),col(21),"Row highlight major",COLORS.Text,S);
         print(row(2),col(23),"Default Pat Len",COLORS.Text,S);
-        print(row(2),col(24),"MIDI In Sync",COLORS.Text,S);
-        print(row(28),col(24),"Chase MIDI Tempo",COLORS.Text,S);
-        print(row(2),col(25),"Post-Load Page",COLORS.Text,S);
+        // MIDI In Sync + Chase MIDI Tempo labels moved to F11 (Songconfig).
+        print(row(2),col(24),"Post-Load Page",COLORS.Text,S);
 //        print(row(2),col(25)," .ZT directory",COLORS.Text,S);
 
         //printtitle(32,"Current Global Settings",COLORS.Text,COLORS.Background,S);

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -151,7 +151,7 @@ CUI_Config::CUI_Config(void) {
     UI->add_element(b,10);
     b->caption = "   Go to page 1   ";   // symmetric with Sysconfig's "Go to page 2" button (same x, y, xsize)
     b->xsize = 18;
-    b->x = 2;
+    b->x = 4;   // matches Sysconfig F12 button x so the button doesn't jump on page switch
     b->y = 12;
     b->ysize = 1;
     b->OnClick = (ActFunc)BTNCLK_GotoSystemConfig;

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -35,10 +35,9 @@ CUI_Config::CUI_Config(void) {
 
     cb = new CheckBox;
     UI->add_element(cb,0);
-    cb->frame = 0;
     cb->x = 20;
     cb->y = 14;
-    cb->xsize = 5;
+    cb->xsize = 3;
     cb->value = &zt_config_globals.autoload_ztfile;
     cb->frame = 1;
 
@@ -64,10 +63,9 @@ CUI_Config::CUI_Config(void) {
 
     cb = new CheckBox;
     UI->add_element(cb,3);
-    cb->frame = 0;
     cb->x = 20;
     cb->y = 18;
-    cb->xsize = 5;
+    cb->xsize = 3;
     cb->value = &zt_config_globals.record_velocity;
     cb->frame = 1;
 

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -57,7 +57,7 @@ CUI_Config::CUI_Config(void) {
     UI->add_element(ti,2);
     ti->frame = 1;
     ti->x = 20;
-    ti->y = 17;
+    ti->y = 16;
     ti->xsize = 50;
     ti->length = 50;
     ti->str = (unsigned char*)zt_config_globals.default_directory;
@@ -66,7 +66,7 @@ CUI_Config::CUI_Config(void) {
     UI->add_element(cb,3);
     cb->frame = 0;
     cb->x = 20;
-    cb->y = 19;
+    cb->y = 18;
     cb->xsize = 5;
     cb->value = &zt_config_globals.record_velocity;
     cb->frame = 1;
@@ -74,7 +74,7 @@ CUI_Config::CUI_Config(void) {
     vs = new ValueSlider;
     UI->add_element(vs,4);
     vs->x = 20;
-    vs->y = 20;
+    vs->y = 19;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.autosave_interval_seconds;
@@ -84,7 +84,7 @@ CUI_Config::CUI_Config(void) {
     vs = new ValueSlider;
     UI->add_element(vs,5);
     vs->x = 20;
-    vs->y = 21;
+    vs->y = 20;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.cur_edit_mode;
@@ -104,7 +104,7 @@ CUI_Config::CUI_Config(void) {
     // "Row highlight minor" label is 19 chars at col 2, so the slider
     // starts at col 22.
     vs->x = 22;
-    vs->y = 22;
+    vs->y = 21;
     vs->xsize = 13;
     vs->ysize = 1;
     vs->value = zt_config_globals.highlight_increment;
@@ -119,7 +119,7 @@ CUI_Config::CUI_Config(void) {
     //   col 40..58 "Row highlight major" label
     //   col 60..72 major slider, col 73..76 readout
     vs->x = 60;
-    vs->y = 22;
+    vs->y = 21;
     vs->xsize = 13;
     vs->ysize = 1;
     vs->value = zt_config_globals.lowlight_increment;
@@ -129,7 +129,7 @@ CUI_Config::CUI_Config(void) {
     vs = new ValueSlider;
     UI->add_element(vs,8);
     vs->x = 20;
-    vs->y = 24;
+    vs->y = 23;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.pattern_length;
@@ -143,7 +143,7 @@ CUI_Config::CUI_Config(void) {
     UI->add_element(cb, 11);
     cb->frame = 1;
     cb->x = 20;
-    cb->y = 25;
+    cb->y = 24;
     cb->xsize = 5;
     cb->value = &zt_config_globals.midi_in_sync;
 
@@ -151,7 +151,7 @@ CUI_Config::CUI_Config(void) {
     UI->add_element(cb, 12);
     cb->frame = 1;
     cb->x = 20;
-    cb->y = 26;
+    cb->y = 25;
     cb->xsize = 5;
     cb->value = &zt_config_globals.midi_in_sync_chase_tempo;
 
@@ -161,7 +161,7 @@ CUI_Config::CUI_Config(void) {
     vs = new ValueSlider;
     UI->add_element(vs, 13);
     vs->x = 20;
-    vs->y = 27;
+    vs->y = 26;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.post_load_page;
@@ -423,18 +423,18 @@ void CUI_Config::draw(Drawable *S) {
         printtitle(PAGE_TITLE_ROW_Y,"Global Configuration (Ctrl+F12)",COLORS.Text,COLORS.Background,S);
         print(row(2),col(14),"Autoload .ZT",COLORS.Text,S);
         print(row(28),col(14),"Autoload File",COLORS.Text,S);
-        print(row(2),col(17),"Default Dir",COLORS.Text,S);
-        print(row(2),col(19),"Record Velocity",COLORS.Text,S);
-        print(row(2),col(20),"Autosave (sec)",COLORS.Text,S);
+        print(row(2),col(16),"Default Dir",COLORS.Text,S);
+        print(row(2),col(18),"Record Velocity",COLORS.Text,S);
+        print(row(2),col(19),"Autosave (sec)",COLORS.Text,S);
 #ifdef _ACTIVAR_CAMBIO_TAMANYO_COLUMNAS
-        print(row(2),col(21),"Default View",COLORS.Text,S);
+        print(row(2),col(20),"Default View",COLORS.Text,S);
 #endif
-        print(row(2),col(22),"Row highlight minor",COLORS.Text,S);
-        print(row(40),col(22),"Row highlight major",COLORS.Text,S);
-        print(row(2),col(24),"Default Pat Len",COLORS.Text,S);
-        print(row(2),col(25),"MIDI In Sync",COLORS.Text,S);
-        print(row(2),col(26),"Chase MIDI Tempo",COLORS.Text,S);
-        print(row(2),col(27),"Post-Load Page",COLORS.Text,S);
+        print(row(2),col(21),"Row highlight minor",COLORS.Text,S);
+        print(row(40),col(21),"Row highlight major",COLORS.Text,S);
+        print(row(2),col(23),"Default Pat Len",COLORS.Text,S);
+        print(row(2),col(24),"MIDI In Sync",COLORS.Text,S);
+        print(row(2),col(25),"Chase MIDI Tempo",COLORS.Text,S);
+        print(row(2),col(26),"Post-Load Page",COLORS.Text,S);
 //        print(row(2),col(25)," .ZT directory",COLORS.Text,S);
 
         //printtitle(32,"Current Global Settings",COLORS.Text,COLORS.Background,S);

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -101,9 +101,11 @@ CUI_Config::CUI_Config(void) {
 
     vs = new ValueSlider;
     UI->add_element(vs,6);
-    vs->x = 20;
+    // "Row highlight minor" label is 19 chars at col 2, so the slider
+    // starts at col 22.
+    vs->x = 22;
     vs->y = 22;
-    vs->xsize = 15;
+    vs->xsize = 13;
     vs->ysize = 1;
     vs->value = zt_config_globals.highlight_increment;
     vs->min = 1;
@@ -111,11 +113,14 @@ CUI_Config::CUI_Config(void) {
 
     vs = new ValueSlider;
     UI->add_element(vs,7);
-    // Pair with the highlight slider on the same row; "Default Lowlight"
-    // label draws at col 38 (16 chars), slider sits to its right.
-    vs->x = 56;
+    // Pair with the minor-row slider on row 22. Layout:
+    //   col 2..20  "Row highlight minor" label
+    //   col 22..34 minor slider, col 35..38 readout
+    //   col 40..58 "Row highlight major" label
+    //   col 60..72 major slider, col 73..76 readout
+    vs->x = 60;
     vs->y = 22;
-    vs->xsize = 15;
+    vs->xsize = 13;
     vs->ysize = 1;
     vs->value = zt_config_globals.lowlight_increment;
     vs->min = 1;
@@ -330,8 +335,8 @@ void CUI_Config::draw(Drawable *S) {
 #ifdef _ACTIVAR_CAMBIO_TAMANYO_COLUMNAS
         sprintf(buf+strlen(buf),"\n|U| View Mode       |L|[|H|%s|L|]",view_mode_name);
 #endif
-        sprintf(buf+strlen(buf),"\n|U| Highlight Inc   |L|[|H|%d|L|]",zt_config_globals.highlight_increment);
-        sprintf(buf+strlen(buf),"\n|U| Lowlight Inc    |L|[|H|%d|L|]",zt_config_globals.lowlight_increment);
+        sprintf(buf+strlen(buf),"\n|U| Row hl minor    |L|[|H|%d|L|]",zt_config_globals.highlight_increment);
+        sprintf(buf+strlen(buf),"\n|U| Row hl major    |L|[|H|%d|L|]",zt_config_globals.lowlight_increment);
         sprintf(buf+strlen(buf),"\n|U| Pattern Len     |L|[|H|%d|L|]",zt_config_globals.pattern_length);
         sprintf(buf+strlen(buf),"\n|U| Full Screen     |L|[|H|%s|L|]",zt_config_globals.full_screen?"On":"Off");
         sprintf(buf+strlen(buf),"\n|U| Send Panic      |L|[|H|%s|L|]",zt_config_globals.auto_send_panic?"On":"Off");
@@ -424,8 +429,8 @@ void CUI_Config::draw(Drawable *S) {
 #ifdef _ACTIVAR_CAMBIO_TAMANYO_COLUMNAS
         print(row(2),col(21),"Default View",COLORS.Text,S);
 #endif
-        print(row(2),col(22),"Default Highlight",COLORS.Text,S);
-        print(row(38),col(22),"Default Lowlight",COLORS.Text,S);
+        print(row(2),col(22),"Row highlight minor",COLORS.Text,S);
+        print(row(40),col(22),"Row highlight major",COLORS.Text,S);
         print(row(2),col(24),"Default Pat Len",COLORS.Text,S);
         print(row(2),col(25),"MIDI In Sync",COLORS.Text,S);
         print(row(2),col(26),"Chase MIDI Tempo",COLORS.Text,S);

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -260,6 +260,39 @@ void CUI_Config::leave(void) {
 }
 
 void CUI_Config::update() {
+    // Enter on Default Dir (tabindex 2) opens a native macOS folder
+    // picker via osascript. Peek the key first so UI->update() doesn't
+    // consume it. The result replaces the TextInput's buffer (which
+    // points at zt_config_globals.default_directory).
+    if (UI->cur_element == 2 && Keys.checkkey() == SDLK_RETURN) {
+        Keys.getkey();
+        FILE *p = popen(
+            "osascript -e 'try' "
+            "-e 'POSIX path of (choose folder with prompt \"Default Dir\")' "
+            "-e 'on error' -e 'return \"\"' -e 'end try'", "r");
+        if (p) {
+            char picked[MAX_PATH + 1] = {0};
+            if (fgets(picked, sizeof(picked), p)) {
+                size_t n = strlen(picked);
+                while (n > 0 && (picked[n-1] == '\n' || picked[n-1] == '\r' || picked[n-1] == '/')) {
+                    picked[--n] = '\0';
+                }
+                if (n > 0) {
+                    strncpy(zt_config_globals.default_directory, picked,
+                            sizeof(zt_config_globals.default_directory) - 1);
+                    zt_config_globals.default_directory[sizeof(zt_config_globals.default_directory) - 1] = '\0';
+                    TextInput *ti2 = (TextInput *)UI->get_element(2);
+                    if (ti2) {
+                        ti2->cursor = 0;
+                        ti2->changed = 1;
+                        ti2->need_redraw++;
+                    }
+                    need_refresh++;
+                }
+            }
+            pclose(p);
+        }
+    }
     UI->update();
     ValueSlider *vs;
     TextInput *ti;

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -101,9 +101,9 @@ CUI_Config::CUI_Config(void) {
 
     vs = new ValueSlider;
     UI->add_element(vs,6);
-    // "Row highlight minor" label is 19 chars at col 2, so the slider
-    // starts at col 22.
-    vs->x = 22;
+    // Row highlight + Row lowlight share row 21. Labels right-align to
+    // end col 18 / col 59 (1-char gap before each slider at x=20 / x=60).
+    vs->x = 20;
     vs->y = 21;
     vs->xsize = 13;
     vs->ysize = 1;
@@ -113,11 +113,6 @@ CUI_Config::CUI_Config(void) {
 
     vs = new ValueSlider;
     UI->add_element(vs,7);
-    // Pair with the minor-row slider on row 22. Layout:
-    //   col 2..20  "Row highlight minor" label
-    //   col 22..34 minor slider, col 35..38 readout
-    //   col 40..58 "Row highlight major" label
-    //   col 60..72 major slider, col 73..76 readout
     vs->x = 60;
     vs->y = 21;
     vs->xsize = 13;
@@ -136,31 +131,11 @@ CUI_Config::CUI_Config(void) {
     vs->min = 1;
     vs->max = 256;
 
-    // MIDI realtime sync toggles. The underlying flags already exist in
-    // zt.conf but were previously only reachable via the Sysconfig page;
-    // expose them here so Global Config (F12) covers the full config set.
-    // MIDI In Sync + Chase MIDI Tempo moved to F11 (Songconfig). Keep
-    // the elements here as off-screen no-tab-stops so the existing
-    // get_element(N) index numbering in update()/draw() doesn't break.
-    cb = new CheckBox;
-    UI->add_element(cb, 9);
-    cb->frame = 0;
-    cb->x = 0; cb->y = 0; cb->xsize = 0;
-    cb->value = &zt_config_globals.midi_in_sync;
-    cb->no_tab_stop = 1;
-
-    cb = new CheckBox;
-    UI->add_element(cb, 10);
-    cb->frame = 0;
-    cb->x = 0; cb->y = 0; cb->xsize = 0;
-    cb->value = &zt_config_globals.midi_in_sync_chase_tempo;
-    cb->no_tab_stop = 1;
-
     // Post-Load Page: where to land after a successful song load.
     // Slider with an inline label name (Inst/Pattern/Songconf) drawn
     // by draw() — same idiom as View Mode above.
     vs = new ValueSlider;
-    UI->add_element(vs, 11);
+    UI->add_element(vs, 9);
     vs->x = 20;
     vs->y = 24;
     vs->xsize = 15;
@@ -170,10 +145,10 @@ CUI_Config::CUI_Config(void) {
     vs->max = POST_LOAD_PAGE_COUNT - 1;
 
     b = new Button;
-    // Tab order: Page-switch button is the LAST element so DOWN-arrow
-    // from the bottom of the config list wraps cleanly back to Autoload
-    // .ZT (tabindex 0) instead of jumping past the MIDI rows.
-    UI->add_element(b,12);
+    // Tab order: Page-switch button is the LAST tab-stop element so
+    // DOWN-arrow from the bottom of the config list wraps cleanly back
+    // to Autoload .ZT (tabindex 0).
+    UI->add_element(b,10);
     b->caption = "   Go to page 1   ";   // symmetric with Sysconfig's "Go to page 2" button (same x, y, xsize)
     b->xsize = 18;
     b->x = 2;
@@ -230,10 +205,10 @@ CUI_Config::CUI_Config(void) {
 */
 
     tb = new TextBox;
-    UI->add_element(tb, 9);
+    UI->add_element(tb, 11);
     tb->no_tab_stop = 1;  // read-only help; swallows UP/DOWN, exclude from focus cycle
     tb->x = 1;
-    tb->y = 28;
+    tb->y = 26;
     tb->xsize = 78;
     {
         const int max_rows = (INTERNAL_RESOLUTION_Y / 8);
@@ -326,7 +301,7 @@ void CUI_Config::update() {
         zt_config_globals.pattern_length = vs->value;
     }
 
-    vs = (ValueSlider *)UI->get_element(11);
+    vs = (ValueSlider *)UI->get_element(9);
     if (vs && vs->value != zt_config_globals.post_load_page) {
         zt_config_globals.post_load_page = vs->value;
     }
@@ -374,8 +349,8 @@ void CUI_Config::draw(Drawable *S) {
 #ifdef _ACTIVAR_CAMBIO_TAMANYO_COLUMNAS
         sprintf(buf+strlen(buf),"\n|U| View Mode       |L|[|H|%s|L|]",view_mode_name);
 #endif
-        sprintf(buf+strlen(buf),"\n|U| Row hl minor    |L|[|H|%d|L|]",zt_config_globals.highlight_increment);
-        sprintf(buf+strlen(buf),"\n|U| Row hl major    |L|[|H|%d|L|]",zt_config_globals.lowlight_increment);
+        sprintf(buf+strlen(buf),"\n|U| Row highlight   |L|[|H|%d|L|]",zt_config_globals.highlight_increment);
+        sprintf(buf+strlen(buf),"\n|U| Row lowlight    |L|[|H|%d|L|]",zt_config_globals.lowlight_increment);
         sprintf(buf+strlen(buf),"\n|U| Pattern Len     |L|[|H|%d|L|]",zt_config_globals.pattern_length);
         sprintf(buf+strlen(buf),"\n|U| Full Screen     |L|[|H|%s|L|]",zt_config_globals.full_screen?"On":"Off");
         sprintf(buf+strlen(buf),"\n|U| Send Panic      |L|[|H|%s|L|]",zt_config_globals.auto_send_panic?"On":"Off");
@@ -442,7 +417,7 @@ void CUI_Config::draw(Drawable *S) {
         // Mode pattern above — slider value alone reads as 0/1/2 which
         // is meaningless to the user without the page name beside it).
         {
-            ValueSlider *vs = (ValueSlider *)UI->get_element(11);
+            ValueSlider *vs = (ValueSlider *)UI->get_element(9);
             if (vs) {
                 const char *post_load_name = "Inst Editor";
                 switch (zt_config_globals.post_load_page) {
@@ -460,19 +435,20 @@ void CUI_Config::draw(Drawable *S) {
         draw_status(S);
         status(S);
         printtitle(PAGE_TITLE_ROW_Y,"Global Configuration (Ctrl+F12)",COLORS.Text,COLORS.Background,S);
-        print(row(2),col(14),"Autoload .ZT",COLORS.Text,S);
+        // Labels right-align so text ends at col 18 (1-char gap before
+        // the col-20 controls).
+        print(row(7),col(14),"Autoload .ZT",COLORS.Text,S);
         print(row(28),col(14),"Autoload File",COLORS.Text,S);
-        print(row(2),col(16),"Default Dir",COLORS.Text,S);
-        print(row(2),col(18),"Record Velocity",COLORS.Text,S);
-        print(row(2),col(19),"Autosave (sec)",COLORS.Text,S);
+        print(row(8),col(16),"Default Dir",COLORS.Text,S);
+        print(row(4),col(18),"Record Velocity",COLORS.Text,S);
+        print(row(5),col(19),"Autosave (sec)",COLORS.Text,S);
 #ifdef _ACTIVAR_CAMBIO_TAMANYO_COLUMNAS
-        print(row(2),col(20),"Default View",COLORS.Text,S);
+        print(row(7),col(20),"Default View",COLORS.Text,S);
 #endif
-        print(row(2),col(21),"Row highlight minor",COLORS.Text,S);
-        print(row(40),col(21),"Row highlight major",COLORS.Text,S);
-        print(row(2),col(23),"Default Pat Len",COLORS.Text,S);
-        // MIDI In Sync + Chase MIDI Tempo labels moved to F11 (Songconfig).
-        print(row(2),col(24),"Post-Load Page",COLORS.Text,S);
+        print(row(6),col(21),"Row highlight",COLORS.Text,S);
+        print(row(48),col(21),"Row lowlight",COLORS.Text,S);
+        print(row(4),col(23),"Default Pat Len",COLORS.Text,S);
+        print(row(5),col(24),"Post-Load Page",COLORS.Text,S);
 //        print(row(2),col(25)," .ZT directory",COLORS.Text,S);
 
         //printtitle(32,"Current Global Settings",COLORS.Text,COLORS.Background,S);

--- a/src/CUI_FileLists_Common.hpp
+++ b/src/CUI_FileLists_Common.hpp
@@ -60,18 +60,20 @@
 #define SAVE_TEXTINPUT_POS_Y         (SAVE_BUTTONS_BASE_Y + 0)
 
 
+// Tighten button stack so it doesn't extend below the right-hand file
+// list. TextInput->first button gap = 1 row, between buttons = 1 row.
 #define SAVE_ZT_BUTTON_POS_X         FILE_LIST_POS_X_CHARS
-#define SAVE_ZT_BUTTON_POS_Y         (SAVE_TEXTINPUT_POS_Y + 1 + 1)
+#define SAVE_ZT_BUTTON_POS_Y         (SAVE_TEXTINPUT_POS_Y + 1)
 
 
 #define SAVE_MID_BUTTON_POS_X        FILE_LIST_POS_X_CHARS
-#define SAVE_MID_BUTTON_POS_Y        (SAVE_ZT_BUTTON_POS_Y + 1 + 1)
+#define SAVE_MID_BUTTON_POS_Y        (SAVE_ZT_BUTTON_POS_Y + 1)
 
 #define SAVE_MID_MC_BUTTON_POS_X     FILE_LIST_POS_X_CHARS
-#define SAVE_MID_MC_BUTTON_POS_Y     (SAVE_MID_BUTTON_POS_Y + 1 + 1)
+#define SAVE_MID_MC_BUTTON_POS_Y     (SAVE_MID_BUTTON_POS_Y + 1)
 
 #define SAVE_MID_PT_BUTTON_POS_X     FILE_LIST_POS_X_CHARS
-#define SAVE_MID_PT_BUTTON_POS_Y     (SAVE_MID_MC_BUTTON_POS_Y + 1 + 1)
+#define SAVE_MID_PT_BUTTON_POS_Y     (SAVE_MID_MC_BUTTON_POS_Y + 1)
 
 //#define SAVE_GBA_BUTTON_POS_X        FILE_LIST_POS_X_CHARS
 //#define SAVE_GBA_BUTTON_POS_Y        (SAVE_ZT_BUTTON_POS_Y + 1 + 1 + 1 + 1)

--- a/src/CUI_Help.cpp
+++ b/src/CUI_Help.cpp
@@ -13,7 +13,7 @@ CUI_Help::CUI_Help(void) {
     UI->add_element(tb, 0);
     tb->x = 1;
     tb->y = 12;
-    tb->xsize = 78 + ((INTERNAL_RESOLUTION_X-640)/8);
+    tb->xsize = TextBox::full_width_xsize();
     // Bottom-anchor: fill from tb->y down to ~5 rows above screen bottom.
     tb->ysize = (INTERNAL_RESOLUTION_Y/8) - tb->y - 8;
     //tb->text = "This is a test of the textbox reader\n\nit is supposed to work";
@@ -327,7 +327,7 @@ void CUI_Help::update() {
 
 void CUI_Help::draw(Drawable *S) {
 
-    tb->xsize = 78 + ((INTERNAL_RESOLUTION_X-640)/8);
+    tb->xsize = TextBox::full_width_xsize();
     // Bottom-anchor: fill from tb->y down to ~5 rows above screen bottom.
     tb->ysize = (INTERNAL_RESOLUTION_Y/8) - tb->y - 8;
 

--- a/src/CUI_InstEditor.cpp
+++ b/src/CUI_InstEditor.cpp
@@ -99,7 +99,7 @@ CUI_InstEditor::CUI_InstEditor(void) {
 
     vso = new ValueSliderOFF(1); // Bank (ID: 1)
     UI->add_element(vso,tabindex++);
-    vso->x = 36;    vso->y = 15;    vso->xsize = 16;    vso->ysize = 1; vso->min = -1;  vso->max = 0x3fff;    vso->value = -1;
+    vso->x = 36;    vso->y = 15;    vso->xsize = 13;    vso->ysize = 1; vso->min = -1;  vso->max = 0x3fff;    vso->value = -1;
     fm = new Frame;
     UI->add_gfx(fm,gfxindex++);
     fm->x=35; fm->y=12; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
@@ -235,7 +235,7 @@ CUI_InstEditor::CUI_InstEditor(void) {
     mds->x=35;
     mds->y=37;
     mds->xsize = 44;
-    mds->ysize = 14;
+    mds->ysize = 15;
     
     reset = 0;
 }

--- a/src/CUI_InstEditor.cpp
+++ b/src/CUI_InstEditor.cpp
@@ -470,7 +470,7 @@ void CUI_InstEditor::draw(Drawable *S)
 
     ie = (InstEditor *)UI->get_element(0);
 
-    ie->ysize = 40 + ((INTERNAL_RESOLUTION_Y-480)/8);
+    ie->ysize = 41 + ((INTERNAL_RESOLUTION_Y-480)/8);
     if(ie->ysize > MAX_INSTS) ie->ysize = MAX_INSTS ;
 
     if (ie->cursor+ie->list_start != cur_inst) {

--- a/src/CUI_KeyBindings.cpp
+++ b/src/CUI_KeyBindings.cpp
@@ -212,7 +212,7 @@ void CUI_KeyBindings::draw(Drawable *S)
                 COLORS.Background);
 
     char buf[96];
-    snprintf(buf, sizeof(buf), "Keyboard Shortcuts (Ctrl+Alt+K)%s",
+    snprintf(buf, sizeof(buf), "Keybindings Editor (Ctrl+Alt+K)%s",
              dirty ? "   [unsaved]" : "");
     printtitle(PAGE_TITLE_ROW_Y, buf, COLORS.Text, COLORS.Background, S);
 

--- a/src/CUI_LoadMsg.cpp
+++ b/src/CUI_LoadMsg.cpp
@@ -140,9 +140,11 @@ void CUI_LoadMsg::update() {
         // people who want to verify BPM/TPB/order list before anything else.
         switch (zt_config_globals.post_load_page) {
             case POST_LOAD_PATTERN_EDIT: switch_page(UIP_Patterneditor); break;
+            case POST_LOAD_INST_EDIT:    switch_page(UIP_InstEditor);    break;
+            case POST_LOAD_PLAYSONG:     switch_page(UIP_Playsong);      break;
             case POST_LOAD_SONG_CONFIG:  switch_page(UIP_Songconfig);    break;
-            case POST_LOAD_INST_EDIT:
-            default:                     switch_page(UIP_InstEditor);   break;
+            case POST_LOAD_SONG_MESSAGE: switch_page(UIP_SongMessage);   break;
+            default:                     switch_page(UIP_Patterneditor); break;
         }
     }
 }

--- a/src/CUI_LuaConsole.cpp
+++ b/src/CUI_LuaConsole.cpp
@@ -228,7 +228,7 @@ void CUI_LuaConsole::draw(Drawable *S)
                 fx2, row(input_row() + 1) - 1, page_bg);
 
     // --- Title ---
-    printtitle(PAGE_TITLE_ROW_Y, "Lua Console (Esc/F2 to close)",
+    printtitle(PAGE_TITLE_ROW_Y, "Lua Console (Ctrl+Alt+L)",
                title_fg, page_bg, S);
 
     // --- Scrollback background (distinct shade, so the console area is

--- a/src/CUI_MainMenu.cpp
+++ b/src/CUI_MainMenu.cpp
@@ -89,43 +89,43 @@ static const mm_entry MM_ENTRIES[] = {
     {MM_CMD,        "Song Message",             "F10",                  CMD_SWITCH_SONGMSG,         NULL},
 #endif
 #ifndef DISABLE_UNFINISHED_F4_MIDI_MACRO_EDITOR
-    {MM_CMD,        "Midimacro Editor",         "Ctrl-M",               CMD_SWITCH_MIDIMACEDIT,     NULL},
+    {MM_CMD,        "Midimacro Editor",         "Ctrl+M",               CMD_SWITCH_MIDIMACEDIT,     NULL},
 #endif
     {MM_CMD,        "Help",                     "F1",                   CMD_SWITCH_HELP,            NULL},
-    {MM_CMD,        "About",                    "Alt-F12",              CMD_SWITCH_ABOUT,           NULL},
+    {MM_CMD,        "About",                    "Alt+F12",              CMD_SWITCH_ABOUT,           NULL},
 
     {MM_SEPARATOR,  NULL,                       NULL,                   0,                          NULL},
     {MM_SUBHEADING, "Playback",                 NULL,                   0,                          NULL},
     {MM_CMD,        "Play Song",                "F5",                   CMD_PLAY,                   NULL},
     {MM_CMD,        "Play Pattern",             "F6",                   CMD_PLAY_PAT,               NULL},
     {MM_CMD,        "Play From Cursor",         "F7",                   CMD_PLAY_PAT_LINE,          NULL},
-    {MM_CMD,        "Play From Order",          "Shift-F7",             CMD_PLAY_ORDER,             NULL},
+    {MM_CMD,        "Play From Order",          "Shift+F7",             CMD_PLAY_ORDER,             NULL},
     {MM_CMD,        "Stop",                     "F8",                   CMD_STOP,                   NULL},
     {MM_FUNC,       "Panic (all MIDI off)",     "F9",                   0,                          mm_panic},
-    {MM_FUNC,       "Hard Panic",               "Shift-F9",             0,                          mm_hard_panic},
+    {MM_FUNC,       "Hard Panic",               "Shift+F9",             0,                          mm_hard_panic},
     {MM_FUNC,       "Toggle Follow Playback",   "ScrollLock",           0,                          mm_toggle_follow_playback},
 
     {MM_SEPARATOR,  NULL,                       NULL,                   0,                          NULL},
     {MM_SUBHEADING, "File",                     NULL,                   0,                          NULL},
-    {MM_CMD,        "Load Song...",             "Ctrl-L",               CMD_SWITCH_LOAD,            NULL},
-    {MM_CMD,        "Save Song / Save As...",   "Ctrl-S",               CMD_SWITCH_SAVE,            NULL},
+    {MM_CMD,        "Load Song...",             "Ctrl+L",               CMD_SWITCH_LOAD,            NULL},
+    {MM_CMD,        "Save Song / Save As...",   "Ctrl+S",               CMD_SWITCH_SAVE,            NULL},
     // CMD_NEWSONG / CMD_MIDI_EXPORT don't exist as enum values; the
-    // user-facing shortcut still works (Ctrl-Alt-N / Ctrl-Shift-M),
+    // user-facing shortcut still works (Ctrl+Alt+N / Ctrl+Shift+M),
     // so we list it as info-only here. Future: wire to dedicated cmds.
 
     {MM_SEPARATOR,  NULL,                       NULL,                   0,                          NULL},
     {MM_SUBHEADING, "Settings",                 NULL,                   0,                          NULL},
     {MM_CMD,        "System Configuration",     "F12",                  CMD_SWITCH_SYSCONF,         NULL},
-    {MM_CMD,        "Global Configuration",     "Ctrl-F12",             CMD_SWITCH_CONFIG,          NULL},
+    {MM_CMD,        "Global Configuration",     "Ctrl+F12",             CMD_SWITCH_CONFIG,          NULL},
 #ifndef DISABLE_PALETTE_EDITOR
-    {MM_CMD,        "Palette Editor",           "Shift-Ctrl-F12",       CMD_SWITCH_PALETTE,         NULL},
+    {MM_CMD,        "Palette Editor",           "Shift+Ctrl+F12",       CMD_SWITCH_PALETTE,         NULL},
 #endif
-    {MM_CMD,        "Keybindings Editor",       "Ctrl-Alt-K",           CMD_SWITCH_KEYBINDINGS,     NULL},
-    {MM_CMD,        "Lua Console",              "Ctrl-Alt-L",           CMD_SWITCH_LUA_CONSOLE,     NULL},
-    {MM_FUNC,       "Toggle Fullscreen",        "Alt-Enter",            0,                          mm_toggle_fullscreen},
+    {MM_CMD,        "Keybindings Editor",       "Ctrl+Alt+K",           CMD_SWITCH_KEYBINDINGS,     NULL},
+    {MM_CMD,        "Lua Console",              "Ctrl+Alt+L",           CMD_SWITCH_LUA_CONSOLE,     NULL},
+    {MM_FUNC,       "Toggle Fullscreen",        "Alt+Enter",            0,                          mm_toggle_fullscreen},
 
     {MM_SEPARATOR,  NULL,                       NULL,                   0,                          NULL},
-    {MM_FUNC,       "Quit",                     "Ctrl-Q",               0,                          mm_quit},
+    {MM_FUNC,       "Quit",                     "Ctrl+Q",               0,                          mm_quit},
 };
 
 static const int MM_COUNT = sizeof(MM_ENTRIES) / sizeof(MM_ENTRIES[0]);

--- a/src/CUI_Midimacroeditor.cpp
+++ b/src/CUI_Midimacroeditor.cpp
@@ -79,7 +79,7 @@ void CUI_Midimacroeditor::draw(Drawable *S) {
     if (S->lock()==0) {
         UI->draw(S);
         draw_status(S);
-        printtitle(PAGE_TITLE_ROW_Y,"MIDI Macro Editor (Ctrl+F4)",COLORS.Text,COLORS.Background,S);
+        printtitle(PAGE_TITLE_ROW_Y,"Midimacro Editor (Ctrl+M)",COLORS.Text,COLORS.Background,S);
         print(col(12),row(BASE_Y),"name",COLORS.Text,S);
         need_refresh = 0; updated=2;
         ztPlayer->num_orders();

--- a/src/CUI_PENature.cpp
+++ b/src/CUI_PENature.cpp
@@ -108,6 +108,11 @@ void CUI_PENature::draw(Drawable *S) {
         print(col(textcenter("Naturalization Amount")),start_y + row(2),"Naturalization Amount",COLORS.Text,S);
         print(start_x + col(1), start_y + window_height / 2,"  Percent:",COLORS.Text,S);
         UI->draw(S);
+        // Show "%" suffix after the slider's numeric readout. ValueSlider
+        // prints " NNN" (4 chars) starting at col(x+xsize); "%" lands
+        // immediately after.
+        ValueSlider *vs = (ValueSlider *)UI->get_element(0);
+        print(col(vs->x + vs->xsize + 4), row(vs->y), "%", COLORS.Text, S);
         S->unlock();
         need_refresh = need_popup_refresh = 0;
         updated++;

--- a/src/CUI_PEParms.cpp
+++ b/src/CUI_PEParms.cpp
@@ -182,6 +182,33 @@ void CUI_PEParms::update() {
         UIP_Patterneditor->mode = (drawmode_val) ? PEM_MOUSEDRAW : PEM_REGULARKEYS;
         if (UIP_Patterneditor->mode == PEM_REGULARKEYS) midiInQueue.clear();
     }
+
+    // Live drawing while the popup is open. With DrawMode on, forward
+    // mouse activity to the pattern editor when the cursor is outside
+    // the popup window. Only forward if the queue is empty (so the PE
+    // can refresh its drag from LastX/LastY) or the next pending key
+    // is a mouse-button event — never a keyboard key, which would
+    // hijack the popup's own input.
+    if (UIP_Patterneditor->mode == PEM_MOUSEDRAW) {
+        int win_w = 54 * col(1);
+        int win_h = 20 * row(1);
+        int wx = (INTERNAL_RESOLUTION_X / 2) - (win_w / 2);
+        int wy = (INTERNAL_RESOLUTION_Y / 2) - (win_h / 2);
+        int outside_popup = (LastX < wx) || (LastX >= wx + win_w) ||
+                            (LastY < wy) || (LastY >= wy + win_h);
+        if (outside_popup) {
+            int peeked = Keys.checkkey();
+            int forwardable_key =
+                peeked == 0 ||
+                peeked == ((unsigned int)((SDL_EVENT_MOUSE_BUTTON_UP   << 8) | SDL_BUTTON_LEFT)) ||
+                peeked == ((unsigned int)((SDL_EVENT_MOUSE_BUTTON_DOWN << 8) | SDL_BUTTON_LEFT));
+            if (forwardable_key) {
+                UIP_Patterneditor->update();
+                need_refresh++;
+                need_popup_refresh++;
+            }
+        }
+    }
 }
 
 void CUI_PEParms::draw(Drawable *S) {

--- a/src/CUI_PEParms.cpp
+++ b/src/CUI_PEParms.cpp
@@ -224,17 +224,18 @@ void CUI_PEParms::draw(Drawable *S) {
         }
         printline(start_x,start_y,143,window_width / 8,COLORS.Highlight,S);
         print(col(textcenter("Pattern Editor Options")),start_y + row(2),"Pattern Editor Options",COLORS.Text,S);
-        // Right-align labels at col 16 (slider/checkbox x-origin sits
-        // at col 17 inside the popup, leaving one space gap).
-        print(start_x + col(2),start_y + row(6),     "      EditStep:",COLORS.Text,S);
-        print(start_x + col(2),start_y + row(8),     "    Pat length:",COLORS.Text,S);
-        print(start_x + col(2),start_y + row(10),    " Row Highlight:",COLORS.Text,S);
-        print(start_x + col(2),start_y + row(12),    "  Row Lowlight:",COLORS.Text,S);
-        print(start_x + col(2),start_y + row(14),    "      Centered:",COLORS.Text,S);
+        // Labels right-align so the colon lands at col 15. The slider/
+        // checkbox x-origin is col 17, so the frame border at col 16
+        // sits between the colon and the chip without stomping either.
+        print(start_x + col(2),start_y + row(6),     "     EditStep:",COLORS.Text,S);
+        print(start_x + col(2),start_y + row(8),     "   Pat length:",COLORS.Text,S);
+        print(start_x + col(2),start_y + row(10),    "Row Highlight:",COLORS.Text,S);
+        print(start_x + col(2),start_y + row(12),    " Row Lowlight:",COLORS.Text,S);
+        print(start_x + col(2),start_y + row(14),    "     Centered:",COLORS.Text,S);
         print(start_x + col(23),start_y + row(14),"StepEdit:",COLORS.Text,S);
         print(start_x + col(39),start_y + row(14),"RecVeloc:",COLORS.Text,S);
-        print(start_x + col(2),start_y + row(16),    "       Speedup:",COLORS.Text,S);
-        print(start_x + col(2),start_y + row(18),    "      DrawMode:",COLORS.Text,S);
+        print(start_x + col(2),start_y + row(16),    "      Speedup:",COLORS.Text,S);
+        print(start_x + col(2),start_y + row(18),    "     DrawMode:",COLORS.Text,S);
         UI->full_refresh();
         UI->draw(S);
         S->unlock();

--- a/src/CUI_PEParms.cpp
+++ b/src/CUI_PEParms.cpp
@@ -61,7 +61,7 @@ CUI_PEParms::CUI_PEParms(void) {
         cb_centered->frame = 0;
         cb_centered->x = (start_x / 8) + 17;
         cb_centered->y = (start_y / 8) + 14;
-        cb_centered->xsize = 5;
+        cb_centered->xsize = 3;
         cb_centered->value = &zt_config_globals.centered_editing;
         cb_centered->frame = 1;
 
@@ -70,7 +70,7 @@ CUI_PEParms::CUI_PEParms(void) {
         cb_stepedit->frame = 0;
         cb_stepedit->x = (start_x / 8) + 17 + 16;
         cb_stepedit->y = (start_y / 8) + 14;
-        cb_stepedit->xsize = 5;
+        cb_stepedit->xsize = 3;
         cb_stepedit->value = &zt_config_globals.step_editing;
         cb_stepedit->frame = 1;
 
@@ -79,7 +79,7 @@ CUI_PEParms::CUI_PEParms(void) {
         cb_recveloc->frame = 0;
         cb_recveloc->x = (start_x / 8) + 17 + 32;
         cb_recveloc->y = (start_y / 8) + 14;
-        cb_recveloc->xsize = 5;
+        cb_recveloc->xsize = 3;
         cb_recveloc->value = &zt_config_globals.record_velocity;
         cb_recveloc->frame = 1;
 
@@ -101,7 +101,7 @@ CUI_PEParms::CUI_PEParms(void) {
         cb_drawmode->frame = 1;
         cb_drawmode->x = (start_x / 8) + 17;
         cb_drawmode->y = (start_y / 8) + 18;
-        cb_drawmode->xsize = 5;
+        cb_drawmode->xsize = 3;
         cb_drawmode->value = &drawmode_val;
 }
 

--- a/src/CUI_PEParms.cpp
+++ b/src/CUI_PEParms.cpp
@@ -19,9 +19,9 @@ CUI_PEParms::CUI_PEParms(void) {
         vs_step = new ValueSlider;
         UI->add_element(vs_step,0);
         vs_step->frame = 1;
-        vs_step->x = (start_x / 8) + 14;
+        vs_step->x = (start_x / 8) + 17;
         vs_step->y = (start_y / 8) + 6; 
-        vs_step->xsize=window_width/8 - 20;
+        vs_step->xsize=window_width/8 - 23;
         vs_step->min = 0;
         vs_step->max = 32;
         vs_step->value = cur_step;   
@@ -29,9 +29,9 @@ CUI_PEParms::CUI_PEParms(void) {
         vs_pat_length = new ValueSlider;
         UI->add_element(vs_pat_length,1);
         vs_pat_length->frame = 1;
-        vs_pat_length->x = (start_x / 8) + 14;
+        vs_pat_length->x = (start_x / 8) + 17;
         vs_pat_length->y = (start_y / 8) + 8; 
-        vs_pat_length->xsize=window_width/8 - 20;
+        vs_pat_length->xsize=window_width/8 - 23;
         vs_pat_length->min = 32;
         vs_pat_length->max = 999;
         vs_pat_length->value = song->patterns[cur_edit_pattern]->length;
@@ -39,9 +39,9 @@ CUI_PEParms::CUI_PEParms(void) {
         vs_highlight = new ValueSlider;
         UI->add_element(vs_highlight,2);
         vs_highlight->frame = 1;
-        vs_highlight->x = (start_x / 8) + 14;
+        vs_highlight->x = (start_x / 8) + 17;
         vs_highlight->y = (start_y / 8) + 10; 
-        vs_highlight->xsize=window_width/8 - 20;
+        vs_highlight->xsize=window_width/8 - 23;
         vs_highlight->min = 1;
         vs_highlight->max = 32;
         vs_highlight->value = zt_config_globals.highlight_increment;
@@ -49,9 +49,9 @@ CUI_PEParms::CUI_PEParms(void) {
         vs_lowlight = new ValueSlider;
         UI->add_element(vs_lowlight,3);
         vs_lowlight->frame = 1;
-        vs_lowlight->x = (start_x / 8) + 14;
+        vs_lowlight->x = (start_x / 8) + 17;
         vs_lowlight->y = (start_y / 8) + 12; 
-        vs_lowlight->xsize=window_width/8 - 20;
+        vs_lowlight->xsize=window_width/8 - 23;
         vs_lowlight->min = 1;
         vs_lowlight->max = 32;
         vs_lowlight->value = zt_config_globals.lowlight_increment;
@@ -59,7 +59,7 @@ CUI_PEParms::CUI_PEParms(void) {
         cb_centered = new CheckBox;
         UI->add_element(cb_centered,4);
         cb_centered->frame = 0;
-        cb_centered->x = (start_x / 8) + 14;
+        cb_centered->x = (start_x / 8) + 17;
         cb_centered->y = (start_y / 8) + 14;
         cb_centered->xsize = 5;
         cb_centered->value = &zt_config_globals.centered_editing;
@@ -68,7 +68,7 @@ CUI_PEParms::CUI_PEParms(void) {
         cb_stepedit = new CheckBox;
         UI->add_element(cb_stepedit,5);
         cb_stepedit->frame = 0;
-        cb_stepedit->x = (start_x / 8) + 14 + 16;
+        cb_stepedit->x = (start_x / 8) + 17 + 16;
         cb_stepedit->y = (start_y / 8) + 14;
         cb_stepedit->xsize = 5;
         cb_stepedit->value = &zt_config_globals.step_editing;
@@ -77,7 +77,7 @@ CUI_PEParms::CUI_PEParms(void) {
         cb_recveloc = new CheckBox;
         UI->add_element(cb_recveloc,6);
         cb_recveloc->frame = 0;
-        cb_recveloc->x = (start_x / 8) + 14 + 32;
+        cb_recveloc->x = (start_x / 8) + 17 + 32;
         cb_recveloc->y = (start_y / 8) + 14;
         cb_recveloc->xsize = 5;
         cb_recveloc->value = &zt_config_globals.record_velocity;
@@ -86,9 +86,9 @@ CUI_PEParms::CUI_PEParms(void) {
         vs_speedup = new ValueSlider;
         UI->add_element(vs_speedup,7);
         vs_speedup->frame = 1;
-        vs_speedup->x = (start_x / 8) + 14;
+        vs_speedup->x = (start_x / 8) + 17;
         vs_speedup->y = (start_y / 8) + 16;
-        vs_speedup->xsize=window_width/8 - 20;
+        vs_speedup->xsize=window_width/8 - 23;
         vs_speedup->min=1;
         vs_speedup->max = 32;
         vs_speedup->value = zt_config_globals.control_navigation_amount;
@@ -99,7 +99,7 @@ CUI_PEParms::CUI_PEParms(void) {
         cb_drawmode = new CheckBox;
         UI->add_element(cb_drawmode, 8);
         cb_drawmode->frame = 1;
-        cb_drawmode->x = (start_x / 8) + 14;
+        cb_drawmode->x = (start_x / 8) + 17;
         cb_drawmode->y = (start_y / 8) + 18;
         cb_drawmode->xsize = 5;
         cb_drawmode->value = &drawmode_val;
@@ -195,23 +195,23 @@ void CUI_PEParms::draw(Drawable *S) {
     for(;start_y % 8;start_y--)
         ;
 
-    vs_step->x = (start_x / 8) + 14;
+    vs_step->x = (start_x / 8) + 17;
     vs_step->y = (start_y / 8) + 6; 
-    vs_pat_length->x = (start_x / 8) + 14;
+    vs_pat_length->x = (start_x / 8) + 17;
     vs_pat_length->y = (start_y / 8) + 8; 
-    vs_highlight->x = (start_x / 8) + 14;
+    vs_highlight->x = (start_x / 8) + 17;
     vs_highlight->y = (start_y / 8) + 10; 
-    vs_lowlight->x = (start_x / 8) + 14;
+    vs_lowlight->x = (start_x / 8) + 17;
     vs_lowlight->y = (start_y / 8) + 12; 
-    cb_centered->x = (start_x / 8) + 14;
+    cb_centered->x = (start_x / 8) + 17;
     cb_centered->y = (start_y / 8) + 14;
-    cb_stepedit->x = (start_x / 8) + 14 + 16;
+    cb_stepedit->x = (start_x / 8) + 17 + 16;
     cb_stepedit->y = (start_y / 8) + 14;
-    cb_recveloc->x = (start_x / 8) + 14 + 32;
+    cb_recveloc->x = (start_x / 8) + 17 + 32;
     cb_recveloc->y = (start_y / 8) + 14;
-    vs_speedup->x = (start_x / 8) + 14;
+    vs_speedup->x = (start_x / 8) + 17;
     vs_speedup->y = (start_y / 8) + 16;
-    cb_drawmode->x = (start_x / 8) + 14;
+    cb_drawmode->x = (start_x / 8) + 17;
     cb_drawmode->y = (start_y / 8) + 18;
 
 
@@ -224,15 +224,17 @@ void CUI_PEParms::draw(Drawable *S) {
         }
         printline(start_x,start_y,143,window_width / 8,COLORS.Highlight,S);
         print(col(textcenter("Pattern Editor Options")),start_y + row(2),"Pattern Editor Options",COLORS.Text,S);
-        print(start_x + col(2),start_y + row(6),"      Step:",COLORS.Text,S);
-        print(start_x + col(2),start_y + row(8),"Pat length:",COLORS.Text,S);
-        print(start_x + col(2),start_y + row(10)," HighLight:",COLORS.Text,S);
-        print(start_x + col(2),start_y + row(12),"  LowLight:",COLORS.Text,S);
-	print(start_x + col(2),start_y + row(14),"  Centered:",COLORS.Text,S);
-	print(start_x + col(20),start_y + row(14),"StepEdit:",COLORS.Text,S);
-    print(start_x + col(36),start_y + row(14),"RecVeloc:",COLORS.Text,S);
-	print(start_x + col(2),start_y + row(16),"   Speedup:",COLORS.Text,S);
-        print(start_x + col(2),start_y + row(18),"  DrawMode:",COLORS.Text,S);
+        // Right-align labels at col 16 (slider/checkbox x-origin sits
+        // at col 17 inside the popup, leaving one space gap).
+        print(start_x + col(2),start_y + row(6),     "      EditStep:",COLORS.Text,S);
+        print(start_x + col(2),start_y + row(8),     "    Pat length:",COLORS.Text,S);
+        print(start_x + col(2),start_y + row(10),    " Row Highlight:",COLORS.Text,S);
+        print(start_x + col(2),start_y + row(12),    "  Row Lowlight:",COLORS.Text,S);
+        print(start_x + col(2),start_y + row(14),    "      Centered:",COLORS.Text,S);
+        print(start_x + col(23),start_y + row(14),"StepEdit:",COLORS.Text,S);
+        print(start_x + col(39),start_y + row(14),"RecVeloc:",COLORS.Text,S);
+        print(start_x + col(2),start_y + row(16),    "       Speedup:",COLORS.Text,S);
+        print(start_x + col(2),start_y + row(18),    "      DrawMode:",COLORS.Text,S);
         UI->full_refresh();
         UI->draw(S);
         S->unlock();

--- a/src/CUI_PaletteEditor.cpp
+++ b/src/CUI_PaletteEditor.cpp
@@ -955,10 +955,13 @@ static void draw_swatch(Drawable *S, int slot, int selected, int channel_edit) {
     S->drawVLine(x0,     y0, y1, border);
     S->drawVLine(x1 - 1, y0, y1, border);
 
-    // Pattern-line preview to the right of the swatch.
+    // Pattern-line preview to the right of the swatch. Width is sized
+    // for the 8-char preview text ("C-5 01..") plus a 1-char border
+    // padding on each side; the swatch's own width is intentionally
+    // narrower than this.
     int px0 = x1 + col(1);
     int py0 = y0;
-    int px1 = px0 + col(PE_SWATCH_W);
+    int px1 = px0 + col(9);
     int py1 = py0 + row(PE_SWATCH_H);
     S->fillRect(px0, py0, px1, py1, COLORS.EditBG);
     print(px0 + 2, py0 + 2,              "C-5 01..", c, S);

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -1680,6 +1680,23 @@ void CUI_Patterneditor::update()
           status_change = 1; need_refresh++; key = 0;
         }
 
+        // Cmd+N (macOS): set length of first note of selection to length of
+        // the selection. Mirrors the Ctrl+N binding documented in help.txt;
+        // on Mac the global Alt+N → New Song would otherwise win because
+        // SDL maps Cmd to KS_META|KS_ALT.
+        if ((kstate & KS_META) && !(kstate & KS_CTRL) && !(kstate & KS_SHIFT) && key == SDLK_N) {
+          if (selected &&
+            (e = song->patterns[cur_edit_pattern]->tracks[select_track_start]->get_event(select_row_start))
+            ) {
+            j = (select_row_end+1 - select_row_start)*(96/song->tpb);
+            for(i=select_track_start;i<=select_track_end;i++)
+              song->patterns[cur_edit_pattern]->tracks[i]->update_event(select_row_start,-1,-1,-1,j,-1,-1);
+            file_changed++;
+            need_refresh++;
+          }
+          key = 0;
+        }
+
         // Double Pattern: Ctrl+Shift+G
         if ((kstate & KS_CTRL) && (kstate & KS_SHIFT) && key == SDLK_G) {
           UNDO_SAVE();

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -25,7 +25,7 @@ static PatternUndo g_undo;
 // INTERNAL_RESOLUTION_Y - 55. At 8px per character row that's ceil(55/8) = 7
 // rows; we reserve one extra row so the pattern's bottom border never touches
 // the toolbar. Matches the legacy layout (40 rows = 0..039 at 480px height).
-#define SPACE_AT_BOTTOM                 8
+#define SPACE_AT_BOTTOM                 7
 
 
 int PATTERN_EDIT_ROWS = 100;

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -3541,18 +3541,6 @@ void CUI_Patterneditor::draw(Drawable *S)
     
     draw_status_vars(S);
 
-    // Show playback position at bottom of pattern area when playing
-    if (ztPlayer->playing) {
-        static char playinfo[128];
-        snprintf(playinfo, 128, " Playing: Ord %03d  Pat %03d  Row %03d/%03d  BPM %d  TPB %d  Step %d ",
-            ztPlayer->playing_cur_order,
-            ztPlayer->playing_cur_pattern,
-            ztPlayer->playing_cur_row,
-            song->patterns[ztPlayer->playing_cur_pattern] ? song->patterns[ztPlayer->playing_cur_pattern]->length : 0,
-            song->bpm, song->tpb, cur_step);
-        print(row(1), col(CHARS_Y - 2), playinfo, COLORS.Data, S);
-    }
-
     printtitle(PAGE_TITLE_ROW_Y,"Pattern Editor (F2)",COLORS.Text,COLORS.Background,S);
     
     switch(mode) {

--- a/src/CUI_SongDuration.cpp
+++ b/src/CUI_SongDuration.cpp
@@ -16,38 +16,42 @@ void BTNCLK_close_songduration(void) {
 // ------------------------------------------------------------------------------------------------
 //
 //
-int calcSongSeconds(int cur_row, int cur_ord)
+// Returns whole-seconds duration. For sub-second precision use
+// calcSongMs() — same row-walk, but expressed in milliseconds so the
+// caller can render MM:SS.t without the integer-truncation chunkiness.
+int calcSongMs(int cur_row, int cur_ord)
 {
     int o = 0;
-    int rows = 0;
-    int seconds;
-    int cr=0;
-    
+    int64_t rows = 0;
+    int64_t cr = 0;
+
     while (o < ZTM_ORDERLIST_LEN && song->orderlist[o] == 0x101) {
         o++;
     }
 
-    while( o < ZTM_ORDERLIST_LEN && song->orderlist[o] < 0x100) {
-        rows += song->patterns[song->orderlist[o]]->length;
+    while (o < ZTM_ORDERLIST_LEN && song->orderlist[o] < 0x100) {
+        int len = song->patterns[song->orderlist[o]]->length;
+        rows += len;
         if (cur_row != -1) {
-            if (o<cur_ord)
-                cr+=song->patterns[song->orderlist[o]]->length;
-            if (o == cur_ord)
-                cr+=cur_row;
+            if (o < cur_ord) cr += len;
+            if (o == cur_ord) cr += cur_row;
         }
         o++;
-        while (o < ZTM_ORDERLIST_LEN && song->orderlist[o]==0x101)
+        while (o < ZTM_ORDERLIST_LEN && song->orderlist[o] == 0x101)
             o++;
     }
-    if (rows>0)
-        seconds = (((rows)/song->tpb)*60)/song->bpm;
-    else 
-        seconds=0;
-    if (cur_row > -1 && rows > 0) {
-        seconds = seconds*cr / rows;
-    }
-        
-    return seconds;
+
+    if (song->tpb <= 0 || song->bpm <= 0) return 0;
+
+    // Time per row = 60/(tpb*bpm) seconds → milliseconds = row*60000/(tpb*bpm).
+    int64_t denom = (int64_t)song->tpb * (int64_t)song->bpm;
+    int64_t target_rows = (cur_row > -1) ? cr : rows;
+    return (int)((target_rows * 60000) / denom);
+}
+
+int calcSongSeconds(int cur_row, int cur_ord)
+{
+    return calcSongMs(cur_row, cur_ord) / 1000;
 }
 
 

--- a/src/CUI_SongMessage.cpp
+++ b/src/CUI_SongMessage.cpp
@@ -98,6 +98,16 @@ void CUI_SongMessage::leave(void) {
 }
 
 void CUI_SongMessage::update() {
+    // Peek for ESC before UI->update() so the CommentEditor doesn't
+    // get a chance to swallow it.
+    if (Keys.size()) {
+        int key = Keys.checkkey();
+        if (key == SDLK_ESCAPE) {
+            Keys.getkey(); // consume
+            switch_page(UIP_Patterneditor);
+            return;
+        }
+    }
     UI->update();
     if (Keys.size()) {
         Keys.getkey();

--- a/src/CUI_SongMessage.cpp
+++ b/src/CUI_SongMessage.cpp
@@ -49,7 +49,7 @@ CUI_SongMessage::CUI_SongMessage(void) {
     UI->add_element(tb, 0);
     tb->x = 1;
     tb->y = 12;
-    tb->xsize = 78 + ((INTERNAL_RESOLUTION_X-640)/8);
+    tb->xsize = TextBox::full_width_xsize();
     // Bottom-anchor: same formula as CUI_Help so the textbox never
     // bleeds into the toolbar strip at INTERNAL_RESOLUTION_Y - 55.
     tb->ysize = (INTERNAL_RESOLUTION_Y/8) - tb->y - 8;
@@ -118,7 +118,7 @@ void CUI_SongMessage::draw(Drawable *S) {
     // Re-run the bottom-anchored sizing in case the window has been
     // resized since the page was constructed.
     CommentEditor *cb = (CommentEditor*)UI->get_element(0);
-    cb->xsize = 78 + ((INTERNAL_RESOLUTION_X-640)/8);
+    cb->xsize = TextBox::full_width_xsize();
     cb->ysize = (INTERNAL_RESOLUTION_Y/8) - cb->y - 8;
     // Refresh the null-terminated display mirror so TextBox::draw has
     // a clean string to walk (CDataBuf is not null-terminated; reading

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -170,7 +170,7 @@ void CUI_Songconfig::enter(void) {
     
     cur_state = STATE_SONG_CONFIG;
     Keys.flush();
-    UI->set_focus(5); // set focus to order editor
+    UI->set_focus(9); // set focus to order editor (id was 5 before renumbering)
 }
 
 void CUI_Songconfig::leave(void) {

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -92,20 +92,15 @@ CUI_Songconfig::CUI_Songconfig(void) {
         cb->xsize = 3;
         cb->value = &song->flag_SendMidiStopStart;
     // END Midi Clock
-    /* Initialize Frame for those two above */
-        fm = new Frame;
-        UI->add_gfx(fm,1);
-        fm->x = 17;
-        fm->y = base_y+5;
-        fm->xsize = 3;
-        fm->ysize = 2;
-    // END Frame
+        // Send MIDI Clock + MIDI Stop/Start checkboxes have no surrounding
+        // Frame — its right border char rendered as a yellow stripe to the
+        // right of the chips and the unframed style matches MIDI In Sync /
+        // Chase MIDI Tempo below.
 
-        // Row highlight minor / major (the global zt_config_globals
-        // values, surfaced here so song-edit tasks can tweak them
-        // without leaving F11).
+        // Row Highlight + Row Lowlight (the global zt_config_globals values,
+        // surfaced here so song-edit tasks can tweak them without leaving F11).
         vs = new ValueSlider;
-        UI->add_element(vs, 6);
+        UI->add_element(vs, 5);
         vs->frame = 0;
         vs->x = 17;
         vs->y = base_y + 8;
@@ -115,7 +110,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
         vs->value = zt_config_globals.highlight_increment;
 
         vs = new ValueSlider;
-        UI->add_element(vs, 7);
+        UI->add_element(vs, 6);
         vs->frame = 0;
         vs->x = 17;
         vs->y = base_y + 9;
@@ -133,7 +128,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
 
         // MIDI In Sync (slave to incoming MIDI clock).
         cb = new CheckBox;
-        UI->add_element(cb, 8);
+        UI->add_element(cb, 7);
         cb->frame = 0;
         cb->x = 17;
         cb->y = base_y + 11;
@@ -142,7 +137,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
 
         // Chase MIDI Tempo.
         cb = new CheckBox;
-        UI->add_element(cb, 9);
+        UI->add_element(cb, 8);
         cb->frame = 0;
         cb->x = 17;
         cb->y = base_y + 12;
@@ -150,7 +145,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
         cb->value = &zt_config_globals.midi_in_sync_chase_tempo;
 
         oe = new OrderEditor;
-        UI->add_element(oe,10);
+        UI->add_element(oe,9);
         oe->x = 59;
         oe->y = 13;
         oe->xsize = 9;
@@ -222,23 +217,23 @@ void CUI_Songconfig::update()
 
         file_changed++;
     }
-    vs = (ValueSlider *)UI->get_element(6);
+    vs = (ValueSlider *)UI->get_element(5);
     if (vs && vs->value != zt_config_globals.highlight_increment) {
         zt_config_globals.highlight_increment = vs->value;
     } else if (vs) {
         vs->value = zt_config_globals.highlight_increment;
     }
-    vs = (ValueSlider *)UI->get_element(7);
+    vs = (ValueSlider *)UI->get_element(6);
     if (vs && vs->value != zt_config_globals.lowlight_increment) {
         zt_config_globals.lowlight_increment = vs->value;
     } else if (vs) {
         vs->value = zt_config_globals.lowlight_increment;
     }
     {
-        CheckBox *cb = (CheckBox *)UI->get_element(8);
+        CheckBox *cb = (CheckBox *)UI->get_element(7);
         if (cb && cb->changed)
             zt_config_globals.midi_in_sync = *(cb->value);
-        cb = (CheckBox *)UI->get_element(9);
+        cb = (CheckBox *)UI->get_element(8);
         if (cb && cb->changed)
             zt_config_globals.midi_in_sync_chase_tempo = *(cb->value);
     }
@@ -262,9 +257,9 @@ void CUI_Songconfig::draw(Drawable *S) {
         print(row(13),col(base_y+3),"TPB",COLORS.Text,S);
         print(row(1),col(base_y+5),"Send MIDI Clock",COLORS.Text,S);
         print(row(1),col(base_y+6.),"MIDI Stop/Start",COLORS.Text,S);
-        // Row highlight minor / major sliders share the BPM/TPB column.
-        print(row(1),col(base_y+8),"Row hl minor   ",COLORS.Text,S);
-        print(row(1),col(base_y+9),"Row hl major   ",COLORS.Text,S);
+        // Row Highlight + Row Lowlight sliders share the BPM/TPB column.
+        print(row(2),col(base_y+8),"Row Highlight ",COLORS.Text,S);
+        print(row(3),col(base_y+9),"Row Lowlight ",COLORS.Text,S);
         printchar(row(17 + 27) + 1,col(base_y+8),0x84,COLORS.Highlight,S);
         printchar(row(17 + 27) + 1,col(base_y+9),0x84,COLORS.Highlight,S);
         // MIDI sync settings (moved from F12 Sysconfig + Ctrl+F12 Global Config).

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -168,18 +168,25 @@ void CUI_Songconfig::enter(void) {
     if(!zt_config_globals.lowlight_increment)
         zt_config_globals.lowlight_increment = song->tpb >> 1 / song->tpb / 2;
     
+    // F11 toggle: when re-entering Songconfig from itself (LastPage==this,
+    // i.e. user pressed F11 while already on F11), focus the Title field
+    // (id 0) instead of the OrderEditor — common workflow is to press F11
+    // a second time to rename the song.
+    bool toggling = (LastPage == this);
     cur_state = STATE_SONG_CONFIG;
     // Reset OrderEditor cursor so the focus indicator is always visible
-    // at row 0 on F11 entry (otherwise stale cursor_y/list_start from a
-    // previous visit could leave it scrolled off-screen).
-    if (oe) {
+    // at row 0 (otherwise stale cursor_y/list_start could leave it
+    // scrolled off-screen). Only reset on a fresh entry — toggling to
+    // Title leaves the OrderEditor state alone.
+    if (oe && !toggling) {
         oe->cursor_y = 0;
         oe->cursor_x = 0;
         oe->list_start = 0;
     }
     Keys.flush();
-    UI->set_focus(9); // OrderEditor — last add_element id in the constructor
-    UI->cur_element = 9;  // belt-and-suspenders against any stale focus state
+    int target = toggling ? 0 : 9;   // 0 = Title TextInput, 9 = OrderEditor
+    UI->set_focus(target);
+    UI->cur_element = target;
 }
 
 void CUI_Songconfig::leave(void) {

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -134,19 +134,19 @@ CUI_Songconfig::CUI_Songconfig(void) {
         // MIDI In Sync (slave to incoming MIDI clock).
         cb = new CheckBox;
         UI->add_element(cb, 8);
-        cb->frame = 1;
+        cb->frame = 0;
         cb->x = 17;
         cb->y = base_y + 11;
-        cb->xsize = 5;
+        cb->xsize = 3;
         cb->value = &zt_config_globals.midi_in_sync;
 
         // Chase MIDI Tempo.
         cb = new CheckBox;
         UI->add_element(cb, 9);
-        cb->frame = 1;
+        cb->frame = 0;
         cb->x = 17;
         cb->y = base_y + 12;
-        cb->xsize = 5;
+        cb->xsize = 3;
         cb->value = &zt_config_globals.midi_in_sync_chase_tempo;
 
         oe = new OrderEditor;

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -101,8 +101,38 @@ CUI_Songconfig::CUI_Songconfig(void) {
         fm->ysize = 2;
     // END Frame
 
+        // Row highlight minor / major (the global zt_config_globals
+        // values, surfaced here so song-edit tasks can tweak them
+        // without leaving F11).
+        vs = new ValueSlider;
+        UI->add_element(vs, 6);
+        vs->frame = 0;
+        vs->x = 17;
+        vs->y = base_y + 8;
+        vs->xsize = 28;
+        vs->min = 1;
+        vs->max = 64;
+        vs->value = zt_config_globals.highlight_increment;
+
+        vs = new ValueSlider;
+        UI->add_element(vs, 7);
+        vs->frame = 0;
+        vs->x = 17;
+        vs->y = base_y + 9;
+        vs->xsize = 28;
+        vs->min = 1;
+        vs->max = 64;
+        vs->value = zt_config_globals.lowlight_increment;
+
+        fm = new Frame;
+        UI->add_gfx(fm, 2);
+        fm->x = 17;
+        fm->y = base_y + 8;
+        fm->xsize = 28;
+        fm->ysize = 2;
+
         oe = new OrderEditor;
-        UI->add_element(oe,5);
+        UI->add_element(oe,8);
         oe->x = 59;
         oe->y = 13;
         oe->xsize = 9;
@@ -136,9 +166,10 @@ void CUI_Songconfig::leave(void) {
 
 void CUI_Songconfig::update()
 {
-    // Reserve 8 rows at the bottom: 7 for the 55px toolbar (ceil(55/8)) plus
-    // one row of safety so the order editor's frame never overlaps.
-    oe->ysize =  ((INTERNAL_RESOLUTION_Y/8) - oe->y - 8) ;
+    // Reserve 7 rows at the bottom for the 55 px toolbar (ceil(55/8));
+    // one extra row of safety was previously added but it left the order
+    // list one row short of the F1 Help bottom edge.
+    oe->ysize =  ((INTERNAL_RESOLUTION_Y/8) - oe->y - 7) ;
 
     ValueSlider *vs;
     TextInput *t;
@@ -161,8 +192,8 @@ void CUI_Songconfig::update()
         file_changed++;
     }
     vs = (ValueSlider *)UI->get_element(2);
-    if (vs->value != rev_tpb_tab[song->tpb]) { 
-        song->tpb = tpb_tab[vs->value]; 
+    if (vs->value != rev_tpb_tab[song->tpb]) {
+        song->tpb = tpb_tab[vs->value];
         ztPlayer->set_speed();
         vs->force_f=1; vs->force_v = song->tpb;
 
@@ -170,8 +201,20 @@ void CUI_Songconfig::update()
             zt_config_globals.highlight_increment = song->tpb;
         if(!zt_config_globals.lowlight_increment)
             zt_config_globals.lowlight_increment = song->tpb >> 1 / song->tpb / 2;
-        
+
         file_changed++;
+    }
+    vs = (ValueSlider *)UI->get_element(6);
+    if (vs && vs->value != zt_config_globals.highlight_increment) {
+        zt_config_globals.highlight_increment = vs->value;
+    } else if (vs) {
+        vs->value = zt_config_globals.highlight_increment;
+    }
+    vs = (ValueSlider *)UI->get_element(7);
+    if (vs && vs->value != zt_config_globals.lowlight_increment) {
+        zt_config_globals.lowlight_increment = vs->value;
+    } else if (vs) {
+        vs->value = zt_config_globals.lowlight_increment;
     }
     if (Keys.size()) {
         Keys.getkey();
@@ -193,11 +236,14 @@ void CUI_Songconfig::draw(Drawable *S) {
         print(row(13),col(base_y+3),"TPB",COLORS.Text,S);
         print(row(1),col(base_y+5),"Send MIDI Clock",COLORS.Text,S);
         print(row(1),col(base_y+6.),"MIDI Stop/Start",COLORS.Text,S);
-        // Order List label: row 11 (one blank row below page title at 9),
-        // horizontally clear of the OE data (OE starts at column 59, so
-        // put label at column 60 which is inside the OE x-span so it
-        // visually belongs to the list).
-        print(row(60),col(11),"Order List",COLORS.Text,S);
+        // Row highlight minor / major sliders share the BPM/TPB column.
+        print(row(1),col(base_y+8),"Row hl minor   ",COLORS.Text,S);
+        print(row(1),col(base_y+9),"Row hl major   ",COLORS.Text,S);
+        printchar(row(17 + 27) + 1,col(base_y+8),0x84,COLORS.Highlight,S);
+        printchar(row(17 + 27) + 1,col(base_y+9),0x84,COLORS.Highlight,S);
+        // Order List label aligned to the OE x-origin (col 59) so the
+        // header sits flush over the "000" index column.
+        print(row(59),col(11),"Order List",COLORS.Text,S);
         printchar(row(17 + 27) + 1,col(base_y+2),0x84,COLORS.Highlight,S);
         printchar(row(17 + 27) + 1,col(base_y+3),0x84,COLORS.Highlight,S);
 

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -268,8 +268,8 @@ void CUI_Songconfig::draw(Drawable *S) {
         printchar(row(17 + 27) + 1,col(base_y+8),0x84,COLORS.Highlight,S);
         printchar(row(17 + 27) + 1,col(base_y+9),0x84,COLORS.Highlight,S);
         // MIDI sync settings (moved from F12 Sysconfig + Ctrl+F12 Global Config).
-        print(row(1),col(base_y+11),"  MIDI In Sync",COLORS.Text,S);
-        print(row(1),col(base_y+12),"Chase MIDI Tempo",COLORS.Text,S);
+        print(row(1),col(base_y+11),"   MIDI In Sync",COLORS.Text,S);
+        print(row(0),col(base_y+12),"Chase MIDI Tempo",COLORS.Text,S);
         // Order List label aligned to the OE x-origin (col 59) so the
         // header sits flush over the "000" index column.
         print(row(59),col(11),"Order List",COLORS.Text,S);

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -131,8 +131,26 @@ CUI_Songconfig::CUI_Songconfig(void) {
         fm->xsize = 28;
         fm->ysize = 2;
 
+        // MIDI In Sync (slave to incoming MIDI clock).
+        cb = new CheckBox;
+        UI->add_element(cb, 8);
+        cb->frame = 1;
+        cb->x = 17;
+        cb->y = base_y + 11;
+        cb->xsize = 5;
+        cb->value = &zt_config_globals.midi_in_sync;
+
+        // Chase MIDI Tempo.
+        cb = new CheckBox;
+        UI->add_element(cb, 9);
+        cb->frame = 1;
+        cb->x = 17;
+        cb->y = base_y + 12;
+        cb->xsize = 5;
+        cb->value = &zt_config_globals.midi_in_sync_chase_tempo;
+
         oe = new OrderEditor;
-        UI->add_element(oe,8);
+        UI->add_element(oe,10);
         oe->x = 59;
         oe->y = 13;
         oe->xsize = 9;
@@ -216,6 +234,14 @@ void CUI_Songconfig::update()
     } else if (vs) {
         vs->value = zt_config_globals.lowlight_increment;
     }
+    {
+        CheckBox *cb = (CheckBox *)UI->get_element(8);
+        if (cb && cb->changed)
+            zt_config_globals.midi_in_sync = *(cb->value);
+        cb = (CheckBox *)UI->get_element(9);
+        if (cb && cb->changed)
+            zt_config_globals.midi_in_sync_chase_tempo = *(cb->value);
+    }
     if (Keys.size()) {
         Keys.getkey();
     }
@@ -241,6 +267,9 @@ void CUI_Songconfig::draw(Drawable *S) {
         print(row(1),col(base_y+9),"Row hl major   ",COLORS.Text,S);
         printchar(row(17 + 27) + 1,col(base_y+8),0x84,COLORS.Highlight,S);
         printchar(row(17 + 27) + 1,col(base_y+9),0x84,COLORS.Highlight,S);
+        // MIDI sync settings (moved from F12 Sysconfig + Ctrl+F12 Global Config).
+        print(row(1),col(base_y+11),"  MIDI In Sync",COLORS.Text,S);
+        print(row(1),col(base_y+12),"Chase MIDI Tempo",COLORS.Text,S);
         // Order List label aligned to the OE x-origin (col 59) so the
         // header sits flush over the "000" index column.
         print(row(59),col(11),"Order List",COLORS.Text,S);

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -169,8 +169,17 @@ void CUI_Songconfig::enter(void) {
         zt_config_globals.lowlight_increment = song->tpb >> 1 / song->tpb / 2;
     
     cur_state = STATE_SONG_CONFIG;
+    // Reset OrderEditor cursor so the focus indicator is always visible
+    // at row 0 on F11 entry (otherwise stale cursor_y/list_start from a
+    // previous visit could leave it scrolled off-screen).
+    if (oe) {
+        oe->cursor_y = 0;
+        oe->cursor_x = 0;
+        oe->list_start = 0;
+    }
     Keys.flush();
-    UI->set_focus(9); // set focus to order editor (id was 5 before renumbering)
+    UI->set_focus(9); // OrderEditor — last add_element id in the constructor
+    UI->cur_element = 9;  // belt-and-suspenders against any stale focus state
 }
 
 void CUI_Songconfig::leave(void) {
@@ -206,6 +215,23 @@ void CUI_Songconfig::update()
     }
     vs = (ValueSlider *)UI->get_element(2);
     if (vs->value != rev_tpb_tab[song->tpb]) {
+        // The TPB slider's `value` is an INDEX into tpb_tab[] {2,4,6,8,12,
+        // 16,24,32,48}, not the actual TPB. Arrow steps move through the
+        // index. But typed-numeric input (vs->from_input) gives the user's
+        // intended TPB literally — they pressed "4" because they want
+        // TPB=4, not slider index 4 (which would map to TPB=12).
+        // When from_input is set and the typed value matches a real TPB,
+        // remap value through rev_tpb_tab so the index lines up.
+        if (vs->from_input) {
+            bool valid_tpb = false;
+            for (int i = 0; i <= 8; i++) {
+                if (tpb_tab[i] == vs->value) { valid_tpb = true; break; }
+            }
+            if (valid_tpb) {
+                vs->value = rev_tpb_tab[vs->value];
+            }
+            vs->from_input = 0;
+        }
         song->tpb = tpb_tab[vs->value];
         ztPlayer->set_speed();
         vs->force_f=1; vs->force_v = song->tpb;

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -202,8 +202,9 @@ void CUI_Songconfig::update()
 
     UI->update();
     vs = (ValueSlider *)UI->get_element(1);
-    if (vs->value != song->bpm) { 
-        song->bpm = vs->value; 
+    if (vs->from_input) vs->from_input = 0;  // BPM slider takes any [min,max]; clamp already applied
+    if (vs->value != song->bpm) {
+        song->bpm = vs->value;
         ztPlayer->set_speed();
 
         if(!zt_config_globals.highlight_increment)
@@ -214,24 +215,30 @@ void CUI_Songconfig::update()
         file_changed++;
     }
     vs = (ValueSlider *)UI->get_element(2);
-    if (vs->value != rev_tpb_tab[song->tpb]) {
-        // The TPB slider's `value` is an INDEX into tpb_tab[] {2,4,6,8,12,
-        // 16,24,32,48}, not the actual TPB. Arrow steps move through the
-        // index. But typed-numeric input (vs->from_input) gives the user's
-        // intended TPB literally — they pressed "4" because they want
-        // TPB=4, not slider index 4 (which would map to TPB=12).
-        // When from_input is set and the typed value matches a real TPB,
-        // remap value through rev_tpb_tab so the index lines up.
-        if (vs->from_input) {
-            bool valid_tpb = false;
-            for (int i = 0; i <= 8; i++) {
-                if (tpb_tab[i] == vs->value) { valid_tpb = true; break; }
+    if (vs->from_input) {
+        // Typed-numeric path. vs->input_value holds the raw number the
+        // user entered (preserved before clamping in Sliders.cpp). Snap
+        // to the nearest valid TPB in tpb_tab[]={2,4,6,8,12,16,24,32,48}
+        // so '8' -> TPB=8 (slider index 3), '5' -> TPB=4 (nearest), etc.
+        // On ties, prefer the higher TPB (more granular, common in
+        // tracker conventions).
+        int typed = vs->input_value;
+        int best_idx = 0;
+        int best_diff = abs(tpb_tab[0] - typed);
+        for (int i = 1; i <= 8; i++) {
+            int diff = abs(tpb_tab[i] - typed);
+            if (diff < best_diff || (diff == best_diff && tpb_tab[i] > typed)) {
+                best_diff = diff;
+                best_idx = i;
             }
-            if (valid_tpb) {
-                vs->value = rev_tpb_tab[vs->value];
-            }
-            vs->from_input = 0;
         }
+        vs->value = best_idx;
+        vs->from_input = 0;
+    }
+    // Clamp slider index to the table range regardless of input source.
+    if (vs->value < 0) vs->value = 0;
+    if (vs->value > 8) vs->value = 8;
+    if (tpb_tab[vs->value] != song->tpb) {
         song->tpb = tpb_tab[vs->value];
         ztPlayer->set_speed();
         vs->force_f=1; vs->force_v = song->tpb;
@@ -244,12 +251,14 @@ void CUI_Songconfig::update()
         file_changed++;
     }
     vs = (ValueSlider *)UI->get_element(5);
+    if (vs && vs->from_input) vs->from_input = 0;
     if (vs && vs->value != zt_config_globals.highlight_increment) {
         zt_config_globals.highlight_increment = vs->value;
     } else if (vs) {
         vs->value = zt_config_globals.highlight_increment;
     }
     vs = (ValueSlider *)UI->get_element(6);
+    if (vs && vs->from_input) vs->from_input = 0;
     if (vs && vs->value != zt_config_globals.lowlight_increment) {
         zt_config_globals.lowlight_increment = vs->value;
     } else if (vs) {

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -80,7 +80,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
         cb->frame = 0;
         cb->x = 17;
         cb->y = base_y+5;
-        cb->xsize = 5;
+        cb->xsize = 3;
         cb->value = &song->flag_SendMidiClock;
     // END Midi Clock
     /* Initialize MIDI Stop/Start checkbox */
@@ -89,15 +89,15 @@ CUI_Songconfig::CUI_Songconfig(void) {
         cb->frame = 0;
         cb->x = 17;
         cb->y = base_y+6;
-        cb->xsize = 5;
+        cb->xsize = 3;
         cb->value = &song->flag_SendMidiStopStart;
     // END Midi Clock
     /* Initialize Frame for those two above */
         fm = new Frame;
         UI->add_gfx(fm,1);
         fm->x = 17;
-        fm->y = base_y+5; 
-        fm->xsize = 5;
+        fm->y = base_y+5;
+        fm->xsize = 3;
         fm->ysize = 2;
     // END Frame
 

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -37,7 +37,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
         ti = new TextInput;
         UI->add_element(ti,0);
         ti->frame = 1;
-        ti->x = 17;
+        ti->x = 20;
         ti->y = base_y;
         ti->xsize=28;
         ti->length=28;
@@ -47,7 +47,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
         vs = new ValueSlider;
         UI->add_element(vs,1);
         vs->frame = 0;
-        vs->x = 17; 
+        vs->x = 20; 
         vs->y = base_y+2; 
         vs->xsize=28;
         vs->min = 60;
@@ -58,7 +58,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
         vs = new ValueSlider;
         UI->add_element(vs,2);
         vs->frame = 0;
-        vs->x = 17; 
+        vs->x = 20; 
         vs->y = base_y+3; 
         vs->xsize=28;
         vs->min = 0;
@@ -69,7 +69,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
     /* Initialize Frame for those two above*/
         fm = new Frame;
         UI->add_gfx(fm,0);
-        fm->x = 17;
+        fm->x = 20;
         fm->y = base_y+2;
         fm->xsize = 28;
         fm->ysize = 2;
@@ -78,7 +78,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
         cb = new CheckBox;
         UI->add_element(cb,3);
         cb->frame = 0;
-        cb->x = 17;
+        cb->x = 20;
         cb->y = base_y+5;
         cb->xsize = 3;
         cb->value = &song->flag_SendMidiClock;
@@ -87,7 +87,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
         cb = new CheckBox;
         UI->add_element(cb,4);
         cb->frame = 0;
-        cb->x = 17;
+        cb->x = 20;
         cb->y = base_y+6;
         cb->xsize = 3;
         cb->value = &song->flag_SendMidiStopStart;
@@ -102,7 +102,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
         vs = new ValueSlider;
         UI->add_element(vs, 5);
         vs->frame = 0;
-        vs->x = 17;
+        vs->x = 20;
         vs->y = base_y + 8;
         vs->xsize = 28;
         vs->min = 1;
@@ -112,7 +112,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
         vs = new ValueSlider;
         UI->add_element(vs, 6);
         vs->frame = 0;
-        vs->x = 17;
+        vs->x = 20;
         vs->y = base_y + 9;
         vs->xsize = 28;
         vs->min = 1;
@@ -121,7 +121,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
 
         fm = new Frame;
         UI->add_gfx(fm, 2);
-        fm->x = 17;
+        fm->x = 20;
         fm->y = base_y + 8;
         fm->xsize = 28;
         fm->ysize = 2;
@@ -130,7 +130,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
         cb = new CheckBox;
         UI->add_element(cb, 7);
         cb->frame = 0;
-        cb->x = 17;
+        cb->x = 20;
         cb->y = base_y + 11;
         cb->xsize = 3;
         cb->value = &zt_config_globals.midi_in_sync;
@@ -139,7 +139,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
         cb = new CheckBox;
         UI->add_element(cb, 8);
         cb->frame = 0;
-        cb->x = 17;
+        cb->x = 20;
         cb->y = base_y + 12;
         cb->xsize = 3;
         cb->value = &zt_config_globals.midi_in_sync_chase_tempo;
@@ -248,28 +248,24 @@ void CUI_Songconfig::draw(Drawable *S) {
         UI->draw(S);
         draw_status(S);
         printtitle(PAGE_TITLE_ROW_Y,"Song Configuration (F11)",COLORS.Text,COLORS.Background,S);
-        // Right-align Title/BPM/TPB labels so their right edge sits one
-        // char before the textfield/slider start (col 17), matching the
-        // tight "Send MIDI Clock" / "MIDI Stop/Start" pattern below.
-        // "Title" = 5 chars → col 11; "BPM"/"TPB" = 3 chars → col 13.
-        print(row(11),col(base_y),"Title",COLORS.Text,S);
-        print(row(13),col(base_y+2),"BPM",COLORS.Text,S);
-        print(row(13),col(base_y+3),"TPB",COLORS.Text,S);
-        print(row(1),col(base_y+5),"Send MIDI Clock",COLORS.Text,S);
-        print(row(1),col(base_y+6.),"MIDI Stop/Start",COLORS.Text,S);
-        // Row Highlight + Row Lowlight sliders share the BPM/TPB column.
-        print(row(2),col(base_y+8),"Row Highlight ",COLORS.Text,S);
-        print(row(3),col(base_y+9),"Row Lowlight ",COLORS.Text,S);
-        printchar(row(17 + 27) + 1,col(base_y+8),0x84,COLORS.Highlight,S);
-        printchar(row(17 + 27) + 1,col(base_y+9),0x84,COLORS.Highlight,S);
-        // MIDI sync settings (moved from F12 Sysconfig + Ctrl+F12 Global Config).
-        print(row(1),col(base_y+11),"   MIDI In Sync",COLORS.Text,S);
-        print(row(0),col(base_y+12),"Chase MIDI Tempo",COLORS.Text,S);
-        // Order List label aligned to the OE x-origin (col 59) so the
-        // header sits flush over the "000" index column.
+        // All labels right-align so text ends col 18 (1-char gap before
+        // col-20 controls). Order List is on its own column (col 59)
+        // and is intentionally NOT shifted.
+        print(row(14),col(base_y),"Title",COLORS.Text,S);
+        print(row(16),col(base_y+2),"BPM",COLORS.Text,S);
+        print(row(16),col(base_y+3),"TPB",COLORS.Text,S);
+        print(row(4),col(base_y+5),"Send MIDI Clock",COLORS.Text,S);
+        print(row(4),col(base_y+6.),"MIDI Stop/Start",COLORS.Text,S);
+        print(row(5),col(base_y+8),"Row Highlight ",COLORS.Text,S);
+        print(row(6),col(base_y+9),"Row Lowlight ",COLORS.Text,S);
+        printchar(row(20 + 27) + 1,col(base_y+8),0x84,COLORS.Highlight,S);
+        printchar(row(20 + 27) + 1,col(base_y+9),0x84,COLORS.Highlight,S);
+        print(row(4),col(base_y+11),"   MIDI In Sync",COLORS.Text,S);
+        print(row(3),col(base_y+12),"Chase MIDI Tempo",COLORS.Text,S);
+        // Order List label aligned to the OE x-origin (col 59) — NOT shifted.
         print(row(59),col(11),"Order List",COLORS.Text,S);
-        printchar(row(17 + 27) + 1,col(base_y+2),0x84,COLORS.Highlight,S);
-        printchar(row(17 + 27) + 1,col(base_y+3),0x84,COLORS.Highlight,S);
+        printchar(row(20 + 27) + 1,col(base_y+2),0x84,COLORS.Highlight,S);
+        printchar(row(20 + 27) + 1,col(base_y+3),0x84,COLORS.Highlight,S);
 
         need_refresh = 0; updated=2;
         ztPlayer->num_orders();

--- a/src/CUI_Sysconfig.cpp
+++ b/src/CUI_Sysconfig.cpp
@@ -261,7 +261,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         UI->add_element(b,tabindex++);
         b->caption = "   Go to page 2   ";
         b->xsize = 18;
-        b->x = 2;
+        b->x = 4;   // align start with "MIDI Out Device Selection" label below
         b->y = 12;
         b->ysize = 1;
         b->OnClick = (ActFunc)BTNCLK_GotoGlobalConfig;
@@ -301,7 +301,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         cb = new CheckBox;
         UI->add_element(cb,tabindex++);
         cb->x = 4 + 16;
-        cb->y = base_y + 6;
+        cb->y = base_y + 4;   // moved 2 rows up
         cb->xsize = 3;
         cb->value = &zt_config_globals.auto_open_midi;
         cb->frame = 0;
@@ -340,7 +340,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         UI->add_element(sk,tabindex++);
         sk->x = 4+35 +10;
         sk->y = base_y + 1;   // "Skin Selection" label sits on the same row as "Prebuffer"; list top border one row below
-        sk->xsize = 19+4;
+        sk->xsize = 19+8;     // ends at col 76, matches MIDI In Device list end
         sk->ysize = 7;   // tight-fit around installed skin count, avoids empty black space
 
         // MIDI Out column — visual order: Refresh (y=28), list (y=30-42),
@@ -485,7 +485,7 @@ void CUI_Sysconfig::draw(Drawable *S) {
         print(row(4),col(TRACKS_ROW_Y+3),"      Prebuffer",COLORS.Text,S);
         print(row(4),col(TRACKS_ROW_Y+5),"  Panic on stop",COLORS.Text,S);
         // "MIDI-IN Slave" label intentionally omitted — see F11 (Songconfig).
-        print(row(4),col(TRACKS_ROW_Y+9)," Auto-open MIDI",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+7)," Auto-open MIDI",COLORS.Text,S);
 
         print(row(4),col(TRACKS_ROW_Y+11),"    Full Screen",COLORS.Text,S);
 #ifndef DISABLED_CONFIGURATION_VALUES

--- a/src/CUI_Sysconfig.cpp
+++ b/src/CUI_Sysconfig.cpp
@@ -284,13 +284,18 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         cb->value = &zt_config_globals.auto_send_panic;
         cb->frame = 1;
 
+        // MIDI In Sync (a.k.a. "MIDI-IN Slave"). The user-facing label
+        // lives in F11 (Songconfig) now, but we keep the element here
+        // off-screen so the tabindex/get_element(N) numbering elsewhere
+        // doesn't shift. xsize=0 / no_tab_stop hide it from cycling.
         cb = new CheckBox;
         UI->add_element(cb,tabindex++);
-        cb->x = 4 + 15;
-        cb->y = base_y + 4;
-        cb->xsize = 5;
+        cb->x = 0;
+        cb->y = 0;
+        cb->xsize = 0;
         cb->value = &zt_config_globals.midi_in_sync;
-        cb->frame = 1;
+        cb->frame = 0;
+        cb->no_tab_stop = 1;
 
         cb = new CheckBox;
         UI->add_element(cb,tabindex++);
@@ -479,7 +484,7 @@ void CUI_Sysconfig::draw(Drawable *S) {
         // "Go to page 2" button, rows 11 and 13 are empty gaps.
         print(row(4),col(TRACKS_ROW_Y+3),"     Prebuffer",COLORS.Text,S);
         print(row(4),col(TRACKS_ROW_Y+5)," Panic on stop",COLORS.Text,S);
-        print(row(4),col(TRACKS_ROW_Y+7)," MIDI-IN Slave",COLORS.Text,S);
+        // "MIDI-IN Slave" label intentionally omitted — see F11 (Songconfig).
         print(row(4),col(TRACKS_ROW_Y+9),"Auto-open MIDI",COLORS.Text,S);
 
         print(row(4),col(TRACKS_ROW_Y+11),"   Full Screen",COLORS.Text,S);

--- a/src/CUI_Sysconfig.cpp
+++ b/src/CUI_Sysconfig.cpp
@@ -280,7 +280,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         cb = new CheckBox;
         UI->add_element(cb,tabindex++);
         cb->x = 4 + 16;
-        cb->y = base_y + 2;
+        cb->y = base_y + 2;   // Panic on stop
         cb->xsize = 3;
         cb->value = &zt_config_globals.auto_send_panic;
         cb->frame = 0;
@@ -301,7 +301,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         cb = new CheckBox;
         UI->add_element(cb,tabindex++);
         cb->x = 4 + 16;
-        cb->y = base_y + 4;   // moved 2 rows up
+        cb->y = base_y + 3;   // Auto-open MIDI — adjacent to Panic on stop
         cb->xsize = 3;
         cb->value = &zt_config_globals.auto_open_midi;
         cb->frame = 0;
@@ -309,7 +309,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         cb = new CheckBox;
         UI->add_element(cb,tabindex++); // Full Screen cb — update() reads via get_element(5)
         cb->x = 4+16;
-        cb->y = base_y + 8;
+        cb->y = base_y + 4;   // adjacent to Auto-open MIDI; matches F11 tight checkbox stack
         cb->xsize = 3;
         cb->value = &zt_config_globals.full_screen;
         cb->frame = 0;
@@ -485,9 +485,9 @@ void CUI_Sysconfig::draw(Drawable *S) {
         print(row(4),col(TRACKS_ROW_Y+3),"      Prebuffer",COLORS.Text,S);
         print(row(4),col(TRACKS_ROW_Y+5),"  Panic on stop",COLORS.Text,S);
         // "MIDI-IN Slave" label intentionally omitted — see F11 (Songconfig).
-        print(row(4),col(TRACKS_ROW_Y+7)," Auto-open MIDI",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+6)," Auto-open MIDI",COLORS.Text,S);
 
-        print(row(4),col(TRACKS_ROW_Y+11),"    Full Screen",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+7),"    Full Screen",COLORS.Text,S);
 #ifndef DISABLED_CONFIGURATION_VALUES
         print(row(4),col(TRACKS_ROW_Y+13),"     Key Repeat",COLORS.Text,S);
         print(row(4),col(TRACKS_ROW_Y+15),"       Key Wait",COLORS.Text,S);

--- a/src/CUI_Sysconfig.cpp
+++ b/src/CUI_Sysconfig.cpp
@@ -496,7 +496,7 @@ void CUI_Sysconfig::draw(Drawable *S) {
         print(row(5),col(49),"Reverse Bank Select ",COLORS.Text,S);
         print(row(5),col(51),"Device Alias",COLORS.Text,S);
         
-        need_refresh = 0; 
+        need_refresh = 0;
         updated=2;
         S->unlock();
     }

--- a/src/CUI_Sysconfig.cpp
+++ b/src/CUI_Sysconfig.cpp
@@ -466,7 +466,6 @@ void CUI_Sysconfig::update() {
     if (bIsFullscreen) i = 1;
     if ( * cb->value != i) {
         attempt_fullscreen_toggle();
-        attempt_fullscreen_toggle();
     }
     if (Keys.size()) {
         Keys.getkey();

--- a/src/CUI_Sysconfig.cpp
+++ b/src/CUI_Sysconfig.cpp
@@ -268,7 +268,8 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
 
         vs = new ValueSlider;
         UI->add_element(vs,tabindex++);
-        vs->x = 4 + 15;
+        // Left column controls at col 20 to match Global Config (Ctrl+F12).
+        vs->x = 4 + 16;
         vs->y = base_y;
         vs->xsize = 15+1;
         vs->ysize = 1;
@@ -278,7 +279,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
 
         cb = new CheckBox;
         UI->add_element(cb,tabindex++);
-        cb->x = 4 + 15;
+        cb->x = 4 + 16;
         cb->y = base_y + 2;
         cb->xsize = 5;
         cb->value = &zt_config_globals.auto_send_panic;
@@ -299,7 +300,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
 
         cb = new CheckBox;
         UI->add_element(cb,tabindex++);
-        cb->x = 4 + 15;
+        cb->x = 4 + 16;
         cb->y = base_y + 6;
         cb->xsize = 5;
         cb->value = &zt_config_globals.auto_open_midi;
@@ -308,7 +309,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         cb = new CheckBox;
         UI->add_element(cb,tabindex++); // Full Screen cb — update() reads via get_element(5)
         cb->frame = 0;
-        cb->x = 4+15;
+        cb->x = 4+16;
         cb->y = base_y + 8;
         cb->xsize = 5;
         cb->value = &zt_config_globals.full_screen;
@@ -317,7 +318,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
 #ifndef DISABLED_CONFIGURATION_VALUES
         vs = new ValueSlider;
         UI->add_element(vs,tabindex++);
-        vs->x = 4+15;
+        vs->x = 4+16;
         vs->y = base_y + 10;
         vs->xsize = 15+4;
         vs->ysize = 1;
@@ -327,7 +328,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
 
         vs = new ValueSlider;
         UI->add_element(vs,tabindex++);
-        vs->x = 4+15;
+        vs->x = 4+16;
         vs->y = base_y + 12;
         vs->xsize = 15+4;
         vs->ysize = 1;
@@ -375,7 +376,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
 
         vs = new LatencyValueSlider(ml);
         UI->add_element(vs,tabindex++);
-        vs->x = 19;                    // align with Prebuffer slider
+        vs->x = 20;                    // align with Prebuffer slider
         vs->y = 47;
         vs->xsize = 15;
         vs->ysize = 1;
@@ -385,7 +386,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         cb = new BankSelectCheckBox(ml);
         UI->add_element(cb,tabindex++);
         cb->frame = 0;
-        cb->x = 25;
+        cb->x = 26;
         cb->y = 49;
         cb->xsize = 5;
         cb->frame = 1;
@@ -393,7 +394,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         ti = new AliasTextInput(ml);
         UI->add_element(ti,tabindex++);
         ti->frame = 1;
-        ti->x = 19;                    // align with Prebuffer slider
+        ti->x = 20;                    // align with Prebuffer slider
         ti->y = 51;
         ti->xsize=42;
         ti->length=41;
@@ -482,15 +483,17 @@ void CUI_Sysconfig::draw(Drawable *S) {
         printtitle(PAGE_TITLE_ROW_Y,"System Configuration (F12)",COLORS.Text,COLORS.Background,S);
         // Labels shifted +3 rows from legacy position: row 12 holds the
         // "Go to page 2" button, rows 11 and 13 are empty gaps.
-        print(row(4),col(TRACKS_ROW_Y+3),"     Prebuffer",COLORS.Text,S);
-        print(row(4),col(TRACKS_ROW_Y+5)," Panic on stop",COLORS.Text,S);
+        // Labels right-align so text ends at col 18 (1-char gap before
+        // col-20 controls). Matches Global Config (Ctrl+F12).
+        print(row(4),col(TRACKS_ROW_Y+3),"      Prebuffer",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+5),"  Panic on stop",COLORS.Text,S);
         // "MIDI-IN Slave" label intentionally omitted — see F11 (Songconfig).
-        print(row(4),col(TRACKS_ROW_Y+9),"Auto-open MIDI",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+9)," Auto-open MIDI",COLORS.Text,S);
 
-        print(row(4),col(TRACKS_ROW_Y+11),"   Full Screen",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+11),"    Full Screen",COLORS.Text,S);
 #ifndef DISABLED_CONFIGURATION_VALUES
-        print(row(4),col(TRACKS_ROW_Y+13),"    Key Repeat",COLORS.Text,S);
-        print(row(4),col(TRACKS_ROW_Y+15),"      Key Wait",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+13),"     Key Repeat",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+15),"       Key Wait",COLORS.Text,S);
 #endif
         print(row(4+37+8),col(TRACKS_ROW_Y+3),"Skin Selection",COLORS.Text,S);
 

--- a/src/CUI_Sysconfig.cpp
+++ b/src/CUI_Sysconfig.cpp
@@ -283,7 +283,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         cb->y = base_y + 2;
         cb->xsize = 3;
         cb->value = &zt_config_globals.auto_send_panic;
-        cb->frame = 1;
+        cb->frame = 0;
 
         // MIDI In Sync (a.k.a. "MIDI-IN Slave"). The user-facing label
         // lives in F11 (Songconfig) now, but we keep the element here
@@ -304,7 +304,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         cb->y = base_y + 6;
         cb->xsize = 3;
         cb->value = &zt_config_globals.auto_open_midi;
-        cb->frame = 1;
+        cb->frame = 0;
 
         cb = new CheckBox;
         UI->add_element(cb,tabindex++); // Full Screen cb — update() reads via get_element(5)
@@ -312,7 +312,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         cb->y = base_y + 8;
         cb->xsize = 3;
         cb->value = &zt_config_globals.full_screen;
-        cb->frame = 1;
+        cb->frame = 0;
 
 #ifndef DISABLED_CONFIGURATION_VALUES
         vs = new ValueSlider;
@@ -387,7 +387,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         cb->x = 26;
         cb->y = 49;
         cb->xsize = 3;
-        cb->frame = 1;
+        cb->frame = 0;
 
         ti = new AliasTextInput(ml);
         UI->add_element(ti,tabindex++);

--- a/src/CUI_Sysconfig.cpp
+++ b/src/CUI_Sysconfig.cpp
@@ -314,6 +314,15 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         cb->value = &zt_config_globals.full_screen;
         cb->frame = 0;
 
+        // Record Velocity (moved from Ctrl+F12 Global Config).
+        cb = new CheckBox;
+        UI->add_element(cb,tabindex++);
+        cb->x = 4+16;
+        cb->y = base_y + 5;
+        cb->xsize = 3;
+        cb->value = &zt_config_globals.record_velocity;
+        cb->frame = 0;
+
 #ifndef DISABLED_CONFIGURATION_VALUES
         vs = new ValueSlider;
         UI->add_element(vs,tabindex++);
@@ -488,6 +497,7 @@ void CUI_Sysconfig::draw(Drawable *S) {
         print(row(4),col(TRACKS_ROW_Y+6)," Auto-open MIDI",COLORS.Text,S);
 
         print(row(4),col(TRACKS_ROW_Y+7),"    Full Screen",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+8),"Record Velocity",COLORS.Text,S);
 #ifndef DISABLED_CONFIGURATION_VALUES
         print(row(4),col(TRACKS_ROW_Y+13),"     Key Repeat",COLORS.Text,S);
         print(row(4),col(TRACKS_ROW_Y+15),"       Key Wait",COLORS.Text,S);

--- a/src/CUI_Sysconfig.cpp
+++ b/src/CUI_Sysconfig.cpp
@@ -281,7 +281,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         UI->add_element(cb,tabindex++);
         cb->x = 4 + 16;
         cb->y = base_y + 2;
-        cb->xsize = 5;
+        cb->xsize = 3;
         cb->value = &zt_config_globals.auto_send_panic;
         cb->frame = 1;
 
@@ -302,16 +302,15 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         UI->add_element(cb,tabindex++);
         cb->x = 4 + 16;
         cb->y = base_y + 6;
-        cb->xsize = 5;
+        cb->xsize = 3;
         cb->value = &zt_config_globals.auto_open_midi;
         cb->frame = 1;
 
         cb = new CheckBox;
         UI->add_element(cb,tabindex++); // Full Screen cb — update() reads via get_element(5)
-        cb->frame = 0;
         cb->x = 4+16;
         cb->y = base_y + 8;
-        cb->xsize = 5;
+        cb->xsize = 3;
         cb->value = &zt_config_globals.full_screen;
         cb->frame = 1;
 
@@ -385,10 +384,9 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
 
         cb = new BankSelectCheckBox(ml);
         UI->add_element(cb,tabindex++);
-        cb->frame = 0;
         cb->x = 26;
         cb->y = 49;
-        cb->xsize = 5;
+        cb->xsize = 3;
         cb->frame = 1;
 
         ti = new AliasTextInput(ml);

--- a/src/CUI_Sysconfig.cpp
+++ b/src/CUI_Sysconfig.cpp
@@ -352,69 +352,14 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         sk->xsize = 19+8;     // ends at col 76, matches MIDI In Device list end
         sk->ysize = 7;   // tight-fit around installed skin count, avoids empty black space
 
-        // MIDI Out column — visual order: Refresh (y=28), list (y=30-42),
-        // Open device (y=45), Latency (y=47), Bank (y=49), Alias (y=51).
-        // tabindex follows the same order so UP/DOWN navigates top-to-bottom.
+        // MIDI In column lives on the LEFT, MIDI Out on the RIGHT (+37
+        // offset). Layout: Refresh (y=28), list (y=30-42), Open device
+        // (y=45). MIDI Out also has Latency (y=47), Bank (y=49), Alias
+        // (y=51). tabindex order: MIDI In group first, then MIDI Out.
         b = new Button;
         UI->add_element(b,tabindex++);
         b->caption = " Refresh";
         b->x = 4+26;
-        b->y = 48 - 16 -2-2;
-        b->xsize = 9;
-        b->ysize = 1;
-        b->OnClick = (ActFunc)BTNCLK_RefreshMidiOutDeviceList;
-
-        ml = new MidiOutDeviceOpener;
-        UI->add_element(ml,tabindex++);
-        midioutdevlist = ml;
-        ml->x = 4;
-        ml->y = 48 - 16-2;
-        ml->xsize=35;
-        ml->ysize = 13;
-
-        b = new Button;
-        UI->add_element(b,tabindex++);
-        b->caption = " Open device   ";
-        b->x = 4+21;
-        b->y = 45;
-        b->xsize = 14;
-        b->ysize = 1;
-        b->OnClick = (ActFunc)BTNCLK_ForgetMidiOutDevice;
-        midiout_action_button = b;
-
-        vs = new LatencyValueSlider(ml);
-        UI->add_element(vs,tabindex++);
-        vs->x = 20;                    // align with Prebuffer slider
-        vs->y = 47;
-        vs->xsize = 15;
-        vs->ysize = 1;
-        vs->min = 0;
-        vs->max = 255;
-
-        cb = new BankSelectCheckBox(ml);
-        UI->add_element(cb,tabindex++);
-        cb->x = 26;
-        cb->y = 49;
-        cb->xsize = 3;
-        cb->frame = 0;
-
-        ti = new AliasTextInput(ml);
-        UI->add_element(ti,tabindex++);
-        ti->frame = 1;
-        ti->x = 20;                    // align with Prebuffer slider
-        ti->y = 51;
-        ti->xsize=42;
-        ti->length=41;
-
-        ml->lvs = vs;  // link midi out list to latency value slider
-        ml->bscb = cb; // link midi out list to bank select checkbox
-        ml->al = ti;
-
-        // MIDI In column — same visual order: Refresh, list, Open device.
-        b = new Button;
-        UI->add_element(b,tabindex++);
-        b->caption = " Refresh";
-        b->x = 4+26+37;
         b->y = 48 - 16 -2-2;
         b->xsize = 9;
         b->ysize = 1;
@@ -423,10 +368,38 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         mi = new MidiInDeviceOpener;
         midiindevlist = mi;
         UI->add_element(mi,tabindex++);
-        mi->x = 4+37;
+        mi->x = 4;
         mi->y = 48 - 16-2;
         mi->xsize=35;
         mi->ysize = 13;
+
+        b = new Button;
+        UI->add_element(b,tabindex++);
+        b->caption = " Open device   ";
+        b->x = 4+21;
+        b->y = 45;
+        b->xsize = 14;
+        b->ysize = 1;
+        b->OnClick = (ActFunc)BTNCLK_ForgetMidiInDevice;
+        midiin_action_button = b;
+
+        // MIDI Out column (right side, +37 offset).
+        b = new Button;
+        UI->add_element(b,tabindex++);
+        b->caption = " Refresh";
+        b->x = 4+26+37;
+        b->y = 48 - 16 -2-2;
+        b->xsize = 9;
+        b->ysize = 1;
+        b->OnClick = (ActFunc)BTNCLK_RefreshMidiOutDeviceList;
+
+        ml = new MidiOutDeviceOpener;
+        UI->add_element(ml,tabindex++);
+        midioutdevlist = ml;
+        ml->x = 4+37;
+        ml->y = 48 - 16-2;
+        ml->xsize=35;
+        ml->ysize = 13;
 
         b = new Button;
         UI->add_element(b,tabindex++);
@@ -435,8 +408,43 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         b->y = 45;
         b->xsize = 14;
         b->ysize = 1;
-        b->OnClick = (ActFunc)BTNCLK_ForgetMidiInDevice;
-        midiin_action_button = b;
+        b->OnClick = (ActFunc)BTNCLK_ForgetMidiOutDevice;
+        midiout_action_button = b;
+
+        vs = new LatencyValueSlider(ml);
+        UI->add_element(vs,tabindex++);
+        vs->x = 20+37;
+        vs->y = 47;
+        vs->xsize = 15;
+        vs->ysize = 1;
+        vs->min = 0;
+        vs->max = 255;
+
+        cb = new BankSelectCheckBox(ml);
+        UI->add_element(cb,tabindex++);
+        cb->x = 26+37;
+        cb->y = 49;
+        cb->xsize = 3;
+        cb->frame = 0;
+
+        ti = new AliasTextInput(ml);
+        UI->add_element(ti,tabindex++);
+        ti->frame = 1;
+        ti->x = 20+37;
+        ti->y = 51;
+        // Alias visible width must fit between x=57 and the right edge.
+        // Default 640px screen = 80 cols, so available = 80-57-1 = 22.
+        // Wider screens get more room. The buffer (length) holds up to
+        // 41 chars regardless — TextInput scrolls horizontally.
+        {
+            const int avail = (INTERNAL_RESOLUTION_X / FONT_SIZE_X) - 57 - 1;
+            ti->xsize  = (avail > 42) ? 42 : (avail > 1 ? avail : 1);
+            ti->length = 41;
+        }
+
+        ml->lvs = vs;  // link midi out list to latency value slider
+        ml->bscb = cb; // link midi out list to bank select checkbox
+        ml->al = ti;
 
 }
 
@@ -504,12 +512,13 @@ void CUI_Sysconfig::draw(Drawable *S) {
 #endif
         print(row(4+37+8),col(TRACKS_ROW_Y+3),"Skin Selection",COLORS.Text,S);
 
-        print(row(4),col(28),"MIDI Out Device Selection",COLORS.Text,S);
-        print(row(4+37),col(28),"MIDI In Device Selection",COLORS.Text,S);
+        // MIDI In on the LEFT (col 4), MIDI Out on the RIGHT (col 4+37).
+        print(row(4),col(28),"MIDI In Device Selection",COLORS.Text,S);
+        print(row(4+37),col(28),"MIDI Out Device Selection",COLORS.Text,S);
 
-        print(row(5),col(47),"Latency ",COLORS.Text,S);
-        print(row(5),col(49),"Reverse Bank Select ",COLORS.Text,S);
-        print(row(5),col(51),"Device Alias",COLORS.Text,S);
+        print(row(5+37),col(47),"Latency ",COLORS.Text,S);
+        print(row(5+37),col(49),"Reverse Bank Select ",COLORS.Text,S);
+        print(row(5+37),col(51),"Device Alias",COLORS.Text,S);
         
         need_refresh = 0;
         updated=2;

--- a/src/InstEditor.cpp
+++ b/src/InstEditor.cpp
@@ -552,11 +552,15 @@ void InstEditor::draw(Drawable *S, int active)
     printcharBG(col(x + 24),row(cy+y),168,COLORS.Lowlight,COLORS.EditBG,S);
   }
 
+  // Extend frame to include the instrument-number / used-mark column on
+  // the left (cols x-4..x-1) so the bordered area covers ALL displayed
+  // content, matching the OrderEditor / pattern-track-frame convention
+  // in F2 where row labels live inside the frame.
   frm->type=0;
-  frm->x=x; frm->y=y; frm->xsize=xsize; frm->ysize=ysize;
+  frm->x=x-4; frm->y=y; frm->xsize=xsize+4; frm->ysize=ysize;
   frm->draw(S,0);
-  
-  screenmanager.Update(col(x-4),row(y-1),col(x+xsize+1),row(y+ysize+1));
+
+  screenmanager.Update(col(x-5),row(y-1),col(x+xsize+1),row(y+ysize+1));
 }
 
 

--- a/src/Sliders.cpp
+++ b/src/Sliders.cpp
@@ -14,6 +14,7 @@ ValueSlider::ValueSlider(int fset)
     ysize   = 1;
     newclick= 1;
     focus = fset;
+    from_input = 0;
 }
 
 
@@ -120,6 +121,7 @@ int ValueSlider::update() {
         if (!UIP_SliderInput->canceled) {
             changed++;
             value = c;
+            from_input = 1;
         }
         if (window_stack.isempty())
             needaclear++; 
@@ -332,6 +334,7 @@ int ValueSliderDL::update() {
         if (!UIP_SliderInput->canceled) {
             changed++;
             value = c;
+            from_input = 1;
         }
         needaclear++; need_refresh++;
     }

--- a/src/Sliders.cpp
+++ b/src/Sliders.cpp
@@ -293,7 +293,10 @@ void ValueSliderOFF::draw(Drawable *S, int active) {
             sprintf(str,"%.2d",value);
         v = value;
     }
-    printBG(col(x+xsize+1),row(cy),str,COLORS.Text,COLORS.Background,S);
+    // One char of gap between the slider's right border and the
+    // numeric readout, matching ValueSlider::draw above (which gets
+    // the same effect by prefixing its sprintf format with a space).
+    printBG(col(x+xsize+2),row(cy),str,COLORS.Text,COLORS.Background,S);
     if (active)
         col = COLORS.Highlight;
     else
@@ -305,7 +308,7 @@ void ValueSliderOFF::draw(Drawable *S, int active) {
         printchar(col(x-1),row(y),0x84,COLORS.Lowlight,S);
         printchar(col(x+xsize),row(y),0x83,COLORS.Highlight,S);
     }
-    screenmanager.Update(col(x-1),row(y-1),col(x+xsize+7),row(y+1));
+    screenmanager.Update(col(x-1),row(y-1),col(x+xsize+8),row(y+1));
     changed = 0;
 }
 

--- a/src/Sliders.cpp
+++ b/src/Sliders.cpp
@@ -15,6 +15,7 @@ ValueSlider::ValueSlider(int fset)
     newclick= 1;
     focus = fset;
     from_input = 0;
+    input_value = 0;
 }
 
 
@@ -121,6 +122,7 @@ int ValueSlider::update() {
         if (!UIP_SliderInput->canceled) {
             changed++;
             value = c;
+            input_value = c;  // preserve raw before any clamping
             from_input = 1;
         }
         if (window_stack.isempty())
@@ -334,6 +336,7 @@ int ValueSliderDL::update() {
         if (!UIP_SliderInput->canceled) {
             changed++;
             value = c;
+            input_value = c;  // preserve raw before any clamping
             from_input = 1;
         }
         needaclear++; need_refresh++;

--- a/src/Sliders.cpp
+++ b/src/Sliders.cpp
@@ -298,9 +298,11 @@ void ValueSliderOFF::draw(Drawable *S, int active) {
         v = value;
     }
     // One char of gap between the slider's right border and the
-    // numeric readout, matching ValueSlider::draw above (which gets
-    // the same effect by prefixing its sprintf format with a space).
-    printBG(col(x+xsize+2),row(cy),str,COLORS.Text,COLORS.Background,S);
+    // numeric readout. ValueSlider::draw uses x+xsize and prefixes the
+    // sprintf format with a leading space (effective text col x+xsize+1);
+    // matching that here so ValueSliderOFF readouts (Patch, Bank) align
+    // with adjacent ValueSliderDL readouts (Default Length, etc.).
+    printBG(col(x+xsize+1),row(cy),str,COLORS.Text,COLORS.Background,S);
     if (active)
         col = COLORS.Highlight;
     else

--- a/src/Sliders.h
+++ b/src/Sliders.h
@@ -17,6 +17,9 @@ class ValueSlider : public UserInterfaceElement {
         int from_input;  // set when value was just set via numeric SliderInput popup;
                          // callers can use this to disambiguate typed-value vs arrow-step
                          // for sliders backed by an index table (e.g. TPB).
+        int input_value; // raw typed number from the popup, preserved BEFORE clamping
+                         // so callers can see the user's literal input even if it falls
+                         // outside [min,max]. Only valid when from_input == 1.
         explicit ValueSlider(int fset = 0);
         virtual ~ValueSlider() = default ;
         int mouseupdate(int cur_element);

--- a/src/Sliders.h
+++ b/src/Sliders.h
@@ -14,6 +14,9 @@ class ValueSlider : public UserInterfaceElement {
         int clear;
         int newclick;
         int focus;  // new value here
+        int from_input;  // set when value was just set via numeric SliderInput popup;
+                         // callers can use this to disambiguate typed-value vs arrow-step
+                         // for sliders backed by an index table (e.g. TPB).
         explicit ValueSlider(int fset = 0);
         virtual ~ValueSlider() = default ;
         int mouseupdate(int cur_element);

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -1017,28 +1017,33 @@ void CheckBox::draw(Drawable *S, int active) {
     int cx,cy=y;
     TColor f,b;
     const char *str;
-    for(cx=x;cx<x+xsize;cx++) {
-        printBG(col(cx),row(cy)," ",COLORS.Text,COLORS.EditBG,S);
-    }
     if (*value)
-        str = "On";
+        str = "On ";
     else
         str = "Off";
+    // Visible chip width derives from the string length so the dark
+    // background is exactly as wide as the text (no trailing padding).
+    // Both "Off" and "On " are 3 chars, so it's a single source of
+    // truth: change the strings and every checkbox in the app follows.
+    const int chip_w = (int)strlen(str);
+    for(cx=x;cx<x+chip_w;cx++) {
+        printBG(col(cx),row(cy)," ",COLORS.Text,COLORS.EditBG,S);
+    }
     if (active) {
         f = COLORS.EditBG;
-        b = COLORS.Highlight; 
+        b = COLORS.Highlight;
     } else {
         f = COLORS.EditText;
         b = COLORS.EditBG;
     }
     printBG(col(x),col(y),str,f,b,S);
     if (frame) {
-        printline(col(x),row(y-1),0x86,xsize,COLORS.Lowlight,S);
-        printline(col(x),row(y+1),0x81,xsize,COLORS.Highlight,S);
+        printline(col(x),row(y-1),0x86,chip_w,COLORS.Lowlight,S);
+        printline(col(x),row(y+1),0x81,chip_w,COLORS.Highlight,S);
         printchar(col(x-1),row(y),0x84,COLORS.Lowlight,S);
-        printchar(col(x+xsize),row(y),0x83,COLORS.Highlight,S);
+        printchar(col(x+chip_w),row(y),0x83,COLORS.Highlight,S);
     }
-    screenmanager.Update(col(x-1),row(y-1),col(x+xsize+1),row(y+1));
+    screenmanager.Update(col(x-1),row(y-1),col(x+chip_w+1),row(y+1));
     changed = 0;
 }
 

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -926,6 +926,10 @@ void TextInput::draw(Drawable *S, int active) {
 //
 CheckBox::CheckBox(void) {
     value = NULL;
+    // Default chip width: "Off" (3 chars) is the widest visible state.
+    // Callers can override but should not exceed 3 — wider values cause a
+    // trailing wipe-to-background that can render slightly off the page bg.
+    xsize = 3;
 }
 
 
@@ -1032,11 +1036,12 @@ void CheckBox::draw(Drawable *S, int active) {
     // Both "Off" and "On " are 3 chars, so it's a single source of
     // truth: change the strings and every checkbox in the app follows.
     const int chip_w = (int)strlen(str);
-    // Wipe trailing cells back to page background. Covers both the
-    // caller-reserved xsize beyond the chip AND the Off->On transition
-    // where the chip shrinks 3->2 and the old "f" cell would otherwise
-    // linger. Min wipe extent is 3 (Off width).
-    const int wipe_end = (xsize > 3) ? xsize : 3;
+    // Visible chip is always chip_w cells wide ("Off"=3, "On"=2). Wipe
+    // up to "Off" width so an Off->On transition clears the stale "f"
+    // cell. Caller-supplied xsize is for the click area only — never
+    // expand the painted region beyond chip_w, since the wipe color may
+    // not match every page's background and would render as a bleed.
+    const int wipe_end = 3;
     if (wipe_end > chip_w) {
         for (cx = x + chip_w; cx < x + wipe_end; cx++) {
             printBG(col(cx),row(cy)," ",COLORS.Text,COLORS.Background,S);

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -1058,12 +1058,10 @@ void CheckBox::draw(Drawable *S, int active) {
         b = COLORS.EditBG;
     }
     printBG(col(x),col(y),str,f,b,S);
-    if (frame) {
-        printline(col(x),row(y-1),0x86,chip_w,COLORS.Lowlight,S);
-        printline(col(x),row(y+1),0x81,chip_w,COLORS.Highlight,S);
-        printchar(col(x-1),row(y),0x84,COLORS.Lowlight,S);
-        printchar(col(x+chip_w),row(y),0x83,COLORS.Highlight,S);
-    }
+    // Frame border is intentionally never drawn around checkboxes — the
+    // border chars rendered as a yellow stripe next to the chip and added
+    // no information on top of the dark chip background. Callers may still
+    // set frame=1, but the flag is a no-op here.
     int dirty_w = (xsize > chip_w) ? xsize : chip_w;
     screenmanager.Update(col(x-1),row(y-1),col(x+dirty_w+1),row(y+1));
     changed = 0;

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -612,6 +612,10 @@ int UserInterfaceElement::mouseupdate(int cur_element)
 //
 TextInput::TextInput(void) {
     cursor = 0;
+    str = NULL;
+    length = 0;
+    xsize = 0;
+    frame = 0;
 }
 
 
@@ -927,9 +931,11 @@ void TextInput::draw(Drawable *S, int active) {
 CheckBox::CheckBox(void) {
     value = NULL;
     // Default chip width: "Off" (3 chars) is the widest visible state.
-    // Callers can override but should not exceed 3 — wider values cause a
-    // trailing wipe-to-background that can render slightly off the page bg.
     xsize = 3;
+    // Frame is a no-op in CheckBox::draw (the border rendered as a yellow
+    // stripe and added no info) — default to 0 so callers don't need to
+    // reset it from the inherited default of 1.
+    frame = 0;
 }
 
 
@@ -1707,6 +1713,11 @@ TextBox::TextBox()
   bEof = false;
   bUseColors = 1;
   bWordWrap = false;
+}
+
+int TextBox::full_width_xsize()
+{
+    return 78 + ((INTERNAL_RESOLUTION_X - 640) / 8);
 }
 
 

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -1024,7 +1024,7 @@ void CheckBox::draw(Drawable *S, int active) {
     TColor f,b;
     const char *str;
     if (*value)
-        str = "On ";
+        str = "On";
     else
         str = "Off";
     // Visible chip width derives from the string length so the dark
@@ -1032,12 +1032,13 @@ void CheckBox::draw(Drawable *S, int active) {
     // Both "Off" and "On " are 3 chars, so it's a single source of
     // truth: change the strings and every checkbox in the app follows.
     const int chip_w = (int)strlen(str);
-    // If the caller's reserved xsize is wider than the visible chip,
-    // wipe the trailing cells back to page background so old "On  "
-    // pixels don't linger after a redraw. Only the cy row — wiping the
-    // rows above and below clobbers neighbouring UI elements.
-    if (xsize > chip_w) {
-        for (cx = x + chip_w; cx < x + xsize; cx++) {
+    // Wipe trailing cells back to page background. Covers both the
+    // caller-reserved xsize beyond the chip AND the Off->On transition
+    // where the chip shrinks 3->2 and the old "f" cell would otherwise
+    // linger. Min wipe extent is 3 (Off width).
+    const int wipe_end = (xsize > 3) ? xsize : 3;
+    if (wipe_end > chip_w) {
+        for (cx = x + chip_w; cx < x + wipe_end; cx++) {
             printBG(col(cx),row(cy)," ",COLORS.Text,COLORS.Background,S);
         }
     }

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -1014,6 +1014,12 @@ int CheckBox::update() {
 //
 //
 void CheckBox::draw(Drawable *S, int active) {
+    // Hidden placeholder: callers can hide a checkbox (without renumbering
+    // get_element() indices elsewhere) by setting xsize=0. Honour that.
+    if (xsize <= 0) {
+        changed = 0;
+        return;
+    }
     int cx,cy=y;
     TColor f,b;
     const char *str;
@@ -1026,15 +1032,14 @@ void CheckBox::draw(Drawable *S, int active) {
     // Both "Off" and "On " are 3 chars, so it's a single source of
     // truth: change the strings and every checkbox in the app follows.
     const int chip_w = (int)strlen(str);
-    // Clear the wider area first (xsize is the bookkeeping width that
-    // callers reserve for hit-testing / older layouts) so we wipe any
-    // stale pixels from a previous chip that was rendered wider, then
-    // paint the visible chip exactly chip_w cells wide.
-    int wipe_w = (xsize > chip_w) ? xsize : chip_w;
-    for (cx = x - 1; cx <= x + wipe_w; cx++) {
-        printBG(col(cx),row(cy-1)," ",COLORS.Text,COLORS.Background,S);
-        printBG(col(cx),row(cy)  ," ",COLORS.Text,COLORS.Background,S);
-        printBG(col(cx),row(cy+1)," ",COLORS.Text,COLORS.Background,S);
+    // If the caller's reserved xsize is wider than the visible chip,
+    // wipe the trailing cells back to page background so old "On  "
+    // pixels don't linger after a redraw. Only the cy row — wiping the
+    // rows above and below clobbers neighbouring UI elements.
+    if (xsize > chip_w) {
+        for (cx = x + chip_w; cx < x + xsize; cx++) {
+            printBG(col(cx),row(cy)," ",COLORS.Text,COLORS.Background,S);
+        }
     }
     for(cx=x;cx<x+chip_w;cx++) {
         printBG(col(cx),row(cy)," ",COLORS.Text,COLORS.EditBG,S);
@@ -1053,7 +1058,8 @@ void CheckBox::draw(Drawable *S, int active) {
         printchar(col(x-1),row(y),0x84,COLORS.Lowlight,S);
         printchar(col(x+chip_w),row(y),0x83,COLORS.Highlight,S);
     }
-    screenmanager.Update(col(x-1),row(y-1),col(x+wipe_w+1),row(y+1));
+    int dirty_w = (xsize > chip_w) ? xsize : chip_w;
+    screenmanager.Update(col(x-1),row(y-1),col(x+dirty_w+1),row(y+1));
     changed = 0;
 }
 

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -1026,6 +1026,16 @@ void CheckBox::draw(Drawable *S, int active) {
     // Both "Off" and "On " are 3 chars, so it's a single source of
     // truth: change the strings and every checkbox in the app follows.
     const int chip_w = (int)strlen(str);
+    // Clear the wider area first (xsize is the bookkeeping width that
+    // callers reserve for hit-testing / older layouts) so we wipe any
+    // stale pixels from a previous chip that was rendered wider, then
+    // paint the visible chip exactly chip_w cells wide.
+    int wipe_w = (xsize > chip_w) ? xsize : chip_w;
+    for (cx = x - 1; cx <= x + wipe_w; cx++) {
+        printBG(col(cx),row(cy-1)," ",COLORS.Text,COLORS.Background,S);
+        printBG(col(cx),row(cy)  ," ",COLORS.Text,COLORS.Background,S);
+        printBG(col(cx),row(cy+1)," ",COLORS.Text,COLORS.Background,S);
+    }
     for(cx=x;cx<x+chip_w;cx++) {
         printBG(col(cx),row(cy)," ",COLORS.Text,COLORS.EditBG,S);
     }
@@ -1043,7 +1053,7 @@ void CheckBox::draw(Drawable *S, int active) {
         printchar(col(x-1),row(y),0x84,COLORS.Lowlight,S);
         printchar(col(x+chip_w),row(y),0x83,COLORS.Highlight,S);
     }
-    screenmanager.Update(col(x-1),row(y-1),col(x+chip_w+1),row(y+1));
+    screenmanager.Update(col(x-1),row(y-1),col(x+wipe_w+1),row(y+1));
     changed = 0;
 }
 

--- a/src/UserInterface.h
+++ b/src/UserInterface.h
@@ -235,6 +235,11 @@ class TextBox : public UserInterfaceElement {
         int update();
         void draw(Drawable *S, int active);
         int mouseupdate(int cur_element);
+
+        // Responsive full-width helper: 78 cols at 640px-wide windows,
+        // grows by 1 col per 8px of extra resolution. Centralized so
+        // callers don't copy-paste the formula.
+        static int full_width_xsize();
 };
 
 class CommentEditor : public TextBox {

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -252,7 +252,7 @@ ZTConf::ZTConf() {
     control_navigation_amount = 2;
     default_directory[0] = '\0';
     record_velocity = 1;
-    post_load_page = POST_LOAD_INST_EDIT;
+    post_load_page = POST_LOAD_PATTERN_EDIT;
 }
 
 ZTConf::~ZTConf() {
@@ -302,7 +302,7 @@ int ZTConf::load()
   if(Config->get("post_load_page")) {
       post_load_page = atoi(Config->get("post_load_page"));
       if (post_load_page < 0 || post_load_page >= POST_LOAD_PAGE_COUNT)
-          post_load_page = POST_LOAD_INST_EDIT;
+          post_load_page = POST_LOAD_PATTERN_EDIT;
   }
   
   ////////////////////////////////////////////////

--- a/src/conf.h
+++ b/src/conf.h
@@ -15,8 +15,14 @@ enum E_edit_viewmode { VIEW_SQUISH, VIEW_REGULAR, VIEW_FX, VIEW_BIG }; //, VIEW_
 // Editor (F3) — matches the long-standing behaviour. Pattern Editor
 // (F2) suits arrangers who go straight to writing notes; Song Config
 // (F11) suits people who want to verify BPM/TPB/order list first.
-enum E_post_load_page { POST_LOAD_INST_EDIT = 0, POST_LOAD_PATTERN_EDIT, POST_LOAD_SONG_CONFIG };
-#define POST_LOAD_PAGE_COUNT 3
+enum E_post_load_page {
+    POST_LOAD_PATTERN_EDIT = 0,
+    POST_LOAD_INST_EDIT,
+    POST_LOAD_PLAYSONG,        // F5 (Playsong page)
+    POST_LOAD_SONG_CONFIG,     // F11 (Order list / Song config)
+    POST_LOAD_SONG_MESSAGE     // F10 (Song message editor)
+};
+#define POST_LOAD_PAGE_COUNT 5
 
 
 //  New class ZTConf puts all global variables in one place

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -939,11 +939,14 @@ void update_status(Drawable *S)
   if (ztPlayer->playing) {
 
     char time[128],time2[64];
-    int sec;
-    sec = calcSongSeconds(ztPlayer->playing_cur_row, ztPlayer->playing_cur_order);
-    sprintf(time2, "|H|%.2d|U|:|H|%.2d|U|",sec/60,sec%60);
-    sec = calcSongSeconds();
-    sprintf(time, "%s/|H|%.2d|U|:|H|%.2d|U|",time2,sec/60,sec%60);
+    int ms = calcSongMs(ztPlayer->playing_cur_row, ztPlayer->playing_cur_order);
+    int sec = ms / 1000;
+    int tenth = (ms % 1000) / 100;
+    sprintf(time2, "|H|%.2d|U|:|H|%.2d|U|.|H|%d|U|", sec/60, sec%60, tenth);
+    ms = calcSongMs();
+    sec = ms / 1000;
+    tenth = (ms % 1000) / 100;
+    sprintf(time, "%s/|H|%.2d|U|:|H|%.2d|U|.|H|%d|U|", time2, sec/60, sec%60, tenth);
 
     if (ztPlayer->playmode) {
       sprintf(szStatmsg,"Playing, Ord: |H|%.3d|U|/|H|%.3d|U|, Pat: |H|%.3d|U|/|H|255|U|, Row: |H|%.3d|U|/|H|%.3d|U|, Time: %s, BPM: |H|%d|U|, TPB: |H|%d|U|, Step: |H|%d|U|  ",ztPlayer->playing_cur_order,ztPlayer->num_real_orders,ztPlayer->playing_cur_pattern,ztPlayer->playing_cur_row,song->patterns[ztPlayer->playing_cur_pattern]->length,time,song->bpm,song->tpb,cur_step);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -946,11 +946,11 @@ void update_status(Drawable *S)
       sprintf(time2, "|H|%.2d|U|:|H|%.2d|U|",sec/60,sec%60);
       sec = calcSongSeconds();
       sprintf(time, "%s/|H|%.2d|U|:|H|%.2d|U|",time2,sec/60,sec%60);
-      sprintf(szStatmsg,"Playing, Ord: |H|%.3d|U|/|H|%.3d|U|, Pat: |H|%.3d|U|/|H|255|U|, Row: |H|%.3d|U|/|H|%.3d|U|, Time: %s  ",ztPlayer->playing_cur_order,ztPlayer->num_real_orders,ztPlayer->playing_cur_pattern,ztPlayer->playing_cur_row,song->patterns[ztPlayer->playing_cur_pattern]->length,time);
+      sprintf(szStatmsg,"Playing, Ord: |H|%.3d|U|/|H|%.3d|U|, Pat: |H|%.3d|U|/|H|255|U|, Row: |H|%.3d|U|/|H|%.3d|U|, Time: %s, BPM: |H|%d|U|, TPB: |H|%d|U|, Step: |H|%d|U|  ",ztPlayer->playing_cur_order,ztPlayer->num_real_orders,ztPlayer->playing_cur_pattern,ztPlayer->playing_cur_row,song->patterns[ztPlayer->playing_cur_pattern]->length,time,song->bpm,song->tpb,cur_step);
     }
     else {
 
-      sprintf(szStatmsg,"Looping, Pattern: |H|%.3d|U|/|H|255|U|, Row: |H|%.3d|U|/|H|%.3d|U|  ",ztPlayer->playing_cur_pattern,ztPlayer->playing_cur_row,song->patterns[ztPlayer->playing_cur_pattern]->length);
+      sprintf(szStatmsg,"Looping, Pattern: |H|%.3d|U|/|H|255|U|, Row: |H|%.3d|U|/|H|%.3d|U|, BPM: |H|%d|U|, TPB: |H|%d|U|, Step: |H|%d|U|  ",ztPlayer->playing_cur_pattern,ztPlayer->playing_cur_row,song->patterns[ztPlayer->playing_cur_pattern]->length,song->bpm,song->tpb,cur_step);
     }
 
     statusmsg = szStatmsg;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -938,19 +938,19 @@ void update_status(Drawable *S)
   // currently editing in.
   if (ztPlayer->playing) {
 
-    if (ztPlayer->playmode) {
+    char time[128],time2[64];
+    int sec;
+    sec = calcSongSeconds(ztPlayer->playing_cur_row, ztPlayer->playing_cur_order);
+    sprintf(time2, "|H|%.2d|U|:|H|%.2d|U|",sec/60,sec%60);
+    sec = calcSongSeconds();
+    sprintf(time, "%s/|H|%.2d|U|:|H|%.2d|U|",time2,sec/60,sec%60);
 
-      char time[128],time2[64];
-      int sec;
-      sec = calcSongSeconds(ztPlayer->playing_cur_row, ztPlayer->playing_cur_order);
-      sprintf(time2, "|H|%.2d|U|:|H|%.2d|U|",sec/60,sec%60);
-      sec = calcSongSeconds();
-      sprintf(time, "%s/|H|%.2d|U|:|H|%.2d|U|",time2,sec/60,sec%60);
+    if (ztPlayer->playmode) {
       sprintf(szStatmsg,"Playing, Ord: |H|%.3d|U|/|H|%.3d|U|, Pat: |H|%.3d|U|/|H|255|U|, Row: |H|%.3d|U|/|H|%.3d|U|, Time: %s, BPM: |H|%d|U|, TPB: |H|%d|U|, Step: |H|%d|U|  ",ztPlayer->playing_cur_order,ztPlayer->num_real_orders,ztPlayer->playing_cur_pattern,ztPlayer->playing_cur_row,song->patterns[ztPlayer->playing_cur_pattern]->length,time,song->bpm,song->tpb,cur_step);
     }
     else {
 
-      sprintf(szStatmsg,"Looping, Pattern: |H|%.3d|U|/|H|255|U|, Row: |H|%.3d|U|/|H|%.3d|U|, BPM: |H|%d|U|, TPB: |H|%d|U|, Step: |H|%d|U|  ",ztPlayer->playing_cur_pattern,ztPlayer->playing_cur_row,song->patterns[ztPlayer->playing_cur_pattern]->length,song->bpm,song->tpb,cur_step);
+      sprintf(szStatmsg,"Looping, Pattern: |H|%.3d|U|/|H|255|U|, Row: |H|%.3d|U|/|H|%.3d|U|, Time: %s, BPM: |H|%d|U|, TPB: |H|%d|U|, Step: |H|%d|U|  ",ztPlayer->playing_cur_pattern,ztPlayer->playing_cur_row,song->patterns[ztPlayer->playing_cur_pattern]->length,time,song->bpm,song->tpb,cur_step);
     }
 
     statusmsg = szStatmsg;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -905,9 +905,20 @@ char *hex2note(char *str,unsigned char note)
 //
 void status(const char *msg,Drawable *S)
 {
-    printBG(col(3),row(INITIAL_ROW + 6),"                                                                            ",COLORS.Text,COLORS.Background,S);
+    // Wipe the full status row up to the right screen edge before
+    // drawing the new message. Hardcoded 76-space string left a stale
+    // strip at the right when a long Playing/Looping line shrank to
+    // "Stopped" on a window wider than 640px.
+    const int max_cols = INTERNAL_RESOLUTION_X / FONT_SIZE_X;
+    char wipe[256];
+    int n = max_cols - 3;
+    if (n < 0) n = 0;
+    if (n > (int)sizeof(wipe) - 1) n = sizeof(wipe) - 1;
+    memset(wipe, ' ', n);
+    wipe[n] = '\0';
+    printBG(col(3),row(INITIAL_ROW + 6),wipe,COLORS.Text,COLORS.Background,S);
     printBGCC(col(3),row(INITIAL_ROW + 6),msg,COLORS.Text,COLORS.Background,S);
-    screenmanager.Update(col(3),row(INITIAL_ROW + 6),col(80)-1,row(10));
+    screenmanager.Update(col(3),row(INITIAL_ROW + 6),col(max_cols)-1,row(10));
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -928,11 +928,10 @@ void update_status(Drawable *S)
   int i,o=0;
   char str[10];
 
-  // Refresh the playing/looping status line on the pages where it makes
-  // sense (Pattern Editor + Play Song). Other pages (Help, Instrument
-  // Editor, Sys Config…) keep the status bar quiet so the playback line
-  // doesn't bleed over their own UI.
-  if (ztPlayer->playing && (cur_state == STATE_PEDIT || cur_state == STATE_PLAY)) {
+  // Refresh the playing/looping status line on every page so the user
+  // can always see where playback is, regardless of which view they're
+  // currently editing in.
+  if (ztPlayer->playing) {
 
     if (ztPlayer->playmode) {
 
@@ -958,10 +957,6 @@ void update_status(Drawable *S)
       cur_edit_row     = ztPlayer->playing_cur_row;
       need_refresh++;
     }
-  }
-  else if (ztPlayer->playing && cur_state != STATE_PEDIT && cur_state != STATE_PLAY) {
-    // Keep statusmsg quiet on Help/InstEdit/SysConfig/etc while playing.
-    statusmsg = (char*)" ";
   }
 
   if (S->lock() == 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -950,10 +950,15 @@ void update_status(Drawable *S)
   if (ztPlayer->playing) {
 
     char time[128],time2[64];
-    int ms = calcSongMs(ztPlayer->playing_cur_row, ztPlayer->playing_cur_order);
+    // Elapsed time: wall-clock since play() started. This is immune to
+    // row-quantization (calcSongMs jumps by tpb*bpm row chunks, which
+    // skips intermediate tenths — at BPM=120 TPB=4 the .4 tenth never
+    // shows because rows hit 0.375 and 0.500 with no value in between).
+    int ms = (int)((uint64_t)SDL_GetTicks() - ztPlayer->playback_start_ms);
     int sec = ms / 1000;
     int tenth = (ms % 1000) / 100;
     sprintf(time2, "|H|%.2d|U|:|H|%.2d|U|.|H|%d|U|", sec/60, sec%60, tenth);
+    // Total time: still derived from song length (independent of playhead).
     ms = calcSongMs();
     sec = ms / 1000;
     tenth = (ms % 1000) / 100;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -446,8 +446,13 @@ void switch_page(CUI_Page *page)
     if (ActivePage->UI)
         ActivePage->UI->full_refresh();
     // Clear any stale status message from the previous page so it
-    // doesn't bleed onto the newly activated page.
-    statusmsg = (char*)" ";
+    // doesn't bleed onto the newly activated page — but only when
+    // we're stopped. While playing, the playhead status line should
+    // carry through page changes; otherwise it briefly blanks and
+    // flashes back in on every F1/F2/F3/etc switch.
+    if (!ztPlayer || !ztPlayer->playing) {
+        statusmsg = (char*)" ";
+    }
 
 
   // <Manu> TO-DO Check if still needed, but not problematic if not

--- a/src/playback.cpp
+++ b/src/playback.cpp
@@ -249,6 +249,7 @@ player::player(int res,int prebuffer_rows, zt_module *ztm) {
     this->wTimerRes = res;
     this->fillbuff = this->playing = this->counter = this->wTimerID = 0;
     this->ztTimerID = 0;
+    this->playback_start_ms = 0;
 //  this->hr_timer = new hires_timer;
     this->playing_cur_row = 1;
     init();
@@ -641,8 +642,9 @@ void player::play(int row, int pattern,int pm, int loopmode)
   playing_buffer = play_buffer[cur_buf];
 
   playing = 1;
+  playback_start_ms = SDL_GetTicks();
   zt_set_window_title("zt - [playing]");
-}   
+}
 
 
 

--- a/src/playback.h
+++ b/src/playback.h
@@ -149,6 +149,11 @@ class player {
         int light_counter;
         int skip;
         int loop_mode;
+        // Wall-clock timestamp (SDL_GetTicks ms) when play() was invoked.
+        // Used by the status display to show real elapsed time, immune
+        // to row-quantization artifacts (.4s skip) that happen when
+        // calcSongMs jumps in tpb*bpm-row chunks.
+        uint64_t playback_start_ms;
 
         zt_module *song;
         pattern patt_memory;

--- a/src/zt.h
+++ b/src/zt.h
@@ -791,5 +791,6 @@ extern int pe_modification;
 extern Drawable * pe_buf;
 
 extern int calcSongSeconds(int cur_row = -1, int cur_ord = -1);
+extern int calcSongMs(int cur_row = -1, int cur_ord = -1);
 
 #endif


### PR DESCRIPTION
A grab-bag of UX hotfixes that came out of a single tour of the app.

## Build / linker
- `build-mac.sh` now `unset LDFLAGS CPPFLAGS` before configuring, dropping the inherited `/usr/local/opt/zlib/lib` (Intel-Homebrew) leftover from the user's shell env. That silences the recurring `ld: warning: search path '/usr/local/opt/zlib/lib' not found` line on Apple Silicon machines.

## ESC handling
- About zTracker (`Alt+F12`) and Song Message (`F10`) now exit on `ESC` back to the pattern editor. Previously the page consumed the keystroke and discarded it. Song Message peeks for `ESC` before `UI->update()` so the embedded `CommentEditor` can't swallow it.

## Page titles + menu format
- Keybindings page title was `Keyboard Shortcuts (Ctrl+Alt+K)` while the menu entry was `Keybindings Editor`. Title now matches the menu.
- Midimacro Editor page advertised a non-existent `Ctrl+F4` shortcut. The real binding is `Ctrl+M` (with `Shift+F4` as a fallback); the title now matches the menu.
- Lua Console page advertised `Esc/F2 to close` instead of its open shortcut. Now shows `Ctrl+Alt+L`.
- Main-menu shortcut separators are now uniformly `+` (`Ctrl+M`, `Alt+F12`, `Ctrl+Alt+K`, `Shift+Ctrl+F12`, ...). Was a mix of `-` and `+`.

## About page polish
- Textbox now starts ~300 px into the logo so the keyboard/headphones art shows behind it.
- Width 66 chars so `(Debvgger)` line fits without wrapping mid-name.
- Bottom row aligned with the F1 Help textbox.
- Single-row copyrights (no longer split author onto a wrap line).
- 2026 dates everywhere; `Esa Juhani Ruoho` added below `Nic Soudee` in Coding credits; License sentence split into its own paragraph; `zTracker` capitalization fixed (URL paths intentionally left lowercase).

## Global Configuration layout
- `Autoload .ZT` checkbox + `Autoload File` text input now share row 14.
- `Row highlight minor` + `Row highlight major` (renamed from `Default Highlight` / `Default Lowlight` to match tracker convention) share row 22, with widths retuned so the slider value readouts no longer overlap the next label.

## Palette Editor
- The `C-5 01..` / `...v40..` preview drawn next to each swatch was 8 chars wide rendered into a 5-char box, so it punched through the right border. Box widened to fit (`col(9)`).

## Playhead status line — DRY
The two big behavioral fixes:

- **Show on every page.** `update_status()` previously gated the `Playing, Ord/Pat/Row/Time` line on `cur_state == STATE_PEDIT || STATE_PLAY` and force-blanked the message on every other page. Removed the gate (and the dead `else if` that quieted it) so playback position is visible from Help, Sys Config, Global Config, Palette Editor, every page.
- **Don't flash on page switch.** `switch_page()` unconditionally cleared `statusmsg = " "` "to avoid stale messages bleeding". Combined with the post-switch framebuffer clear, that caused the playhead line to blank and snap back in on every F1/F2/F3 switch. Clear is now skipped when `ztPlayer->playing`, so the message carries through cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
