### PR TITLE
F11/F12/Ctrl+F12 layout polish + widget upstream cleanup

### DIFF
--- a/build-mac.sh
+++ b/build-mac.sh
@@ -87,6 +87,13 @@ EOF
   exit 1
 fi
 
+# zlib/libpng are vendored under extlibs/, so we don't need (and don't want)
+# any inherited LDFLAGS/CPPFLAGS pointing at /usr/local/opt/* (Intel-Homebrew
+# leftovers on Apple Silicon machines). Clearing them avoids the
+#   ld: warning: search path '/usr/local/opt/zlib/lib' not found
+# warning during link.
+unset LDFLAGS CPPFLAGS
+
 configure_args=(
   -S "$script_dir"
   -B "$build_dir"

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -5,7 +5,7 @@
  Home/End    : Just try them
  PgUp/PgDn   : Up/down 16 rows
  Ins/Del     : Insert/delete row on current track
-              Hold CTRL for ALL tracks
+               Hold CTRL for ALL tracks
 
  Tab         : Next track
  SHIFT-TAB   : Previous track
@@ -27,11 +27,11 @@
  SHIFT-,     : Select previous instrument.
  SHIFT-.     : Select next instrument.
  SHIFT-~     : Switch between regular and effect-draw mode
-              Use TAB here to switch edit mode
+               Use TAB here to switch edit mode
 
  CTRL-1 => 0 : Change the step-value in the pattern editor
  ALT-`       : Set previous note's length to distance between
-              note and current cursor position
+               note and current cursor position
  ScrollLock  : Follow playback toggle (cursor follows playback position)
 
 |L|%==|H|Pattern Operations|L|==%|U|
@@ -52,27 +52,27 @@
  CTRL-B : Marks the beginning of a select block.
  CTRL-E : Marks the end of a select block.
  CTRL-L : Select whole track, pressing it again will select the entire
-              pattern.
+          pattern.
  CTRL-U : Unselect block
  ALT-D  : Select one beat (press multiple times to select next beats)
 
  CTRL-C : Copy the selected block to the clipboard.
  CTRL-P : Copy pattern, paste to next empty pattern,
-              and jump to new pattern
+          and jump to new pattern
  CTRL-V : Paste the contents of the clipboard to the cursor location.
  CTRL-O : Overwrite paste
  CTRL-M : Merge paste the contents of the clipboard with the contents
-              of the location you're pasting to.
+          of the location you're pasting to.
  CTRL-X : Cut the selected block. (remove and copy to clipboard)
  CTRL-Z : Clear block (hold this one)
 
  CTRL-N : Set length of first row of block to length of block
  CTRL-W : Clear unused volumes
  CTRL-I : Interpolate values through selection (note, vol, or fx param,
-              depending on which column the cursor is on; falls back to
-              effect-data interpolation when no selection column applies)
+          depending on which column the cursor is on; falls back to
+          effect-data interpolation when no selection column applies)
  CTRL-T : Set all effect and effect data fields of block to same
-              value as first row in block
+          value as first row in block
  CTRL-K : Interpolate volume (block)
  ALT-Q  : Transpose block up
  ALT-A  : Transpose block down
@@ -81,8 +81,8 @@
  CTRL-[ : Decrease all volumes in block by 8
  CTRL-] : Increase all volumes in block by 8
  CTRL-` : Set all note's lengths in selection to distance
-              between note and next note
- ALT-S  : Set instruments in block to current instrument
+          between note and next note
+ ALT-S      : Set instruments in block to current instrument
  SHIFT-move : Block selection (movements are arrows and PgUp/PgDn)
 
 
@@ -104,21 +104,21 @@
 
  F1             : Help (That is this text)
  F2             : Pattern editor - Pressing F2 again while in the pattern
-              editing screen brings up the pattern settings.
+                  editing screen brings up the pattern settings.
  F3             : Instrument editor
  F4             : Arpeggio editor
  CTRL-M         : Midimacro editor (works everywhere; SHIFT-F4 also works
-              on systems where F-keys are not eaten by the OS)
+                  on systems where F-keys are not eaten by the OS)
  CTRL-SHIFT-M   : Quick MIDI export of current song
  F10            : Song message editor
  F5             : Song play (F5 PatternDisplay widget,
-              left-right/space/alt-1 thru alt-0/alt-f9/alt-f10)
+                  left-right/space/alt-1 thru alt-0/alt-f9/alt-f10)
  F6             : Pattern Play - will play the current pattern being edited.
  F7             : Start the song at the current row -
-              If in the pattern edit mode, F7 will start at the current
-              row, at the first instance of the pattern in the pattern
-              order.  If in the pattern order screen, F7 will start the
-              song at the cursor position (by pattern).
+                  If in the pattern edit mode, F7 will start at the current
+                  row, at the first instance of the pattern in the pattern
+                  order.  If in the pattern order screen, F7 will start the
+                  song at the cursor position (by pattern).
  SHIFT-F11      : Set current order
  SHIFT-F7       : Play song from the current order
  F8             : Stop playback
@@ -139,17 +139,16 @@
 
  Up/Down   : Cycles through widgets
  TAB       : Cycles forwards through widgets
-              (in Help: jumps to next section)
+             (in Help: jumps to next section)
  SHIFT-TAB : Cycles backwards through widgets
-              (in Help: jumps to previous section)
+             (in Help: jumps to previous section)
  ENTER     : Confirms choice
  SPACE     : Toggles an option or clicks a button
 
  Sliders   : If you hold CTRL while using LEFT/RIGHT the slider will move in
-              bigger steps
+             bigger steps
  Listboxes : Up/Down scroll, Space toggles select-items in a list box
  Popups    : ESC closes, all other UI keys apply
-
 
 |L|%==|H|Effects|L|==%|U|
 
@@ -157,7 +156,7 @@
  B  00 : Set "[" in the midi file.
  B  01 : Set "]" in the midi file.
  Cxxxx : Pattern break - setting the C marker denotes the end of a
-              pattern.  ex: C0000 will skip to the next pattern, row 0
+         pattern.  ex: C0000 will skip to the next pattern, row 0
  D..xx : Delay note/volume/cut - by xxxx sub-ticks.
  Exxxx : Pitch slide down, E0000 will repeat the last portamento command.
  Fxxxx : Pitch slide up, F0000 will repeat the last portamento down command.
@@ -165,15 +164,14 @@
  Q..xx : Retrig note every xx subticks
  R..xx : Start arpeggio xx.  R0000 will continue the last arpeggio
  Sxxyy : xx is the CC (Continuous Controller) number, yy is the value (0-80).
-              ex. S0142 will set CC #01 (Mod Wheel) to a value of 42.
-              >=80 sends last value
+         ex. S0142 will set CC #01 (Mod Wheel) to a value of 42.
+         >=80 sends last value
  T..xx : Set tempo to xx bpm
  Wxxxx : Absolute pitch set, between 0 and 3FFF, 2000 is no pitch change,
-              0 is max down, 3FFF is max up
+         0 is max down, 3FFF is max up
  X..xx : Set panning, 00=left, 40=center, 7F=right
  Zxxyy : Send midimacro xx with parameter yy.  00 repeats the last used
-              value
-
+         value
 
 |L|%==|H|Troubleshooting|L|==%|U|
 
@@ -183,7 +181,6 @@
    A: If you have any other applications open, try closing them.  If this
  	   doesn't work, perhaps you're drunk.  If drunk, fall down.  end if.
 
-
  Display issues:
 
    Q: The screen is beige/gray and is displaying  "This unit is in accordance
@@ -191,14 +188,12 @@
    A: You are looking at the back of the monitor.  For best results, look at
       the front, or "screen" of your monitor.
 
-
    Q: The screen is black and zTracker is not responding to any key/mouse
       commands.
    A: Your computer is not turned on.  Press the "power" switch on the front
       of the housing and follow the resulting prompts.  You may also want to
       gently pat the front of your pants using two outstretched fingers, to
       ensure that you haven't wet yourself.
-
 
    Q: The screen is displaying a small cyan and red airplane on what appears
       to be an airfield surrounded by buildings.  Occasionally, a small red
@@ -209,49 +204,42 @@
       of your plane by pressing the "," and "/" keys.  The "." key will cause
       your plane to invert - up is down, and down is up - watch out!
 
-
 |L|%==|H|The Merits of zTracker|L|==%|U|
 
-
-  	Congratulations on your decision to use zTracker, the champagne of midi
+ Congratulations on your decision to use zTracker, the champagne of midi
  sequencers.  Simply by choosing to employ zTracker as your personal midi
  geisha, you've now moved yourself one notch further from "idiot" and
  closer to "ultra-smartass".  (Refer to fig 1.1)  However, the fact that
  you're reading the help file kicks you back one notch towards "idiot".  A
  pointless exercise or a profound metaphor for our existence?  Only
  continued use will tell - but if the rash persists, discontinue use
- immediately.  Otherwise:
+ immediately. Otherwise:
 
- 	You, like the zTracker development team, [see fig 1.2] feel that
+ You, like the zTracker development team, [see fig 1.2] feel that
  trackers are simply the best way to exert precise, megalomaniacal control
  over sound.  But you're addicted to the high-fidelity, knob twiddling,
  credit-card-maxed-out world of professional MIDI equipment.  Is there
  some common ground where these two worlds meet, an interdimensional
  portal sort of like the moongates first seen in Ultima IV? [see fig 1.3]
 
+ The answer is yes.  The answer is also zTracker.
 
- 	The answer is yes.  The answer is also zTracker.
+ To sum up: yes, zTracker.
 
- 	To sum up: yes, zTracker.
-
-
- 	In the past, those who exhibited proficiency with
+ In the past, those who exhibited proficiency with
  light-and-switch-adorned gadgetry coupled with the need for complete
  control of as many elements as possible were limited to careers in the
  already saturated mad science and evil genius fields.
 
+ Until zTracker.
 
- 	Until zTracker.
-
-
- 	In these volatile times of sugarfree sugar and piano-playing robots,
+ In these volatile times of sugarfree sugar and piano-playing robots,
  many people are changing careers as many as twelve times during their
  lifetime. An exciting career in the lucrative and burgeoning field of
  musicianship awaits you!  Are you ready to meet the challenge?  Then join
  in the cry:
 
- 	zTracker : it is a midi tracker for writing music!
-
+ zTracker : it is a midi tracker for writing music!
 
 |L|%==|H|Documentation Credits|L|==%|U|
 
@@ -260,4 +248,3 @@
    * Quasimojo/Chill
    * Opaque Fear
    * Daniel Kahlin
-

--- a/src/CUI_About.cpp
+++ b/src/CUI_About.cpp
@@ -122,7 +122,10 @@ void CUI_About::leave(void) {
 void CUI_About::update() {
     UI->update();
     if (Keys.size()) {
-        Keys.getkey();
+        int key = Keys.getkey();
+        if (key == SDLK_ESCAPE) {
+            switch_page(UIP_Patterneditor);
+        }
     }
     //need_refresh++;
 }

--- a/src/CUI_About.cpp
+++ b/src/CUI_About.cpp
@@ -33,10 +33,7 @@ CUI_About::CUI_About(void) {
     // lower than the previous -27 setting).
     int box_top = ((row(9) + 300) / 8) - 27;
     if (box_top < 0) box_top = 0;
-    // Height: 75% of the available room, plus 1 extra row so the bottom
-    // sits 2 rows lower than the previous setting (top moved down 1,
-    // bottom moved down 2 → size grows by 1).
-    int box_size = ((max_end_row - box_top) * 75) / 100 + 9;
+    int box_size = ((max_end_row - box_top) * 75) / 100 + 3;
     if (box_size < 6) box_size = 6;
     l->y     = box_top;
     l->ysize = box_size;

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -35,19 +35,20 @@ CUI_Config::CUI_Config(void) {
 
     cb = new CheckBox;
     UI->add_element(cb,0);
-    cb->frame = 0;
     cb->x = 20;
     cb->y = 14;
-    cb->xsize = 5;
+    cb->xsize = 3;
     cb->value = &zt_config_globals.autoload_ztfile;
-    cb->frame = 1;
+    cb->frame = 0;
 
     ti = new TextInput;
     UI->add_element(ti,1);
     ti->frame = 1;
-    ti->x = 20;
-    ti->y = 15;
-    ti->xsize = 50;
+    // Sit on the same row as the Autoload .ZT checkbox, to the right of
+    // the "Autoload File" label that draws at col 28 (label is 13 cols).
+    ti->x = 42;
+    ti->y = 14;
+    ti->xsize = 30;
     ti->length = 50;
     ti->str = (unsigned char*)zt_config_globals.autoload_ztfile_filename;
 
@@ -55,24 +56,17 @@ CUI_Config::CUI_Config(void) {
     UI->add_element(ti,2);
     ti->frame = 1;
     ti->x = 20;
-    ti->y = 17;
-    ti->xsize = 50;
+    ti->y = 16;
+    ti->xsize = 52;   // ends col 72 — matches Autoload File textfield right edge
     ti->length = 50;
     ti->str = (unsigned char*)zt_config_globals.default_directory;
 
-    cb = new CheckBox;
-    UI->add_element(cb,3);
-    cb->frame = 0;
-    cb->x = 20;
-    cb->y = 19;
-    cb->xsize = 5;
-    cb->value = &zt_config_globals.record_velocity;
-    cb->frame = 1;
-
+    // Autosave (sec) — moved up to row 18 (was sharing row with Record
+    // Velocity, which has moved to F12 Sysconfig).
     vs = new ValueSlider;
-    UI->add_element(vs,4);
+    UI->add_element(vs,3);
     vs->x = 20;
-    vs->y = 20;
+    vs->y = 18;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.autosave_interval_seconds;
@@ -80,9 +74,9 @@ CUI_Config::CUI_Config(void) {
     vs->max = 3600;
 
     vs = new ValueSlider;
-    UI->add_element(vs,5);
+    UI->add_element(vs,4);
     vs->x = 20;
-    vs->y = 21;
+    vs->y = 20;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.cur_edit_mode;
@@ -97,62 +91,24 @@ CUI_Config::CUI_Config(void) {
     vs->no_tab_stop = 1;  // invisible stub; skip it in UP/DOWN cycling
 #endif
 
+    // Row Highlight / Row Lowlight live in F11 (Songconfig) only — they
+    // were duplicated here previously.
+
     vs = new ValueSlider;
-    UI->add_element(vs,6);
+    UI->add_element(vs,5);
     vs->x = 20;
     vs->y = 22;
-    vs->xsize = 15;
-    vs->ysize = 1;
-    vs->value = zt_config_globals.highlight_increment;
-    vs->min = 1;
-    vs->max = 64;
-
-    vs = new ValueSlider;
-    UI->add_element(vs,7);
-    vs->x = 20;
-    vs->y = 23;
-    vs->xsize = 15;
-    vs->ysize = 1;
-    vs->value = zt_config_globals.lowlight_increment;
-    vs->min = 1;
-    vs->max = 64;
-
-    vs = new ValueSlider;
-    UI->add_element(vs,8);
-    vs->x = 20;
-    vs->y = 24;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.pattern_length;
     vs->min = 1;
     vs->max = 256;
 
-    // MIDI realtime sync toggles. The underlying flags already exist in
-    // zt.conf but were previously only reachable via the Sysconfig page;
-    // expose them here so Global Config (F12) covers the full config set.
-    cb = new CheckBox;
-    UI->add_element(cb, 11);
-    cb->frame = 1;
-    cb->x = 20;
-    cb->y = 25;
-    cb->xsize = 5;
-    cb->value = &zt_config_globals.midi_in_sync;
-
-    cb = new CheckBox;
-    UI->add_element(cb, 12);
-    cb->frame = 1;
-    cb->x = 20;
-    cb->y = 26;
-    cb->xsize = 5;
-    cb->value = &zt_config_globals.midi_in_sync_chase_tempo;
-
     // Post-Load Page: where to land after a successful song load.
-    // Slider with an inline label name (Inst/Pattern/Songconf) drawn
-    // by draw() — same idiom as View Mode above.
     vs = new ValueSlider;
-    UI->add_element(vs, 13);
+    UI->add_element(vs, 6);
     vs->x = 20;
-    vs->y = 27;
+    vs->y = 23;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.post_load_page;
@@ -160,10 +116,13 @@ CUI_Config::CUI_Config(void) {
     vs->max = POST_LOAD_PAGE_COUNT - 1;
 
     b = new Button;
-    UI->add_element(b,10);
+    // Tab order: Page-switch button is the LAST tab-stop element so
+    // DOWN-arrow from the bottom of the config list wraps cleanly back
+    // to Autoload .ZT (tabindex 0).
+    UI->add_element(b,7);
     b->caption = "   Go to page 1   ";   // symmetric with Sysconfig's "Go to page 2" button (same x, y, xsize)
     b->xsize = 18;
-    b->x = 2;
+    b->x = 4;   // matches Sysconfig F12 button x so the button doesn't jump on page switch
     b->y = 12;
     b->ysize = 1;
     b->OnClick = (ActFunc)BTNCLK_GotoSystemConfig;
@@ -217,11 +176,14 @@ CUI_Config::CUI_Config(void) {
 */
 
     tb = new TextBox;
-    UI->add_element(tb, 9);
+    UI->add_element(tb, 8);
     tb->no_tab_stop = 1;  // read-only help; swallows UP/DOWN, exclude from focus cycle
-    tb->x = 1;
-    tb->y = 28;
-    tb->xsize = 78;
+    // Align left edge with the 'Go to page 1' button (x=4) above so the
+    // page balances visually. Right edge stays where it was — same column
+    // count, just shifted right by 3.
+    tb->x = 4;
+    tb->y = 26;
+    tb->xsize = 75;
     {
         const int max_rows = (INTERNAL_RESOLUTION_Y / 8);
         int remain = max_rows - tb->y - 1 - 9;
@@ -239,7 +201,7 @@ void CUI_Config::enter(void) {
     Keys.flush();
     // Start with focus on "Go to page 1" so the user can bounce straight
     // back to System Config without tabbing past every field first.
-    UI->set_focus(10);
+    UI->set_focus(7);   // 'Go to page 1' button (was 10 before renumbering)
 }
 
 void CUI_Config::leave(void) {
@@ -247,38 +209,88 @@ void CUI_Config::leave(void) {
 }
 
 void CUI_Config::update() {
+#ifdef __APPLE__
+    // Pop a native macOS Finder picker. element_id selects between the
+    // Default Dir (folder picker) and Autoload File (file picker — basename
+    // only). Both share the same Enter-flush so keystrokes pressed inside
+    // the modal dialog don't bounce back into zTracker.
+    auto run_picker = [this](int element_id, char *target_buf, size_t target_size,
+                              bool basename_only, const char *osascript_cmd) {
+        FILE *p = popen(osascript_cmd, "r");
+        if (p) {
+            char picked[MAX_PATH + 1] = {0};
+            if (fgets(picked, sizeof(picked), p)) {
+                size_t n = strlen(picked);
+                while (n > 0 && (picked[n-1] == '\n' || picked[n-1] == '\r' ||
+                                 (!basename_only && picked[n-1] == '/'))) {
+                    picked[--n] = '\0';
+                }
+                if (n > 0) {
+                    const char *src = picked;
+                    if (basename_only) {
+                        const char *slash = strrchr(picked, '/');
+                        if (slash) src = slash + 1;
+                    }
+                    strncpy(target_buf, src, target_size - 1);
+                    target_buf[target_size - 1] = '\0';
+                    TextInput *ti = (TextInput *)UI->get_element(element_id);
+                    if (ti) {
+                        ti->cursor = 0;
+                        ti->changed = 1;
+                        ti->need_redraw++;
+                    }
+                    need_refresh++;
+                }
+            }
+            pclose(p);
+        }
+        SDL_PumpEvents();
+        SDL_FlushEvent(SDL_EVENT_KEY_DOWN);
+        SDL_FlushEvent(SDL_EVENT_KEY_UP);
+        Keys.flush();
+    };
+
+    // Enter on Default Dir (id 2) opens a folder picker.
+    if (UI->cur_element == 2 && Keys.checkkey() == SDLK_RETURN) {
+        Keys.getkey();
+        run_picker(2, zt_config_globals.default_directory,
+                   sizeof(zt_config_globals.default_directory), false,
+                   "osascript -e 'try' "
+                   "-e 'POSIX path of (choose folder with prompt \"Default Dir\")' "
+                   "-e 'on error' -e 'return \"\"' -e 'end try'");
+    }
+    // Enter on Autoload File (id 1) opens a file picker; basename only.
+    else if (UI->cur_element == 1 && Keys.checkkey() == SDLK_RETURN) {
+        Keys.getkey();
+        run_picker(1, zt_config_globals.autoload_ztfile_filename,
+                   sizeof(zt_config_globals.autoload_ztfile_filename), true,
+                   "osascript -e 'try' "
+                   "-e 'POSIX path of (choose file with prompt \"Autoload File\")' "
+                   "-e 'on error' -e 'return \"\"' -e 'end try'");
+    }
+#endif
     UI->update();
     ValueSlider *vs;
     TextInput *ti;
 
-    vs = (ValueSlider *)UI->get_element(4);
+    vs = (ValueSlider *)UI->get_element(3);   // Autosave (was 4)
     if (vs && vs->value != zt_config_globals.autosave_interval_seconds) {
         zt_config_globals.autosave_interval_seconds = vs->value;
     }
 
-    vs = (ValueSlider *)UI->get_element(5);
+    vs = (ValueSlider *)UI->get_element(4);   // View Mode (was 5)
 #ifdef _ACTIVAR_CAMBIO_TAMANYO_COLUMNAS
     if (vs && vs->value != zt_config_globals.cur_edit_mode) {
         zt_config_globals.cur_edit_mode = vs->value;
     }
 #endif
 
-    vs = (ValueSlider *)UI->get_element(6);
-    if (vs && vs->value != zt_config_globals.highlight_increment) {
-        zt_config_globals.highlight_increment = vs->value;
-    }
-
-    vs = (ValueSlider *)UI->get_element(7);
-    if (vs && vs->value != zt_config_globals.lowlight_increment) {
-        zt_config_globals.lowlight_increment = vs->value;
-    }
-
-    vs = (ValueSlider *)UI->get_element(8);
+    vs = (ValueSlider *)UI->get_element(5);   // Default Pat Len (was 8)
     if (vs && vs->value != zt_config_globals.pattern_length) {
         zt_config_globals.pattern_length = vs->value;
     }
 
-    vs = (ValueSlider *)UI->get_element(13);
+    vs = (ValueSlider *)UI->get_element(6);   // Post-Load Page (was 9)
     if (vs && vs->value != zt_config_globals.post_load_page) {
         zt_config_globals.post_load_page = vs->value;
     }
@@ -326,19 +338,20 @@ void CUI_Config::draw(Drawable *S) {
 #ifdef _ACTIVAR_CAMBIO_TAMANYO_COLUMNAS
         sprintf(buf+strlen(buf),"\n|U| View Mode       |L|[|H|%s|L|]",view_mode_name);
 #endif
-        sprintf(buf+strlen(buf),"\n|U| Highlight Inc   |L|[|H|%d|L|]",zt_config_globals.highlight_increment);
-        sprintf(buf+strlen(buf),"\n|U| Lowlight Inc    |L|[|H|%d|L|]",zt_config_globals.lowlight_increment);
+        // Row highlight / Row lowlight live in F11 only — not duplicated here.
         sprintf(buf+strlen(buf),"\n|U| Pattern Len     |L|[|H|%d|L|]",zt_config_globals.pattern_length);
         sprintf(buf+strlen(buf),"\n|U| Full Screen     |L|[|H|%s|L|]",zt_config_globals.full_screen?"On":"Off");
         sprintf(buf+strlen(buf),"\n|U| Send Panic      |L|[|H|%s|L|]",zt_config_globals.auto_send_panic?"On":"Off");
         sprintf(buf+strlen(buf),"\n|U| MIDI In Sync    |L|[|H|%s|L|]",zt_config_globals.midi_in_sync?"On":"Off");
         sprintf(buf+strlen(buf),"\n|U| Chase MIDI Tempo|L|[|H|%s|L|]",zt_config_globals.midi_in_sync_chase_tempo?"On":"Off");
-        const char *post_load_name = "Inst Editor";
+        const char *post_load_name = "Pattern Edit";
         switch (zt_config_globals.post_load_page) {
             case POST_LOAD_PATTERN_EDIT: post_load_name = "Pattern Edit"; break;
+            case POST_LOAD_INST_EDIT:    post_load_name = "Inst Editor";  break;
+            case POST_LOAD_PLAYSONG:     post_load_name = "Play Song";    break;
             case POST_LOAD_SONG_CONFIG:  post_load_name = "Song Config";  break;
-            case POST_LOAD_INST_EDIT:
-            default:                     post_load_name = "Inst Editor";  break;
+            case POST_LOAD_SONG_MESSAGE: post_load_name = "Song Message"; break;
+            default:                     post_load_name = "Pattern Edit"; break;
         }
         sprintf(buf+strlen(buf),"\n|U| Post-Load Page  |L|[|H|%s|L|]",post_load_name);
         sprintf(buf+strlen(buf),"\n|U| Step Editing    |L|[|H|%s|L|]",zt_config_globals.step_editing?"On":"Off");
@@ -374,7 +387,7 @@ void CUI_Config::draw(Drawable *S) {
         UI->draw(S);
 #ifdef _ACTIVAR_CAMBIO_TAMANYO_COLUMNAS
         {
-            ValueSlider *vs = (ValueSlider *)UI->get_element(5);
+            ValueSlider *vs = (ValueSlider *)UI->get_element(4);   // View Mode (was 5)
             if (vs) {
                 const char *view_mode_name = "Regular";
                 switch (zt_config_globals.cur_edit_mode) {
@@ -394,14 +407,16 @@ void CUI_Config::draw(Drawable *S) {
         // Mode pattern above — slider value alone reads as 0/1/2 which
         // is meaningless to the user without the page name beside it).
         {
-            ValueSlider *vs = (ValueSlider *)UI->get_element(13);
+            ValueSlider *vs = (ValueSlider *)UI->get_element(6);   // Post-Load Page (was 9)
             if (vs) {
-                const char *post_load_name = "Inst Editor";
+                const char *post_load_name = "Pattern Edit";
                 switch (zt_config_globals.post_load_page) {
                     case POST_LOAD_PATTERN_EDIT: post_load_name = "Pattern Edit"; break;
+                    case POST_LOAD_INST_EDIT:    post_load_name = "Inst Editor";  break;
+                    case POST_LOAD_PLAYSONG:     post_load_name = "Play Song";    break;
                     case POST_LOAD_SONG_CONFIG:  post_load_name = "Song Config";  break;
-                    case POST_LOAD_INST_EDIT:
-                    default:                     post_load_name = "Inst Editor";  break;
+                    case POST_LOAD_SONG_MESSAGE: post_load_name = "Song Message"; break;
+                    default:                     post_load_name = "Pattern Edit"; break;
                 }
                 char label[20];
                 snprintf(label, sizeof(label), " %-12s", post_load_name);
@@ -412,20 +427,19 @@ void CUI_Config::draw(Drawable *S) {
         draw_status(S);
         status(S);
         printtitle(PAGE_TITLE_ROW_Y,"Global Configuration (Ctrl+F12)",COLORS.Text,COLORS.Background,S);
-        print(row(2),col(14),"Autoload .ZT",COLORS.Text,S);
-        print(row(2),col(15),"Autoload File",COLORS.Text,S);
-        print(row(2),col(17),"Default Dir",COLORS.Text,S);
-        print(row(2),col(19),"Record Velocity",COLORS.Text,S);
-        print(row(2),col(20),"Autosave (sec)",COLORS.Text,S);
+        // Labels right-align so text ends at col 18 (1-char gap before
+        // the col-20 controls).
+        print(row(7),col(14),"Autoload .ZT",COLORS.Text,S);
+        print(row(28),col(14),"Autoload File",COLORS.Text,S);
+        print(row(8),col(16),"Default Dir",COLORS.Text,S);
+        // Record Velocity moved to F12 (Sysconfig).
+        print(row(5),col(18),"Autosave (sec)",COLORS.Text,S);
 #ifdef _ACTIVAR_CAMBIO_TAMANYO_COLUMNAS
-        print(row(2),col(21),"Default View",COLORS.Text,S);
+        print(row(7),col(20),"Default View",COLORS.Text,S);
 #endif
-        print(row(2),col(22),"Default Highlight",COLORS.Text,S);
-        print(row(2),col(23),"Default Lowlight",COLORS.Text,S);
-        print(row(2),col(24),"Default Pat Len",COLORS.Text,S);
-        print(row(2),col(25),"MIDI In Sync",COLORS.Text,S);
-        print(row(2),col(26),"Chase MIDI Tempo",COLORS.Text,S);
-        print(row(2),col(27),"Post-Load Page",COLORS.Text,S);
+        // Row Highlight / Row Lowlight live in F11 (Songconfig) only.
+        print(row(4),col(22),"Default Pat Len",COLORS.Text,S);
+        print(row(5),col(23),"Post-Load Page",COLORS.Text,S);
 //        print(row(2),col(25)," .ZT directory",COLORS.Text,S);
 
         //printtitle(32,"Current Global Settings",COLORS.Text,COLORS.Background,S);

--- a/src/CUI_Config.cpp
+++ b/src/CUI_Config.cpp
@@ -97,7 +97,7 @@ CUI_Config::CUI_Config(void) {
     vs = new ValueSlider;
     UI->add_element(vs,5);
     vs->x = 20;
-    vs->y = 22;
+    vs->y = 21;
     vs->xsize = 15;
     vs->ysize = 1;
     vs->value = zt_config_globals.pattern_length;
@@ -183,7 +183,7 @@ CUI_Config::CUI_Config(void) {
     // count, just shifted right by 3.
     tb->x = 4;
     tb->y = 26;
-    tb->xsize = 75;
+    tb->xsize = 72;   // ends col 76 — matches F12 MIDI list right edge
     {
         const int max_rows = (INTERNAL_RESOLUTION_Y / 8);
         int remain = max_rows - tb->y - 1 - 9;
@@ -344,14 +344,14 @@ void CUI_Config::draw(Drawable *S) {
         sprintf(buf+strlen(buf),"\n|U| Send Panic      |L|[|H|%s|L|]",zt_config_globals.auto_send_panic?"On":"Off");
         sprintf(buf+strlen(buf),"\n|U| MIDI In Sync    |L|[|H|%s|L|]",zt_config_globals.midi_in_sync?"On":"Off");
         sprintf(buf+strlen(buf),"\n|U| Chase MIDI Tempo|L|[|H|%s|L|]",zt_config_globals.midi_in_sync_chase_tempo?"On":"Off");
-        const char *post_load_name = "Pattern Edit";
+        const char *post_load_name = "Pattern Editor (F2)";
         switch (zt_config_globals.post_load_page) {
-            case POST_LOAD_PATTERN_EDIT: post_load_name = "Pattern Edit"; break;
-            case POST_LOAD_INST_EDIT:    post_load_name = "Inst Editor";  break;
-            case POST_LOAD_PLAYSONG:     post_load_name = "Play Song";    break;
-            case POST_LOAD_SONG_CONFIG:  post_load_name = "Song Config";  break;
-            case POST_LOAD_SONG_MESSAGE: post_load_name = "Song Message"; break;
-            default:                     post_load_name = "Pattern Edit"; break;
+            case POST_LOAD_PATTERN_EDIT: post_load_name = "Pattern Editor (F2)";    break;
+            case POST_LOAD_INST_EDIT:    post_load_name = "Instrument Editor (F3)"; break;
+            case POST_LOAD_PLAYSONG:     post_load_name = "Play Song (F5)";         break;
+            case POST_LOAD_SONG_CONFIG:  post_load_name = "Song Configuration (F11)"; break;
+            case POST_LOAD_SONG_MESSAGE: post_load_name = "Song Message (F10)";     break;
+            default:                     post_load_name = "Pattern Editor (F2)";    break;
         }
         sprintf(buf+strlen(buf),"\n|U| Post-Load Page  |L|[|H|%s|L|]",post_load_name);
         sprintf(buf+strlen(buf),"\n|U| Step Editing    |L|[|H|%s|L|]",zt_config_globals.step_editing?"On":"Off");
@@ -409,18 +409,18 @@ void CUI_Config::draw(Drawable *S) {
         {
             ValueSlider *vs = (ValueSlider *)UI->get_element(6);   // Post-Load Page (was 9)
             if (vs) {
-                const char *post_load_name = "Pattern Edit";
+                const char *post_load_name = "Pattern Editor (F2)";
                 switch (zt_config_globals.post_load_page) {
-                    case POST_LOAD_PATTERN_EDIT: post_load_name = "Pattern Edit"; break;
-                    case POST_LOAD_INST_EDIT:    post_load_name = "Inst Editor";  break;
-                    case POST_LOAD_PLAYSONG:     post_load_name = "Play Song";    break;
-                    case POST_LOAD_SONG_CONFIG:  post_load_name = "Song Config";  break;
-                    case POST_LOAD_SONG_MESSAGE: post_load_name = "Song Message"; break;
-                    default:                     post_load_name = "Pattern Edit"; break;
+                    case POST_LOAD_PATTERN_EDIT: post_load_name = "Pattern Editor (F2)";    break;
+                    case POST_LOAD_INST_EDIT:    post_load_name = "Instrument Editor (F3)"; break;
+                    case POST_LOAD_PLAYSONG:     post_load_name = "Play Song (F5)";         break;
+                    case POST_LOAD_SONG_CONFIG:  post_load_name = "Song Configuration (F11)"; break;
+                    case POST_LOAD_SONG_MESSAGE: post_load_name = "Song Message (F10)";     break;
+                    default:                     post_load_name = "Pattern Editor (F2)";    break;
                 }
-                char label[20];
-                snprintf(label, sizeof(label), " %-12s", post_load_name);
-                printBG(col(vs->x + vs->xsize), row(vs->y), "             ", COLORS.Text, COLORS.Background, S);
+                char label[32];
+                snprintf(label, sizeof(label), " %-25s", post_load_name);
+                printBG(col(vs->x + vs->xsize), row(vs->y), "                          ", COLORS.Text, COLORS.Background, S);
                 printBG(col(vs->x + vs->xsize), row(vs->y), label, COLORS.Text, COLORS.Background, S);
             }
         }
@@ -438,7 +438,7 @@ void CUI_Config::draw(Drawable *S) {
         print(row(7),col(20),"Default View",COLORS.Text,S);
 #endif
         // Row Highlight / Row Lowlight live in F11 (Songconfig) only.
-        print(row(4),col(22),"Default Pat Len",COLORS.Text,S);
+        print(row(4),col(21),"Default Pat Len",COLORS.Text,S);
         print(row(5),col(23),"Post-Load Page",COLORS.Text,S);
 //        print(row(2),col(25)," .ZT directory",COLORS.Text,S);
 

--- a/src/CUI_FileLists_Common.hpp
+++ b/src/CUI_FileLists_Common.hpp
@@ -60,18 +60,20 @@
 #define SAVE_TEXTINPUT_POS_Y         (SAVE_BUTTONS_BASE_Y + 0)
 
 
+// Tighten button stack so it doesn't extend below the right-hand file
+// list. TextInput->first button gap = 1 row, between buttons = 1 row.
 #define SAVE_ZT_BUTTON_POS_X         FILE_LIST_POS_X_CHARS
-#define SAVE_ZT_BUTTON_POS_Y         (SAVE_TEXTINPUT_POS_Y + 1 + 1)
+#define SAVE_ZT_BUTTON_POS_Y         (SAVE_TEXTINPUT_POS_Y + 1)
 
 
 #define SAVE_MID_BUTTON_POS_X        FILE_LIST_POS_X_CHARS
-#define SAVE_MID_BUTTON_POS_Y        (SAVE_ZT_BUTTON_POS_Y + 1 + 1)
+#define SAVE_MID_BUTTON_POS_Y        (SAVE_ZT_BUTTON_POS_Y + 1)
 
 #define SAVE_MID_MC_BUTTON_POS_X     FILE_LIST_POS_X_CHARS
-#define SAVE_MID_MC_BUTTON_POS_Y     (SAVE_MID_BUTTON_POS_Y + 1 + 1)
+#define SAVE_MID_MC_BUTTON_POS_Y     (SAVE_MID_BUTTON_POS_Y + 1)
 
 #define SAVE_MID_PT_BUTTON_POS_X     FILE_LIST_POS_X_CHARS
-#define SAVE_MID_PT_BUTTON_POS_Y     (SAVE_MID_MC_BUTTON_POS_Y + 1 + 1)
+#define SAVE_MID_PT_BUTTON_POS_Y     (SAVE_MID_MC_BUTTON_POS_Y + 1)
 
 //#define SAVE_GBA_BUTTON_POS_X        FILE_LIST_POS_X_CHARS
 //#define SAVE_GBA_BUTTON_POS_Y        (SAVE_ZT_BUTTON_POS_Y + 1 + 1 + 1 + 1)

--- a/src/CUI_Help.cpp
+++ b/src/CUI_Help.cpp
@@ -13,7 +13,7 @@ CUI_Help::CUI_Help(void) {
     UI->add_element(tb, 0);
     tb->x = 1;
     tb->y = 12;
-    tb->xsize = 78 + ((INTERNAL_RESOLUTION_X-640)/8);
+    tb->xsize = TextBox::full_width_xsize();
     // Bottom-anchor: fill from tb->y down to ~5 rows above screen bottom.
     tb->ysize = (INTERNAL_RESOLUTION_Y/8) - tb->y - 8;
     //tb->text = "This is a test of the textbox reader\n\nit is supposed to work";
@@ -327,7 +327,7 @@ void CUI_Help::update() {
 
 void CUI_Help::draw(Drawable *S) {
 
-    tb->xsize = 78 + ((INTERNAL_RESOLUTION_X-640)/8);
+    tb->xsize = TextBox::full_width_xsize();
     // Bottom-anchor: fill from tb->y down to ~5 rows above screen bottom.
     tb->ysize = (INTERNAL_RESOLUTION_Y/8) - tb->y - 8;
 

--- a/src/CUI_InstEditor.cpp
+++ b/src/CUI_InstEditor.cpp
@@ -99,7 +99,7 @@ CUI_InstEditor::CUI_InstEditor(void) {
 
     vso = new ValueSliderOFF(1); // Bank (ID: 1)
     UI->add_element(vso,tabindex++);
-    vso->x = 36;    vso->y = 15;    vso->xsize = 16;    vso->ysize = 1; vso->min = -1;  vso->max = 0x3fff;    vso->value = -1;
+    vso->x = 36;    vso->y = 15;    vso->xsize = 13;    vso->ysize = 1; vso->min = -1;  vso->max = 0x3fff;    vso->value = -1;
     fm = new Frame;
     UI->add_gfx(fm,gfxindex++);
     fm->x=35; fm->y=12; fm->xsize = 22; fm->ysize = 5; fm->type = 0;
@@ -235,7 +235,7 @@ CUI_InstEditor::CUI_InstEditor(void) {
     mds->x=35;
     mds->y=37;
     mds->xsize = 44;
-    mds->ysize = 14;
+    mds->ysize = 15;
     
     reset = 0;
 }
@@ -470,7 +470,7 @@ void CUI_InstEditor::draw(Drawable *S)
 
     ie = (InstEditor *)UI->get_element(0);
 
-    ie->ysize = 40 + ((INTERNAL_RESOLUTION_Y-480)/8);
+    ie->ysize = 41 + ((INTERNAL_RESOLUTION_Y-480)/8);
     if(ie->ysize > MAX_INSTS) ie->ysize = MAX_INSTS ;
 
     if (ie->cursor+ie->list_start != cur_inst) {

--- a/src/CUI_KeyBindings.cpp
+++ b/src/CUI_KeyBindings.cpp
@@ -212,7 +212,7 @@ void CUI_KeyBindings::draw(Drawable *S)
                 COLORS.Background);
 
     char buf[96];
-    snprintf(buf, sizeof(buf), "Keyboard Shortcuts (Ctrl+Alt+K)%s",
+    snprintf(buf, sizeof(buf), "Keybindings Editor (Ctrl+Alt+K)%s",
              dirty ? "   [unsaved]" : "");
     printtitle(PAGE_TITLE_ROW_Y, buf, COLORS.Text, COLORS.Background, S);
 

--- a/src/CUI_LoadMsg.cpp
+++ b/src/CUI_LoadMsg.cpp
@@ -140,9 +140,11 @@ void CUI_LoadMsg::update() {
         // people who want to verify BPM/TPB/order list before anything else.
         switch (zt_config_globals.post_load_page) {
             case POST_LOAD_PATTERN_EDIT: switch_page(UIP_Patterneditor); break;
+            case POST_LOAD_INST_EDIT:    switch_page(UIP_InstEditor);    break;
+            case POST_LOAD_PLAYSONG:     switch_page(UIP_Playsong);      break;
             case POST_LOAD_SONG_CONFIG:  switch_page(UIP_Songconfig);    break;
-            case POST_LOAD_INST_EDIT:
-            default:                     switch_page(UIP_InstEditor);   break;
+            case POST_LOAD_SONG_MESSAGE: switch_page(UIP_SongMessage);   break;
+            default:                     switch_page(UIP_Patterneditor); break;
         }
     }
 }

--- a/src/CUI_LuaConsole.cpp
+++ b/src/CUI_LuaConsole.cpp
@@ -228,7 +228,7 @@ void CUI_LuaConsole::draw(Drawable *S)
                 fx2, row(input_row() + 1) - 1, page_bg);
 
     // --- Title ---
-    printtitle(PAGE_TITLE_ROW_Y, "Lua Console (Esc/F2 to close)",
+    printtitle(PAGE_TITLE_ROW_Y, "Lua Console (Ctrl+Alt+L)",
                title_fg, page_bg, S);
 
     // --- Scrollback background (distinct shade, so the console area is

--- a/src/CUI_MainMenu.cpp
+++ b/src/CUI_MainMenu.cpp
@@ -89,43 +89,43 @@ static const mm_entry MM_ENTRIES[] = {
     {MM_CMD,        "Song Message",             "F10",                  CMD_SWITCH_SONGMSG,         NULL},
 #endif
 #ifndef DISABLE_UNFINISHED_F4_MIDI_MACRO_EDITOR
-    {MM_CMD,        "Midimacro Editor",         "Ctrl-M",               CMD_SWITCH_MIDIMACEDIT,     NULL},
+    {MM_CMD,        "Midimacro Editor",         "Ctrl+M",               CMD_SWITCH_MIDIMACEDIT,     NULL},
 #endif
     {MM_CMD,        "Help",                     "F1",                   CMD_SWITCH_HELP,            NULL},
-    {MM_CMD,        "About",                    "Alt-F12",              CMD_SWITCH_ABOUT,           NULL},
+    {MM_CMD,        "About",                    "Alt+F12",              CMD_SWITCH_ABOUT,           NULL},
 
     {MM_SEPARATOR,  NULL,                       NULL,                   0,                          NULL},
     {MM_SUBHEADING, "Playback",                 NULL,                   0,                          NULL},
     {MM_CMD,        "Play Song",                "F5",                   CMD_PLAY,                   NULL},
     {MM_CMD,        "Play Pattern",             "F6",                   CMD_PLAY_PAT,               NULL},
     {MM_CMD,        "Play From Cursor",         "F7",                   CMD_PLAY_PAT_LINE,          NULL},
-    {MM_CMD,        "Play From Order",          "Shift-F7",             CMD_PLAY_ORDER,             NULL},
+    {MM_CMD,        "Play From Order",          "Shift+F7",             CMD_PLAY_ORDER,             NULL},
     {MM_CMD,        "Stop",                     "F8",                   CMD_STOP,                   NULL},
     {MM_FUNC,       "Panic (all MIDI off)",     "F9",                   0,                          mm_panic},
-    {MM_FUNC,       "Hard Panic",               "Shift-F9",             0,                          mm_hard_panic},
+    {MM_FUNC,       "Hard Panic",               "Shift+F9",             0,                          mm_hard_panic},
     {MM_FUNC,       "Toggle Follow Playback",   "ScrollLock",           0,                          mm_toggle_follow_playback},
 
     {MM_SEPARATOR,  NULL,                       NULL,                   0,                          NULL},
     {MM_SUBHEADING, "File",                     NULL,                   0,                          NULL},
-    {MM_CMD,        "Load Song...",             "Ctrl-L",               CMD_SWITCH_LOAD,            NULL},
-    {MM_CMD,        "Save Song / Save As...",   "Ctrl-S",               CMD_SWITCH_SAVE,            NULL},
+    {MM_CMD,        "Load Song...",             "Ctrl+L",               CMD_SWITCH_LOAD,            NULL},
+    {MM_CMD,        "Save Song / Save As...",   "Ctrl+S",               CMD_SWITCH_SAVE,            NULL},
     // CMD_NEWSONG / CMD_MIDI_EXPORT don't exist as enum values; the
-    // user-facing shortcut still works (Ctrl-Alt-N / Ctrl-Shift-M),
+    // user-facing shortcut still works (Ctrl+Alt+N / Ctrl+Shift+M),
     // so we list it as info-only here. Future: wire to dedicated cmds.
 
     {MM_SEPARATOR,  NULL,                       NULL,                   0,                          NULL},
     {MM_SUBHEADING, "Settings",                 NULL,                   0,                          NULL},
     {MM_CMD,        "System Configuration",     "F12",                  CMD_SWITCH_SYSCONF,         NULL},
-    {MM_CMD,        "Global Configuration",     "Ctrl-F12",             CMD_SWITCH_CONFIG,          NULL},
+    {MM_CMD,        "Global Configuration",     "Ctrl+F12",             CMD_SWITCH_CONFIG,          NULL},
 #ifndef DISABLE_PALETTE_EDITOR
-    {MM_CMD,        "Palette Editor",           "Shift-Ctrl-F12",       CMD_SWITCH_PALETTE,         NULL},
+    {MM_CMD,        "Palette Editor",           "Shift+Ctrl+F12",       CMD_SWITCH_PALETTE,         NULL},
 #endif
-    {MM_CMD,        "Keybindings Editor",       "Ctrl-Alt-K",           CMD_SWITCH_KEYBINDINGS,     NULL},
-    {MM_CMD,        "Lua Console",              "Ctrl-Alt-L",           CMD_SWITCH_LUA_CONSOLE,     NULL},
-    {MM_FUNC,       "Toggle Fullscreen",        "Alt-Enter",            0,                          mm_toggle_fullscreen},
+    {MM_CMD,        "Keybindings Editor",       "Ctrl+Alt+K",           CMD_SWITCH_KEYBINDINGS,     NULL},
+    {MM_CMD,        "Lua Console",              "Ctrl+Alt+L",           CMD_SWITCH_LUA_CONSOLE,     NULL},
+    {MM_FUNC,       "Toggle Fullscreen",        "Alt+Enter",            0,                          mm_toggle_fullscreen},
 
     {MM_SEPARATOR,  NULL,                       NULL,                   0,                          NULL},
-    {MM_FUNC,       "Quit",                     "Ctrl-Q",               0,                          mm_quit},
+    {MM_FUNC,       "Quit",                     "Ctrl+Q",               0,                          mm_quit},
 };
 
 static const int MM_COUNT = sizeof(MM_ENTRIES) / sizeof(MM_ENTRIES[0]);

--- a/src/CUI_Midimacroeditor.cpp
+++ b/src/CUI_Midimacroeditor.cpp
@@ -79,7 +79,7 @@ void CUI_Midimacroeditor::draw(Drawable *S) {
     if (S->lock()==0) {
         UI->draw(S);
         draw_status(S);
-        printtitle(PAGE_TITLE_ROW_Y,"MIDI Macro Editor (Ctrl+F4)",COLORS.Text,COLORS.Background,S);
+        printtitle(PAGE_TITLE_ROW_Y,"Midimacro Editor (Ctrl+M)",COLORS.Text,COLORS.Background,S);
         print(col(12),row(BASE_Y),"name",COLORS.Text,S);
         need_refresh = 0; updated=2;
         ztPlayer->num_orders();

--- a/src/CUI_PENature.cpp
+++ b/src/CUI_PENature.cpp
@@ -108,6 +108,11 @@ void CUI_PENature::draw(Drawable *S) {
         print(col(textcenter("Naturalization Amount")),start_y + row(2),"Naturalization Amount",COLORS.Text,S);
         print(start_x + col(1), start_y + window_height / 2,"  Percent:",COLORS.Text,S);
         UI->draw(S);
+        // Show "%" suffix after the slider's numeric readout. ValueSlider
+        // prints " NNN" (4 chars) starting at col(x+xsize); "%" lands
+        // immediately after.
+        ValueSlider *vs = (ValueSlider *)UI->get_element(0);
+        print(col(vs->x + vs->xsize + 4), row(vs->y), "%", COLORS.Text, S);
         S->unlock();
         need_refresh = need_popup_refresh = 0;
         updated++;

--- a/src/CUI_PEParms.cpp
+++ b/src/CUI_PEParms.cpp
@@ -19,9 +19,9 @@ CUI_PEParms::CUI_PEParms(void) {
         vs_step = new ValueSlider;
         UI->add_element(vs_step,0);
         vs_step->frame = 1;
-        vs_step->x = (start_x / 8) + 14;
+        vs_step->x = (start_x / 8) + 17;
         vs_step->y = (start_y / 8) + 6; 
-        vs_step->xsize=window_width/8 - 20;
+        vs_step->xsize=window_width/8 - 23;
         vs_step->min = 0;
         vs_step->max = 32;
         vs_step->value = cur_step;   
@@ -29,9 +29,9 @@ CUI_PEParms::CUI_PEParms(void) {
         vs_pat_length = new ValueSlider;
         UI->add_element(vs_pat_length,1);
         vs_pat_length->frame = 1;
-        vs_pat_length->x = (start_x / 8) + 14;
+        vs_pat_length->x = (start_x / 8) + 17;
         vs_pat_length->y = (start_y / 8) + 8; 
-        vs_pat_length->xsize=window_width/8 - 20;
+        vs_pat_length->xsize=window_width/8 - 23;
         vs_pat_length->min = 32;
         vs_pat_length->max = 999;
         vs_pat_length->value = song->patterns[cur_edit_pattern]->length;
@@ -39,9 +39,9 @@ CUI_PEParms::CUI_PEParms(void) {
         vs_highlight = new ValueSlider;
         UI->add_element(vs_highlight,2);
         vs_highlight->frame = 1;
-        vs_highlight->x = (start_x / 8) + 14;
+        vs_highlight->x = (start_x / 8) + 17;
         vs_highlight->y = (start_y / 8) + 10; 
-        vs_highlight->xsize=window_width/8 - 20;
+        vs_highlight->xsize=window_width/8 - 23;
         vs_highlight->min = 1;
         vs_highlight->max = 32;
         vs_highlight->value = zt_config_globals.highlight_increment;
@@ -49,9 +49,9 @@ CUI_PEParms::CUI_PEParms(void) {
         vs_lowlight = new ValueSlider;
         UI->add_element(vs_lowlight,3);
         vs_lowlight->frame = 1;
-        vs_lowlight->x = (start_x / 8) + 14;
+        vs_lowlight->x = (start_x / 8) + 17;
         vs_lowlight->y = (start_y / 8) + 12; 
-        vs_lowlight->xsize=window_width/8 - 20;
+        vs_lowlight->xsize=window_width/8 - 23;
         vs_lowlight->min = 1;
         vs_lowlight->max = 32;
         vs_lowlight->value = zt_config_globals.lowlight_increment;
@@ -59,36 +59,36 @@ CUI_PEParms::CUI_PEParms(void) {
         cb_centered = new CheckBox;
         UI->add_element(cb_centered,4);
         cb_centered->frame = 0;
-        cb_centered->x = (start_x / 8) + 14;
+        cb_centered->x = (start_x / 8) + 17;
         cb_centered->y = (start_y / 8) + 14;
-        cb_centered->xsize = 5;
+        cb_centered->xsize = 3;
         cb_centered->value = &zt_config_globals.centered_editing;
         cb_centered->frame = 1;
 
         cb_stepedit = new CheckBox;
         UI->add_element(cb_stepedit,5);
         cb_stepedit->frame = 0;
-        cb_stepedit->x = (start_x / 8) + 14 + 16;
+        cb_stepedit->x = (start_x / 8) + 17 + 16;
         cb_stepedit->y = (start_y / 8) + 14;
-        cb_stepedit->xsize = 5;
+        cb_stepedit->xsize = 3;
         cb_stepedit->value = &zt_config_globals.step_editing;
         cb_stepedit->frame = 1;
 
         cb_recveloc = new CheckBox;
         UI->add_element(cb_recveloc,6);
         cb_recveloc->frame = 0;
-        cb_recveloc->x = (start_x / 8) + 14 + 32;
+        cb_recveloc->x = (start_x / 8) + 17 + 32;
         cb_recveloc->y = (start_y / 8) + 14;
-        cb_recveloc->xsize = 5;
+        cb_recveloc->xsize = 3;
         cb_recveloc->value = &zt_config_globals.record_velocity;
         cb_recveloc->frame = 1;
 
         vs_speedup = new ValueSlider;
         UI->add_element(vs_speedup,7);
         vs_speedup->frame = 1;
-        vs_speedup->x = (start_x / 8) + 14;
+        vs_speedup->x = (start_x / 8) + 17;
         vs_speedup->y = (start_y / 8) + 16;
-        vs_speedup->xsize=window_width/8 - 20;
+        vs_speedup->xsize=window_width/8 - 23;
         vs_speedup->min=1;
         vs_speedup->max = 32;
         vs_speedup->value = zt_config_globals.control_navigation_amount;
@@ -99,9 +99,9 @@ CUI_PEParms::CUI_PEParms(void) {
         cb_drawmode = new CheckBox;
         UI->add_element(cb_drawmode, 8);
         cb_drawmode->frame = 1;
-        cb_drawmode->x = (start_x / 8) + 14;
+        cb_drawmode->x = (start_x / 8) + 17;
         cb_drawmode->y = (start_y / 8) + 18;
-        cb_drawmode->xsize = 5;
+        cb_drawmode->xsize = 3;
         cb_drawmode->value = &drawmode_val;
 }
 
@@ -182,6 +182,33 @@ void CUI_PEParms::update() {
         UIP_Patterneditor->mode = (drawmode_val) ? PEM_MOUSEDRAW : PEM_REGULARKEYS;
         if (UIP_Patterneditor->mode == PEM_REGULARKEYS) midiInQueue.clear();
     }
+
+    // Live drawing while the popup is open. With DrawMode on, forward
+    // mouse activity to the pattern editor when the cursor is outside
+    // the popup window. Only forward if the queue is empty (so the PE
+    // can refresh its drag from LastX/LastY) or the next pending key
+    // is a mouse-button event — never a keyboard key, which would
+    // hijack the popup's own input.
+    if (UIP_Patterneditor->mode == PEM_MOUSEDRAW) {
+        int win_w = 54 * col(1);
+        int win_h = 20 * row(1);
+        int wx = (INTERNAL_RESOLUTION_X / 2) - (win_w / 2);
+        int wy = (INTERNAL_RESOLUTION_Y / 2) - (win_h / 2);
+        int outside_popup = (LastX < wx) || (LastX >= wx + win_w) ||
+                            (LastY < wy) || (LastY >= wy + win_h);
+        if (outside_popup) {
+            int peeked = Keys.checkkey();
+            int forwardable_key =
+                peeked == 0 ||
+                peeked == ((unsigned int)((SDL_EVENT_MOUSE_BUTTON_UP   << 8) | SDL_BUTTON_LEFT)) ||
+                peeked == ((unsigned int)((SDL_EVENT_MOUSE_BUTTON_DOWN << 8) | SDL_BUTTON_LEFT));
+            if (forwardable_key) {
+                UIP_Patterneditor->update();
+                need_refresh++;
+                need_popup_refresh++;
+            }
+        }
+    }
 }
 
 void CUI_PEParms::draw(Drawable *S) {
@@ -195,23 +222,23 @@ void CUI_PEParms::draw(Drawable *S) {
     for(;start_y % 8;start_y--)
         ;
 
-    vs_step->x = (start_x / 8) + 14;
+    vs_step->x = (start_x / 8) + 17;
     vs_step->y = (start_y / 8) + 6; 
-    vs_pat_length->x = (start_x / 8) + 14;
+    vs_pat_length->x = (start_x / 8) + 17;
     vs_pat_length->y = (start_y / 8) + 8; 
-    vs_highlight->x = (start_x / 8) + 14;
+    vs_highlight->x = (start_x / 8) + 17;
     vs_highlight->y = (start_y / 8) + 10; 
-    vs_lowlight->x = (start_x / 8) + 14;
+    vs_lowlight->x = (start_x / 8) + 17;
     vs_lowlight->y = (start_y / 8) + 12; 
-    cb_centered->x = (start_x / 8) + 14;
+    cb_centered->x = (start_x / 8) + 17;
     cb_centered->y = (start_y / 8) + 14;
-    cb_stepedit->x = (start_x / 8) + 14 + 16;
+    cb_stepedit->x = (start_x / 8) + 17 + 16;
     cb_stepedit->y = (start_y / 8) + 14;
-    cb_recveloc->x = (start_x / 8) + 14 + 32;
+    cb_recveloc->x = (start_x / 8) + 17 + 32;
     cb_recveloc->y = (start_y / 8) + 14;
-    vs_speedup->x = (start_x / 8) + 14;
+    vs_speedup->x = (start_x / 8) + 17;
     vs_speedup->y = (start_y / 8) + 16;
-    cb_drawmode->x = (start_x / 8) + 14;
+    cb_drawmode->x = (start_x / 8) + 17;
     cb_drawmode->y = (start_y / 8) + 18;
 
 
@@ -224,15 +251,18 @@ void CUI_PEParms::draw(Drawable *S) {
         }
         printline(start_x,start_y,143,window_width / 8,COLORS.Highlight,S);
         print(col(textcenter("Pattern Editor Options")),start_y + row(2),"Pattern Editor Options",COLORS.Text,S);
-        print(start_x + col(2),start_y + row(6),"      Step:",COLORS.Text,S);
-        print(start_x + col(2),start_y + row(8),"Pat length:",COLORS.Text,S);
-        print(start_x + col(2),start_y + row(10)," HighLight:",COLORS.Text,S);
-        print(start_x + col(2),start_y + row(12),"  LowLight:",COLORS.Text,S);
-	print(start_x + col(2),start_y + row(14),"  Centered:",COLORS.Text,S);
-	print(start_x + col(20),start_y + row(14),"StepEdit:",COLORS.Text,S);
-    print(start_x + col(36),start_y + row(14),"RecVeloc:",COLORS.Text,S);
-	print(start_x + col(2),start_y + row(16),"   Speedup:",COLORS.Text,S);
-        print(start_x + col(2),start_y + row(18),"  DrawMode:",COLORS.Text,S);
+        // Labels right-align so the colon lands at col 15. The slider/
+        // checkbox x-origin is col 17, so the frame border at col 16
+        // sits between the colon and the chip without stomping either.
+        print(start_x + col(2),start_y + row(6),     "     EditStep:",COLORS.Text,S);
+        print(start_x + col(2),start_y + row(8),     "   Pat length:",COLORS.Text,S);
+        print(start_x + col(2),start_y + row(10),    "Row Highlight:",COLORS.Text,S);
+        print(start_x + col(2),start_y + row(12),    " Row Lowlight:",COLORS.Text,S);
+        print(start_x + col(2),start_y + row(14),    "     Centered:",COLORS.Text,S);
+        print(start_x + col(23),start_y + row(14),"StepEdit:",COLORS.Text,S);
+        print(start_x + col(39),start_y + row(14),"RecVeloc:",COLORS.Text,S);
+        print(start_x + col(2),start_y + row(16),    "      Speedup:",COLORS.Text,S);
+        print(start_x + col(2),start_y + row(18),    "     DrawMode:",COLORS.Text,S);
         UI->full_refresh();
         UI->draw(S);
         S->unlock();

--- a/src/CUI_PaletteEditor.cpp
+++ b/src/CUI_PaletteEditor.cpp
@@ -955,10 +955,13 @@ static void draw_swatch(Drawable *S, int slot, int selected, int channel_edit) {
     S->drawVLine(x0,     y0, y1, border);
     S->drawVLine(x1 - 1, y0, y1, border);
 
-    // Pattern-line preview to the right of the swatch.
+    // Pattern-line preview to the right of the swatch. Width is sized
+    // for the 8-char preview text ("C-5 01..") plus a 1-char border
+    // padding on each side; the swatch's own width is intentionally
+    // narrower than this.
     int px0 = x1 + col(1);
     int py0 = y0;
-    int px1 = px0 + col(PE_SWATCH_W);
+    int px1 = px0 + col(9);
     int py1 = py0 + row(PE_SWATCH_H);
     S->fillRect(px0, py0, px1, py1, COLORS.EditBG);
     print(px0 + 2, py0 + 2,              "C-5 01..", c, S);

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -25,7 +25,7 @@ static PatternUndo g_undo;
 // INTERNAL_RESOLUTION_Y - 55. At 8px per character row that's ceil(55/8) = 7
 // rows; we reserve one extra row so the pattern's bottom border never touches
 // the toolbar. Matches the legacy layout (40 rows = 0..039 at 480px height).
-#define SPACE_AT_BOTTOM                 8
+#define SPACE_AT_BOTTOM                 7
 
 
 int PATTERN_EDIT_ROWS = 100;
@@ -1678,6 +1678,23 @@ void CUI_Patterneditor::update()
             statusmsg = "Nothing to undo";
           }
           status_change = 1; need_refresh++; key = 0;
+        }
+
+        // Cmd+N (macOS): set length of first note of selection to length of
+        // the selection. Mirrors the Ctrl+N binding documented in help.txt;
+        // on Mac the global Alt+N → New Song would otherwise win because
+        // SDL maps Cmd to KS_META|KS_ALT.
+        if ((kstate & KS_META) && !(kstate & KS_CTRL) && !(kstate & KS_SHIFT) && key == SDLK_N) {
+          if (selected &&
+            (e = song->patterns[cur_edit_pattern]->tracks[select_track_start]->get_event(select_row_start))
+            ) {
+            j = (select_row_end+1 - select_row_start)*(96/song->tpb);
+            for(i=select_track_start;i<=select_track_end;i++)
+              song->patterns[cur_edit_pattern]->tracks[i]->update_event(select_row_start,-1,-1,-1,j,-1,-1);
+            file_changed++;
+            need_refresh++;
+          }
+          key = 0;
         }
 
         // Double Pattern: Ctrl+Shift+G
@@ -3540,18 +3557,6 @@ void CUI_Patterneditor::draw(Drawable *S)
     }
     
     draw_status_vars(S);
-
-    // Show playback position at bottom of pattern area when playing
-    if (ztPlayer->playing) {
-        static char playinfo[128];
-        snprintf(playinfo, 128, " Playing: Ord %03d  Pat %03d  Row %03d/%03d  BPM %d  TPB %d  Step %d ",
-            ztPlayer->playing_cur_order,
-            ztPlayer->playing_cur_pattern,
-            ztPlayer->playing_cur_row,
-            song->patterns[ztPlayer->playing_cur_pattern] ? song->patterns[ztPlayer->playing_cur_pattern]->length : 0,
-            song->bpm, song->tpb, cur_step);
-        print(row(1), col(CHARS_Y - 2), playinfo, COLORS.Data, S);
-    }
 
     printtitle(PAGE_TITLE_ROW_Y,"Pattern Editor (F2)",COLORS.Text,COLORS.Background,S);
     

--- a/src/CUI_SongDuration.cpp
+++ b/src/CUI_SongDuration.cpp
@@ -16,38 +16,42 @@ void BTNCLK_close_songduration(void) {
 // ------------------------------------------------------------------------------------------------
 //
 //
-int calcSongSeconds(int cur_row, int cur_ord)
+// Returns whole-seconds duration. For sub-second precision use
+// calcSongMs() — same row-walk, but expressed in milliseconds so the
+// caller can render MM:SS.t without the integer-truncation chunkiness.
+int calcSongMs(int cur_row, int cur_ord)
 {
     int o = 0;
-    int rows = 0;
-    int seconds;
-    int cr=0;
-    
+    int64_t rows = 0;
+    int64_t cr = 0;
+
     while (o < ZTM_ORDERLIST_LEN && song->orderlist[o] == 0x101) {
         o++;
     }
 
-    while( o < ZTM_ORDERLIST_LEN && song->orderlist[o] < 0x100) {
-        rows += song->patterns[song->orderlist[o]]->length;
+    while (o < ZTM_ORDERLIST_LEN && song->orderlist[o] < 0x100) {
+        int len = song->patterns[song->orderlist[o]]->length;
+        rows += len;
         if (cur_row != -1) {
-            if (o<cur_ord)
-                cr+=song->patterns[song->orderlist[o]]->length;
-            if (o == cur_ord)
-                cr+=cur_row;
+            if (o < cur_ord) cr += len;
+            if (o == cur_ord) cr += cur_row;
         }
         o++;
-        while (o < ZTM_ORDERLIST_LEN && song->orderlist[o]==0x101)
+        while (o < ZTM_ORDERLIST_LEN && song->orderlist[o] == 0x101)
             o++;
     }
-    if (rows>0)
-        seconds = (((rows)/song->tpb)*60)/song->bpm;
-    else 
-        seconds=0;
-    if (cur_row > -1 && rows > 0) {
-        seconds = seconds*cr / rows;
-    }
-        
-    return seconds;
+
+    if (song->tpb <= 0 || song->bpm <= 0) return 0;
+
+    // Time per row = 60/(tpb*bpm) seconds → milliseconds = row*60000/(tpb*bpm).
+    int64_t denom = (int64_t)song->tpb * (int64_t)song->bpm;
+    int64_t target_rows = (cur_row > -1) ? cr : rows;
+    return (int)((target_rows * 60000) / denom);
+}
+
+int calcSongSeconds(int cur_row, int cur_ord)
+{
+    return calcSongMs(cur_row, cur_ord) / 1000;
 }
 
 

--- a/src/CUI_SongMessage.cpp
+++ b/src/CUI_SongMessage.cpp
@@ -49,7 +49,7 @@ CUI_SongMessage::CUI_SongMessage(void) {
     UI->add_element(tb, 0);
     tb->x = 1;
     tb->y = 12;
-    tb->xsize = 78 + ((INTERNAL_RESOLUTION_X-640)/8);
+    tb->xsize = TextBox::full_width_xsize();
     // Bottom-anchor: same formula as CUI_Help so the textbox never
     // bleeds into the toolbar strip at INTERNAL_RESOLUTION_Y - 55.
     tb->ysize = (INTERNAL_RESOLUTION_Y/8) - tb->y - 8;
@@ -98,6 +98,16 @@ void CUI_SongMessage::leave(void) {
 }
 
 void CUI_SongMessage::update() {
+    // Peek for ESC before UI->update() so the CommentEditor doesn't
+    // get a chance to swallow it.
+    if (Keys.size()) {
+        int key = Keys.checkkey();
+        if (key == SDLK_ESCAPE) {
+            Keys.getkey(); // consume
+            switch_page(UIP_Patterneditor);
+            return;
+        }
+    }
     UI->update();
     if (Keys.size()) {
         Keys.getkey();
@@ -108,7 +118,7 @@ void CUI_SongMessage::draw(Drawable *S) {
     // Re-run the bottom-anchored sizing in case the window has been
     // resized since the page was constructed.
     CommentEditor *cb = (CommentEditor*)UI->get_element(0);
-    cb->xsize = 78 + ((INTERNAL_RESOLUTION_X-640)/8);
+    cb->xsize = TextBox::full_width_xsize();
     cb->ysize = (INTERNAL_RESOLUTION_Y/8) - cb->y - 8;
     // Refresh the null-terminated display mirror so TextBox::draw has
     // a clean string to walk (CDataBuf is not null-terminated; reading

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -37,7 +37,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
         ti = new TextInput;
         UI->add_element(ti,0);
         ti->frame = 1;
-        ti->x = 17;
+        ti->x = 20;
         ti->y = base_y;
         ti->xsize=28;
         ti->length=28;
@@ -47,7 +47,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
         vs = new ValueSlider;
         UI->add_element(vs,1);
         vs->frame = 0;
-        vs->x = 17; 
+        vs->x = 20; 
         vs->y = base_y+2; 
         vs->xsize=28;
         vs->min = 60;
@@ -58,7 +58,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
         vs = new ValueSlider;
         UI->add_element(vs,2);
         vs->frame = 0;
-        vs->x = 17; 
+        vs->x = 20; 
         vs->y = base_y+3; 
         vs->xsize=28;
         vs->min = 0;
@@ -69,7 +69,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
     /* Initialize Frame for those two above*/
         fm = new Frame;
         UI->add_gfx(fm,0);
-        fm->x = 17;
+        fm->x = 20;
         fm->y = base_y+2;
         fm->xsize = 28;
         fm->ysize = 2;
@@ -78,31 +78,74 @@ CUI_Songconfig::CUI_Songconfig(void) {
         cb = new CheckBox;
         UI->add_element(cb,3);
         cb->frame = 0;
-        cb->x = 17;
+        cb->x = 20;
         cb->y = base_y+5;
-        cb->xsize = 5;
+        cb->xsize = 3;
         cb->value = &song->flag_SendMidiClock;
     // END Midi Clock
     /* Initialize MIDI Stop/Start checkbox */
         cb = new CheckBox;
         UI->add_element(cb,4);
         cb->frame = 0;
-        cb->x = 17;
+        cb->x = 20;
         cb->y = base_y+6;
-        cb->xsize = 5;
+        cb->xsize = 3;
         cb->value = &song->flag_SendMidiStopStart;
     // END Midi Clock
-    /* Initialize Frame for those two above */
+        // Send MIDI Clock + MIDI Stop/Start checkboxes have no surrounding
+        // Frame — its right border char rendered as a yellow stripe to the
+        // right of the chips and the unframed style matches MIDI In Sync /
+        // Chase MIDI Tempo below.
+
+        // Row Highlight + Row Lowlight (the global zt_config_globals values,
+        // surfaced here so song-edit tasks can tweak them without leaving F11).
+        vs = new ValueSlider;
+        UI->add_element(vs, 5);
+        vs->frame = 0;
+        vs->x = 20;
+        vs->y = base_y + 8;
+        vs->xsize = 28;
+        vs->min = 1;
+        vs->max = 64;
+        vs->value = zt_config_globals.highlight_increment;
+
+        vs = new ValueSlider;
+        UI->add_element(vs, 6);
+        vs->frame = 0;
+        vs->x = 20;
+        vs->y = base_y + 9;
+        vs->xsize = 28;
+        vs->min = 1;
+        vs->max = 64;
+        vs->value = zt_config_globals.lowlight_increment;
+
         fm = new Frame;
-        UI->add_gfx(fm,1);
-        fm->x = 17;
-        fm->y = base_y+5; 
-        fm->xsize = 5;
+        UI->add_gfx(fm, 2);
+        fm->x = 20;
+        fm->y = base_y + 8;
+        fm->xsize = 28;
         fm->ysize = 2;
-    // END Frame
+
+        // MIDI In Sync (slave to incoming MIDI clock).
+        cb = new CheckBox;
+        UI->add_element(cb, 7);
+        cb->frame = 0;
+        cb->x = 20;
+        cb->y = base_y + 11;
+        cb->xsize = 3;
+        cb->value = &zt_config_globals.midi_in_sync;
+
+        // Chase MIDI Tempo.
+        cb = new CheckBox;
+        UI->add_element(cb, 8);
+        cb->frame = 0;
+        cb->x = 20;
+        cb->y = base_y + 12;
+        cb->xsize = 3;
+        cb->value = &zt_config_globals.midi_in_sync_chase_tempo;
 
         oe = new OrderEditor;
-        UI->add_element(oe,5);
+        UI->add_element(oe,9);
         oe->x = 59;
         oe->y = 13;
         oe->xsize = 9;
@@ -125,9 +168,25 @@ void CUI_Songconfig::enter(void) {
     if(!zt_config_globals.lowlight_increment)
         zt_config_globals.lowlight_increment = song->tpb >> 1 / song->tpb / 2;
     
+    // F11 toggle: when re-entering Songconfig from itself (LastPage==this,
+    // i.e. user pressed F11 while already on F11), focus the Title field
+    // (id 0) instead of the OrderEditor — common workflow is to press F11
+    // a second time to rename the song.
+    bool toggling = (LastPage == this);
     cur_state = STATE_SONG_CONFIG;
+    // Reset OrderEditor cursor so the focus indicator is always visible
+    // at row 0 (otherwise stale cursor_y/list_start could leave it
+    // scrolled off-screen). Only reset on a fresh entry — toggling to
+    // Title leaves the OrderEditor state alone.
+    if (oe && !toggling) {
+        oe->cursor_y = 0;
+        oe->cursor_x = 0;
+        oe->list_start = 0;
+    }
     Keys.flush();
-    UI->set_focus(5); // set focus to order editor
+    int target = toggling ? 0 : 9;   // 0 = Title TextInput, 9 = OrderEditor
+    UI->set_focus(target);
+    UI->cur_element = target;
 }
 
 void CUI_Songconfig::leave(void) {
@@ -136,9 +195,10 @@ void CUI_Songconfig::leave(void) {
 
 void CUI_Songconfig::update()
 {
-    // Reserve 8 rows at the bottom: 7 for the 55px toolbar (ceil(55/8)) plus
-    // one row of safety so the order editor's frame never overlaps.
-    oe->ysize =  ((INTERNAL_RESOLUTION_Y/8) - oe->y - 8) ;
+    // Reserve 7 rows at the bottom for the 55 px toolbar (ceil(55/8));
+    // one extra row of safety was previously added but it left the order
+    // list one row short of the F1 Help bottom edge.
+    oe->ysize =  ((INTERNAL_RESOLUTION_Y/8) - oe->y - 7) ;
 
     ValueSlider *vs;
     TextInput *t;
@@ -149,8 +209,9 @@ void CUI_Songconfig::update()
 
     UI->update();
     vs = (ValueSlider *)UI->get_element(1);
-    if (vs->value != song->bpm) { 
-        song->bpm = vs->value; 
+    if (vs->from_input) vs->from_input = 0;  // BPM slider takes any [min,max]; clamp already applied
+    if (vs->value != song->bpm) {
+        song->bpm = vs->value;
         ztPlayer->set_speed();
 
         if(!zt_config_globals.highlight_increment)
@@ -161,8 +222,31 @@ void CUI_Songconfig::update()
         file_changed++;
     }
     vs = (ValueSlider *)UI->get_element(2);
-    if (vs->value != rev_tpb_tab[song->tpb]) { 
-        song->tpb = tpb_tab[vs->value]; 
+    if (vs->from_input) {
+        // Typed-numeric path. vs->input_value holds the raw number the
+        // user entered (preserved before clamping in Sliders.cpp). Snap
+        // to the nearest valid TPB in tpb_tab[]={2,4,6,8,12,16,24,32,48}
+        // so '8' -> TPB=8 (slider index 3), '5' -> TPB=4 (nearest), etc.
+        // On ties, prefer the higher TPB (more granular, common in
+        // tracker conventions).
+        int typed = vs->input_value;
+        int best_idx = 0;
+        int best_diff = abs(tpb_tab[0] - typed);
+        for (int i = 1; i <= 8; i++) {
+            int diff = abs(tpb_tab[i] - typed);
+            if (diff < best_diff || (diff == best_diff && tpb_tab[i] > typed)) {
+                best_diff = diff;
+                best_idx = i;
+            }
+        }
+        vs->value = best_idx;
+        vs->from_input = 0;
+    }
+    // Clamp slider index to the table range regardless of input source.
+    if (vs->value < 0) vs->value = 0;
+    if (vs->value > 8) vs->value = 8;
+    if (tpb_tab[vs->value] != song->tpb) {
+        song->tpb = tpb_tab[vs->value];
         ztPlayer->set_speed();
         vs->force_f=1; vs->force_v = song->tpb;
 
@@ -170,8 +254,30 @@ void CUI_Songconfig::update()
             zt_config_globals.highlight_increment = song->tpb;
         if(!zt_config_globals.lowlight_increment)
             zt_config_globals.lowlight_increment = song->tpb >> 1 / song->tpb / 2;
-        
+
         file_changed++;
+    }
+    vs = (ValueSlider *)UI->get_element(5);
+    if (vs && vs->from_input) vs->from_input = 0;
+    if (vs && vs->value != zt_config_globals.highlight_increment) {
+        zt_config_globals.highlight_increment = vs->value;
+    } else if (vs) {
+        vs->value = zt_config_globals.highlight_increment;
+    }
+    vs = (ValueSlider *)UI->get_element(6);
+    if (vs && vs->from_input) vs->from_input = 0;
+    if (vs && vs->value != zt_config_globals.lowlight_increment) {
+        zt_config_globals.lowlight_increment = vs->value;
+    } else if (vs) {
+        vs->value = zt_config_globals.lowlight_increment;
+    }
+    {
+        CheckBox *cb = (CheckBox *)UI->get_element(7);
+        if (cb && cb->changed)
+            zt_config_globals.midi_in_sync = *(cb->value);
+        cb = (CheckBox *)UI->get_element(8);
+        if (cb && cb->changed)
+            zt_config_globals.midi_in_sync_chase_tempo = *(cb->value);
     }
     if (Keys.size()) {
         Keys.getkey();
@@ -184,22 +290,24 @@ void CUI_Songconfig::draw(Drawable *S) {
         UI->draw(S);
         draw_status(S);
         printtitle(PAGE_TITLE_ROW_Y,"Song Configuration (F11)",COLORS.Text,COLORS.Background,S);
-        // Right-align Title/BPM/TPB labels so their right edge sits one
-        // char before the textfield/slider start (col 17), matching the
-        // tight "Send MIDI Clock" / "MIDI Stop/Start" pattern below.
-        // "Title" = 5 chars → col 11; "BPM"/"TPB" = 3 chars → col 13.
-        print(row(11),col(base_y),"Title",COLORS.Text,S);
-        print(row(13),col(base_y+2),"BPM",COLORS.Text,S);
-        print(row(13),col(base_y+3),"TPB",COLORS.Text,S);
-        print(row(1),col(base_y+5),"Send MIDI Clock",COLORS.Text,S);
-        print(row(1),col(base_y+6.),"MIDI Stop/Start",COLORS.Text,S);
-        // Order List label: row 11 (one blank row below page title at 9),
-        // horizontally clear of the OE data (OE starts at column 59, so
-        // put label at column 60 which is inside the OE x-span so it
-        // visually belongs to the list).
-        print(row(60),col(11),"Order List",COLORS.Text,S);
-        printchar(row(17 + 27) + 1,col(base_y+2),0x84,COLORS.Highlight,S);
-        printchar(row(17 + 27) + 1,col(base_y+3),0x84,COLORS.Highlight,S);
+        // All labels right-align so text ends col 18 (1-char gap before
+        // col-20 controls). Order List is on its own column (col 59)
+        // and is intentionally NOT shifted.
+        print(row(14),col(base_y),"Title",COLORS.Text,S);
+        print(row(16),col(base_y+2),"BPM",COLORS.Text,S);
+        print(row(16),col(base_y+3),"TPB",COLORS.Text,S);
+        print(row(4),col(base_y+5),"Send MIDI Clock",COLORS.Text,S);
+        print(row(4),col(base_y+6.),"MIDI Stop/Start",COLORS.Text,S);
+        print(row(5),col(base_y+8),"Row Highlight ",COLORS.Text,S);
+        print(row(6),col(base_y+9),"Row Lowlight ",COLORS.Text,S);
+        printchar(row(20 + 27) + 1,col(base_y+8),0x84,COLORS.Highlight,S);
+        printchar(row(20 + 27) + 1,col(base_y+9),0x84,COLORS.Highlight,S);
+        print(row(4),col(base_y+11),"   MIDI In Sync",COLORS.Text,S);
+        print(row(3),col(base_y+12),"Chase MIDI Tempo",COLORS.Text,S);
+        // Order List label aligned to the OE x-origin (col 59) — NOT shifted.
+        print(row(59),col(11),"Order List",COLORS.Text,S);
+        printchar(row(20 + 27) + 1,col(base_y+2),0x84,COLORS.Highlight,S);
+        printchar(row(20 + 27) + 1,col(base_y+3),0x84,COLORS.Highlight,S);
 
         need_refresh = 0; updated=2;
         ztPlayer->num_orders();

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -168,23 +168,27 @@ void CUI_Songconfig::enter(void) {
     if(!zt_config_globals.lowlight_increment)
         zt_config_globals.lowlight_increment = song->tpb >> 1 / song->tpb / 2;
     
-    // F11 toggle: when re-entering Songconfig from itself (LastPage==this,
-    // i.e. user pressed F11 while already on F11), focus the Title field
-    // (id 0) instead of the OrderEditor — common workflow is to press F11
-    // a second time to rename the song.
-    bool toggling = (LastPage == this);
+    // F11 toggle: pressing F11 while already on Songconfig flips focus
+    // between OrderEditor (id 9) and Title (id 0) on every press, so the
+    // user can keep tapping F11 to alternate. Fresh entry from another
+    // page lands on the OrderEditor.
+    bool same_page = (LastPage == this);
     cur_state = STATE_SONG_CONFIG;
     // Reset OrderEditor cursor so the focus indicator is always visible
     // at row 0 (otherwise stale cursor_y/list_start could leave it
-    // scrolled off-screen). Only reset on a fresh entry — toggling to
-    // Title leaves the OrderEditor state alone.
-    if (oe && !toggling) {
+    // scrolled off-screen). Only reset on a fresh entry.
+    if (oe && !same_page) {
         oe->cursor_y = 0;
         oe->cursor_x = 0;
         oe->list_start = 0;
     }
     Keys.flush();
-    int target = toggling ? 0 : 9;   // 0 = Title TextInput, 9 = OrderEditor
+    int target;
+    if (same_page) {
+        target = (UI->cur_element == 0) ? 9 : 0;
+    } else {
+        target = 9;   // fresh entry → OrderEditor
+    }
     UI->set_focus(target);
     UI->cur_element = target;
 }

--- a/src/CUI_Sysconfig.cpp
+++ b/src/CUI_Sysconfig.cpp
@@ -261,14 +261,15 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         UI->add_element(b,tabindex++);
         b->caption = "   Go to page 2   ";
         b->xsize = 18;
-        b->x = 2;
+        b->x = 4;   // align start with "MIDI Out Device Selection" label below
         b->y = 12;
         b->ysize = 1;
         b->OnClick = (ActFunc)BTNCLK_GotoGlobalConfig;
 
         vs = new ValueSlider;
         UI->add_element(vs,tabindex++);
-        vs->x = 4 + 15;
+        // Left column controls at col 20 to match Global Config (Ctrl+F12).
+        vs->x = 4 + 16;
         vs->y = base_y;
         vs->xsize = 15+1;
         vs->ysize = 1;
@@ -278,41 +279,54 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
 
         cb = new CheckBox;
         UI->add_element(cb,tabindex++);
-        cb->x = 4 + 15;
-        cb->y = base_y + 2;
-        cb->xsize = 5;
+        cb->x = 4 + 16;
+        cb->y = base_y + 2;   // Panic on stop
+        cb->xsize = 3;
         cb->value = &zt_config_globals.auto_send_panic;
-        cb->frame = 1;
+        cb->frame = 0;
 
+        // MIDI In Sync (a.k.a. "MIDI-IN Slave"). The user-facing label
+        // lives in F11 (Songconfig) now, but we keep the element here
+        // off-screen so the tabindex/get_element(N) numbering elsewhere
+        // doesn't shift. xsize=0 / no_tab_stop hide it from cycling.
         cb = new CheckBox;
         UI->add_element(cb,tabindex++);
-        cb->x = 4 + 15;
-        cb->y = base_y + 4;
-        cb->xsize = 5;
+        cb->x = 0;
+        cb->y = 0;
+        cb->xsize = 0;
         cb->value = &zt_config_globals.midi_in_sync;
-        cb->frame = 1;
+        cb->frame = 0;
+        cb->no_tab_stop = 1;
 
         cb = new CheckBox;
         UI->add_element(cb,tabindex++);
-        cb->x = 4 + 15;
-        cb->y = base_y + 6;
-        cb->xsize = 5;
+        cb->x = 4 + 16;
+        cb->y = base_y + 3;   // Auto-open MIDI — adjacent to Panic on stop
+        cb->xsize = 3;
         cb->value = &zt_config_globals.auto_open_midi;
-        cb->frame = 1;
+        cb->frame = 0;
 
         cb = new CheckBox;
         UI->add_element(cb,tabindex++); // Full Screen cb — update() reads via get_element(5)
-        cb->frame = 0;
-        cb->x = 4+15;
-        cb->y = base_y + 8;
-        cb->xsize = 5;
+        cb->x = 4+16;
+        cb->y = base_y + 4;   // adjacent to Auto-open MIDI; matches F11 tight checkbox stack
+        cb->xsize = 3;
         cb->value = &zt_config_globals.full_screen;
-        cb->frame = 1;
+        cb->frame = 0;
+
+        // Record Velocity (moved from Ctrl+F12 Global Config).
+        cb = new CheckBox;
+        UI->add_element(cb,tabindex++);
+        cb->x = 4+16;
+        cb->y = base_y + 5;
+        cb->xsize = 3;
+        cb->value = &zt_config_globals.record_velocity;
+        cb->frame = 0;
 
 #ifndef DISABLED_CONFIGURATION_VALUES
         vs = new ValueSlider;
         UI->add_element(vs,tabindex++);
-        vs->x = 4+15;
+        vs->x = 4+16;
         vs->y = base_y + 10;
         vs->xsize = 15+4;
         vs->ysize = 1;
@@ -322,7 +336,7 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
 
         vs = new ValueSlider;
         UI->add_element(vs,tabindex++);
-        vs->x = 4+15;
+        vs->x = 4+16;
         vs->y = base_y + 12;
         vs->xsize = 15+4;
         vs->ysize = 1;
@@ -335,73 +349,17 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         UI->add_element(sk,tabindex++);
         sk->x = 4+35 +10;
         sk->y = base_y + 1;   // "Skin Selection" label sits on the same row as "Prebuffer"; list top border one row below
-        sk->xsize = 19+4;
+        sk->xsize = 19+8;     // ends at col 76, matches MIDI In Device list end
         sk->ysize = 7;   // tight-fit around installed skin count, avoids empty black space
 
-        // MIDI Out column — visual order: Refresh (y=28), list (y=30-42),
-        // Open device (y=45), Latency (y=47), Bank (y=49), Alias (y=51).
-        // tabindex follows the same order so UP/DOWN navigates top-to-bottom.
+        // MIDI In column lives on the LEFT, MIDI Out on the RIGHT (+37
+        // offset). Layout: Refresh (y=28), list (y=30-42), Open device
+        // (y=45). MIDI Out also has Latency (y=47), Bank (y=49), Alias
+        // (y=51). tabindex order: MIDI In group first, then MIDI Out.
         b = new Button;
         UI->add_element(b,tabindex++);
         b->caption = " Refresh";
         b->x = 4+26;
-        b->y = 48 - 16 -2-2;
-        b->xsize = 9;
-        b->ysize = 1;
-        b->OnClick = (ActFunc)BTNCLK_RefreshMidiOutDeviceList;
-
-        ml = new MidiOutDeviceOpener;
-        UI->add_element(ml,tabindex++);
-        midioutdevlist = ml;
-        ml->x = 4;
-        ml->y = 48 - 16-2;
-        ml->xsize=35;
-        ml->ysize = 13;
-
-        b = new Button;
-        UI->add_element(b,tabindex++);
-        b->caption = " Open device   ";
-        b->x = 4+21;
-        b->y = 45;
-        b->xsize = 14;
-        b->ysize = 1;
-        b->OnClick = (ActFunc)BTNCLK_ForgetMidiOutDevice;
-        midiout_action_button = b;
-
-        vs = new LatencyValueSlider(ml);
-        UI->add_element(vs,tabindex++);
-        vs->x = 19;                    // align with Prebuffer slider
-        vs->y = 47;
-        vs->xsize = 15;
-        vs->ysize = 1;
-        vs->min = 0;
-        vs->max = 255;
-
-        cb = new BankSelectCheckBox(ml);
-        UI->add_element(cb,tabindex++);
-        cb->frame = 0;
-        cb->x = 25;
-        cb->y = 49;
-        cb->xsize = 5;
-        cb->frame = 1;
-
-        ti = new AliasTextInput(ml);
-        UI->add_element(ti,tabindex++);
-        ti->frame = 1;
-        ti->x = 19;                    // align with Prebuffer slider
-        ti->y = 51;
-        ti->xsize=42;
-        ti->length=41;
-
-        ml->lvs = vs;  // link midi out list to latency value slider
-        ml->bscb = cb; // link midi out list to bank select checkbox
-        ml->al = ti;
-
-        // MIDI In column — same visual order: Refresh, list, Open device.
-        b = new Button;
-        UI->add_element(b,tabindex++);
-        b->caption = " Refresh";
-        b->x = 4+26+37;
         b->y = 48 - 16 -2-2;
         b->xsize = 9;
         b->ysize = 1;
@@ -410,10 +368,38 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         mi = new MidiInDeviceOpener;
         midiindevlist = mi;
         UI->add_element(mi,tabindex++);
-        mi->x = 4+37;
+        mi->x = 4;
         mi->y = 48 - 16-2;
         mi->xsize=35;
         mi->ysize = 13;
+
+        b = new Button;
+        UI->add_element(b,tabindex++);
+        b->caption = " Open device   ";
+        b->x = 4+21;
+        b->y = 45;
+        b->xsize = 14;
+        b->ysize = 1;
+        b->OnClick = (ActFunc)BTNCLK_ForgetMidiInDevice;
+        midiin_action_button = b;
+
+        // MIDI Out column (right side, +37 offset).
+        b = new Button;
+        UI->add_element(b,tabindex++);
+        b->caption = " Refresh";
+        b->x = 4+26+37;
+        b->y = 48 - 16 -2-2;
+        b->xsize = 9;
+        b->ysize = 1;
+        b->OnClick = (ActFunc)BTNCLK_RefreshMidiOutDeviceList;
+
+        ml = new MidiOutDeviceOpener;
+        UI->add_element(ml,tabindex++);
+        midioutdevlist = ml;
+        ml->x = 4+37;
+        ml->y = 48 - 16-2;
+        ml->xsize=35;
+        ml->ysize = 13;
 
         b = new Button;
         UI->add_element(b,tabindex++);
@@ -422,8 +408,43 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         b->y = 45;
         b->xsize = 14;
         b->ysize = 1;
-        b->OnClick = (ActFunc)BTNCLK_ForgetMidiInDevice;
-        midiin_action_button = b;
+        b->OnClick = (ActFunc)BTNCLK_ForgetMidiOutDevice;
+        midiout_action_button = b;
+
+        vs = new LatencyValueSlider(ml);
+        UI->add_element(vs,tabindex++);
+        vs->x = 20+37;
+        vs->y = 47;
+        vs->xsize = 15;
+        vs->ysize = 1;
+        vs->min = 0;
+        vs->max = 255;
+
+        cb = new BankSelectCheckBox(ml);
+        UI->add_element(cb,tabindex++);
+        cb->x = 26+37;
+        cb->y = 49;
+        cb->xsize = 3;
+        cb->frame = 0;
+
+        ti = new AliasTextInput(ml);
+        UI->add_element(ti,tabindex++);
+        ti->frame = 1;
+        ti->x = 20+37;
+        ti->y = 51;
+        // Alias visible width must fit between x=57 and the right edge.
+        // Default 640px screen = 80 cols, so available = 80-57-1 = 22.
+        // Wider screens get more room. The buffer (length) holds up to
+        // 41 chars regardless — TextInput scrolls horizontally.
+        {
+            const int avail = (INTERNAL_RESOLUTION_X / FONT_SIZE_X) - 57 - 1;
+            ti->xsize  = (avail > 42) ? 42 : (avail > 1 ? avail : 1);
+            ti->length = 41;
+        }
+
+        ml->lvs = vs;  // link midi out list to latency value slider
+        ml->bscb = cb; // link midi out list to bank select checkbox
+        ml->al = ti;
 
 }
 
@@ -462,7 +483,6 @@ void CUI_Sysconfig::update() {
     if (bIsFullscreen) i = 1;
     if ( * cb->value != i) {
         attempt_fullscreen_toggle();
-        attempt_fullscreen_toggle();
     }
     if (Keys.size()) {
         Keys.getkey();
@@ -477,26 +497,30 @@ void CUI_Sysconfig::draw(Drawable *S) {
         printtitle(PAGE_TITLE_ROW_Y,"System Configuration (F12)",COLORS.Text,COLORS.Background,S);
         // Labels shifted +3 rows from legacy position: row 12 holds the
         // "Go to page 2" button, rows 11 and 13 are empty gaps.
-        print(row(4),col(TRACKS_ROW_Y+3),"     Prebuffer",COLORS.Text,S);
-        print(row(4),col(TRACKS_ROW_Y+5)," Panic on stop",COLORS.Text,S);
-        print(row(4),col(TRACKS_ROW_Y+7)," MIDI-IN Slave",COLORS.Text,S);
-        print(row(4),col(TRACKS_ROW_Y+9),"Auto-open MIDI",COLORS.Text,S);
+        // Labels right-align so text ends at col 18 (1-char gap before
+        // col-20 controls). Matches Global Config (Ctrl+F12).
+        print(row(4),col(TRACKS_ROW_Y+3),"      Prebuffer",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+5),"  Panic on stop",COLORS.Text,S);
+        // "MIDI-IN Slave" label intentionally omitted — see F11 (Songconfig).
+        print(row(4),col(TRACKS_ROW_Y+6)," Auto-open MIDI",COLORS.Text,S);
 
-        print(row(4),col(TRACKS_ROW_Y+11),"   Full Screen",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+7),"    Full Screen",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+8),"Record Velocity",COLORS.Text,S);
 #ifndef DISABLED_CONFIGURATION_VALUES
-        print(row(4),col(TRACKS_ROW_Y+13),"    Key Repeat",COLORS.Text,S);
-        print(row(4),col(TRACKS_ROW_Y+15),"      Key Wait",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+13),"     Key Repeat",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+15),"       Key Wait",COLORS.Text,S);
 #endif
         print(row(4+37+8),col(TRACKS_ROW_Y+3),"Skin Selection",COLORS.Text,S);
 
-        print(row(4),col(28),"MIDI Out Device Selection",COLORS.Text,S);
-        print(row(4+37),col(28),"MIDI In Device Selection",COLORS.Text,S);
+        // MIDI In on the LEFT (col 4), MIDI Out on the RIGHT (col 4+37).
+        print(row(4),col(28),"MIDI In Device Selection",COLORS.Text,S);
+        print(row(4+37),col(28),"MIDI Out Device Selection",COLORS.Text,S);
 
-        print(row(5),col(47),"Latency ",COLORS.Text,S);
-        print(row(5),col(49),"Reverse Bank Select ",COLORS.Text,S);
-        print(row(5),col(51),"Device Alias",COLORS.Text,S);
+        print(row(5+37),col(47),"Latency ",COLORS.Text,S);
+        print(row(5+37),col(49),"Reverse Bank Select ",COLORS.Text,S);
+        print(row(5+37),col(51),"Device Alias",COLORS.Text,S);
         
-        need_refresh = 0; 
+        need_refresh = 0;
         updated=2;
         S->unlock();
     }

--- a/src/CUI_Sysconfig.cpp
+++ b/src/CUI_Sysconfig.cpp
@@ -40,11 +40,16 @@ void BTNCLK_RefreshMidiInDeviceList(UserInterfaceElement*) {
     
 }
 
+// All captions are exactly 15 chars (= button xsize) and centred so the
+// visible text sits in the same column for every device state.
+//   "Open device"   (11) -> "  Open device  " (2 + 11 + 2)
+//   "Forget device" (13) -> " Forget device " (1 + 13 + 1)
+//   "Close device"  (12) -> " Close device  " (1 + 12 + 2)
 static const char *get_midi_out_action_caption()
 {
     LBNode *selected = midioutdevlist ? midioutdevlist->getNode(midioutdevlist->getCurrentItemIndex()) : NULL;
     if (!selected) {
-        return " Open device   ";
+        return "  Open device  ";
     }
     if (selected->int_data < 0) {
         return " Forget device ";
@@ -52,14 +57,14 @@ static const char *get_midi_out_action_caption()
     if (MidiOut->QueryDevice(selected->int_data)) {
         return " Close device  ";
     }
-    return " Open device   ";
+    return "  Open device  ";
 }
 
 static const char *get_midi_in_action_caption()
 {
     LBNode *selected = midiindevlist ? midiindevlist->getNode(midiindevlist->getCurrentItemIndex()) : NULL;
     if (!selected) {
-        return " Open device   ";
+        return "  Open device  ";
     }
     if (selected->int_data < 0) {
         return " Forget device ";
@@ -67,7 +72,7 @@ static const char *get_midi_in_action_caption()
     if (MidiIn->QueryDevice(selected->int_data)) {
         return " Close device  ";
     }
-    return " Open device   ";
+    return "  Open device  ";
 }
 
 static void sync_midi_action_buttons()
@@ -375,10 +380,10 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
 
         b = new Button;
         UI->add_element(b,tabindex++);
-        b->caption = " Open device   ";
-        b->x = 4+21;
+        b->caption = "  Open device  ";
+        b->x = 4+20;       // right edge ends at col 39 (= MIDI In list end)
         b->y = 45;
-        b->xsize = 14;
+        b->xsize = 15;     // matches caption length so text never gets truncated
         b->ysize = 1;
         b->OnClick = (ActFunc)BTNCLK_ForgetMidiInDevice;
         midiin_action_button = b;
@@ -403,26 +408,30 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
 
         b = new Button;
         UI->add_element(b,tabindex++);
-        b->caption = " Open device   ";
-        b->x = 4+21+37;
+        b->caption = "  Open device  ";
+        b->x = 4+20+37;   // align left edge with MIDI Out list (4+37=41) shifted by +20 chars to space the button
         b->y = 45;
-        b->xsize = 14;
+        b->xsize = 15;
         b->ysize = 1;
         b->OnClick = (ActFunc)BTNCLK_ForgetMidiOutDevice;
         midiout_action_button = b;
 
+        // Latency / Bank / Alias share the right half (col 41..76, matching
+        // the MIDI Out list / Open device button width). Labels start at
+        // col 41 (left-aligned with list); values follow each label and
+        // extend to col 76.
         vs = new LatencyValueSlider(ml);
         UI->add_element(vs,tabindex++);
-        vs->x = 20+37;
+        vs->x = 49;        // after "Latency " label (cols 41..48)
         vs->y = 47;
-        vs->xsize = 15;
+        vs->xsize = 27;    // ends col 76 — matches list right edge
         vs->ysize = 1;
         vs->min = 0;
         vs->max = 255;
 
         cb = new BankSelectCheckBox(ml);
         UI->add_element(cb,tabindex++);
-        cb->x = 26+37;
+        cb->x = 61;        // after "Reverse Bank Select " label (cols 41..60)
         cb->y = 49;
         cb->xsize = 3;
         cb->frame = 0;
@@ -430,17 +439,10 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         ti = new AliasTextInput(ml);
         UI->add_element(ti,tabindex++);
         ti->frame = 1;
-        ti->x = 20+37;
+        ti->x = 54;        // after "Device Alias " label (cols 41..53)
         ti->y = 51;
-        // Alias visible width must fit between x=57 and the right edge.
-        // Default 640px screen = 80 cols, so available = 80-57-1 = 22.
-        // Wider screens get more room. The buffer (length) holds up to
-        // 41 chars regardless — TextInput scrolls horizontally.
-        {
-            const int avail = (INTERNAL_RESOLUTION_X / FONT_SIZE_X) - 57 - 1;
-            ti->xsize  = (avail > 42) ? 42 : (avail > 1 ? avail : 1);
-            ti->length = 41;
-        }
+        ti->xsize = 22;    // ends col 76 — matches list right edge
+        ti->length = 41;   // buffer still fits a long alias; field scrolls horizontally
 
         ml->lvs = vs;  // link midi out list to latency value slider
         ml->bscb = cb; // link midi out list to bank select checkbox
@@ -516,9 +518,10 @@ void CUI_Sysconfig::draw(Drawable *S) {
         print(row(4),col(28),"MIDI In Device Selection",COLORS.Text,S);
         print(row(4+37),col(28),"MIDI Out Device Selection",COLORS.Text,S);
 
-        print(row(5+37),col(47),"Latency ",COLORS.Text,S);
-        print(row(5+37),col(49),"Reverse Bank Select ",COLORS.Text,S);
-        print(row(5+37),col(51),"Device Alias",COLORS.Text,S);
+        // Labels left-aligned to col 41 (= MIDI Out list left edge).
+        print(row(4+37),col(47),"Latency",COLORS.Text,S);
+        print(row(4+37),col(49),"Reverse Bank Select",COLORS.Text,S);
+        print(row(4+37),col(51),"Device Alias",COLORS.Text,S);
         
         need_refresh = 0;
         updated=2;

--- a/src/InstEditor.cpp
+++ b/src/InstEditor.cpp
@@ -552,11 +552,15 @@ void InstEditor::draw(Drawable *S, int active)
     printcharBG(col(x + 24),row(cy+y),168,COLORS.Lowlight,COLORS.EditBG,S);
   }
 
+  // Extend frame to include the instrument-number / used-mark column on
+  // the left (cols x-4..x-1) so the bordered area covers ALL displayed
+  // content, matching the OrderEditor / pattern-track-frame convention
+  // in F2 where row labels live inside the frame.
   frm->type=0;
-  frm->x=x; frm->y=y; frm->xsize=xsize; frm->ysize=ysize;
+  frm->x=x-4; frm->y=y; frm->xsize=xsize+4; frm->ysize=ysize;
   frm->draw(S,0);
-  
-  screenmanager.Update(col(x-4),row(y-1),col(x+xsize+1),row(y+ysize+1));
+
+  screenmanager.Update(col(x-5),row(y-1),col(x+xsize+1),row(y+ysize+1));
 }
 
 

--- a/src/Sliders.cpp
+++ b/src/Sliders.cpp
@@ -14,6 +14,8 @@ ValueSlider::ValueSlider(int fset)
     ysize   = 1;
     newclick= 1;
     focus = fset;
+    from_input = 0;
+    input_value = 0;
 }
 
 
@@ -120,6 +122,8 @@ int ValueSlider::update() {
         if (!UIP_SliderInput->canceled) {
             changed++;
             value = c;
+            input_value = c;  // preserve raw before any clamping
+            from_input = 1;
         }
         if (window_stack.isempty())
             needaclear++; 
@@ -293,6 +297,11 @@ void ValueSliderOFF::draw(Drawable *S, int active) {
             sprintf(str,"%.2d",value);
         v = value;
     }
+    // One char of gap between the slider's right border and the
+    // numeric readout. ValueSlider::draw uses x+xsize and prefixes the
+    // sprintf format with a leading space (effective text col x+xsize+1);
+    // matching that here so ValueSliderOFF readouts (Patch, Bank) align
+    // with adjacent ValueSliderDL readouts (Default Length, etc.).
     printBG(col(x+xsize+1),row(cy),str,COLORS.Text,COLORS.Background,S);
     if (active)
         col = COLORS.Highlight;
@@ -305,7 +314,7 @@ void ValueSliderOFF::draw(Drawable *S, int active) {
         printchar(col(x-1),row(y),0x84,COLORS.Lowlight,S);
         printchar(col(x+xsize),row(y),0x83,COLORS.Highlight,S);
     }
-    screenmanager.Update(col(x-1),row(y-1),col(x+xsize+7),row(y+1));
+    screenmanager.Update(col(x-1),row(y-1),col(x+xsize+8),row(y+1));
     changed = 0;
 }
 
@@ -329,6 +338,8 @@ int ValueSliderDL::update() {
         if (!UIP_SliderInput->canceled) {
             changed++;
             value = c;
+            input_value = c;  // preserve raw before any clamping
+            from_input = 1;
         }
         needaclear++; need_refresh++;
     }

--- a/src/Sliders.h
+++ b/src/Sliders.h
@@ -14,6 +14,12 @@ class ValueSlider : public UserInterfaceElement {
         int clear;
         int newclick;
         int focus;  // new value here
+        int from_input;  // set when value was just set via numeric SliderInput popup;
+                         // callers can use this to disambiguate typed-value vs arrow-step
+                         // for sliders backed by an index table (e.g. TPB).
+        int input_value; // raw typed number from the popup, preserved BEFORE clamping
+                         // so callers can see the user's literal input even if it falls
+                         // outside [min,max]. Only valid when from_input == 1.
         explicit ValueSlider(int fset = 0);
         virtual ~ValueSlider() = default ;
         int mouseupdate(int cur_element);

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -612,6 +612,10 @@ int UserInterfaceElement::mouseupdate(int cur_element)
 //
 TextInput::TextInput(void) {
     cursor = 0;
+    str = NULL;
+    length = 0;
+    xsize = 0;
+    frame = 0;
 }
 
 
@@ -926,6 +930,12 @@ void TextInput::draw(Drawable *S, int active) {
 //
 CheckBox::CheckBox(void) {
     value = NULL;
+    // Default chip width: "Off" (3 chars) is the widest visible state.
+    xsize = 3;
+    // Frame is a no-op in CheckBox::draw (the border rendered as a yellow
+    // stripe and added no info) — default to 0 so callers don't need to
+    // reset it from the inherited default of 1.
+    frame = 0;
 }
 
 
@@ -1014,31 +1024,52 @@ int CheckBox::update() {
 //
 //
 void CheckBox::draw(Drawable *S, int active) {
+    // Hidden placeholder: callers can hide a checkbox (without renumbering
+    // get_element() indices elsewhere) by setting xsize=0. Honour that.
+    if (xsize <= 0) {
+        changed = 0;
+        return;
+    }
     int cx,cy=y;
     TColor f,b;
     const char *str;
-    for(cx=x;cx<x+xsize;cx++) {
-        printBG(col(cx),row(cy)," ",COLORS.Text,COLORS.EditBG,S);
-    }
     if (*value)
         str = "On";
     else
         str = "Off";
+    // Visible chip width derives from the string length so the dark
+    // background is exactly as wide as the text (no trailing padding).
+    // Both "Off" and "On " are 3 chars, so it's a single source of
+    // truth: change the strings and every checkbox in the app follows.
+    const int chip_w = (int)strlen(str);
+    // Visible chip is always chip_w cells wide ("Off"=3, "On"=2). Wipe
+    // up to "Off" width so an Off->On transition clears the stale "f"
+    // cell. Caller-supplied xsize is for the click area only — never
+    // expand the painted region beyond chip_w, since the wipe color may
+    // not match every page's background and would render as a bleed.
+    const int wipe_end = 3;
+    if (wipe_end > chip_w) {
+        for (cx = x + chip_w; cx < x + wipe_end; cx++) {
+            printBG(col(cx),row(cy)," ",COLORS.Text,COLORS.Background,S);
+        }
+    }
+    for(cx=x;cx<x+chip_w;cx++) {
+        printBG(col(cx),row(cy)," ",COLORS.Text,COLORS.EditBG,S);
+    }
     if (active) {
         f = COLORS.EditBG;
-        b = COLORS.Highlight; 
+        b = COLORS.Highlight;
     } else {
         f = COLORS.EditText;
         b = COLORS.EditBG;
     }
     printBG(col(x),col(y),str,f,b,S);
-    if (frame) {
-        printline(col(x),row(y-1),0x86,xsize,COLORS.Lowlight,S);
-        printline(col(x),row(y+1),0x81,xsize,COLORS.Highlight,S);
-        printchar(col(x-1),row(y),0x84,COLORS.Lowlight,S);
-        printchar(col(x+xsize),row(y),0x83,COLORS.Highlight,S);
-    }
-    screenmanager.Update(col(x-1),row(y-1),col(x+xsize+1),row(y+1));
+    // Frame border is intentionally never drawn around checkboxes — the
+    // border chars rendered as a yellow stripe next to the chip and added
+    // no information on top of the dark chip background. Callers may still
+    // set frame=1, but the flag is a no-op here.
+    int dirty_w = (xsize > chip_w) ? xsize : chip_w;
+    screenmanager.Update(col(x-1),row(y-1),col(x+dirty_w+1),row(y+1));
     changed = 0;
 }
 
@@ -1682,6 +1713,11 @@ TextBox::TextBox()
   bEof = false;
   bUseColors = 1;
   bWordWrap = false;
+}
+
+int TextBox::full_width_xsize()
+{
+    return 78 + ((INTERNAL_RESOLUTION_X - 640) / 8);
 }
 
 

--- a/src/UserInterface.h
+++ b/src/UserInterface.h
@@ -235,6 +235,11 @@ class TextBox : public UserInterfaceElement {
         int update();
         void draw(Drawable *S, int active);
         int mouseupdate(int cur_element);
+
+        // Responsive full-width helper: 78 cols at 640px-wide windows,
+        // grows by 1 col per 8px of extra resolution. Centralized so
+        // callers don't copy-paste the formula.
+        static int full_width_xsize();
 };
 
 class CommentEditor : public TextBox {

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -252,7 +252,7 @@ ZTConf::ZTConf() {
     control_navigation_amount = 2;
     default_directory[0] = '\0';
     record_velocity = 1;
-    post_load_page = POST_LOAD_INST_EDIT;
+    post_load_page = POST_LOAD_PATTERN_EDIT;
 }
 
 ZTConf::~ZTConf() {
@@ -302,7 +302,7 @@ int ZTConf::load()
   if(Config->get("post_load_page")) {
       post_load_page = atoi(Config->get("post_load_page"));
       if (post_load_page < 0 || post_load_page >= POST_LOAD_PAGE_COUNT)
-          post_load_page = POST_LOAD_INST_EDIT;
+          post_load_page = POST_LOAD_PATTERN_EDIT;
   }
   
   ////////////////////////////////////////////////

--- a/src/conf.h
+++ b/src/conf.h
@@ -15,8 +15,14 @@ enum E_edit_viewmode { VIEW_SQUISH, VIEW_REGULAR, VIEW_FX, VIEW_BIG }; //, VIEW_
 // Editor (F3) — matches the long-standing behaviour. Pattern Editor
 // (F2) suits arrangers who go straight to writing notes; Song Config
 // (F11) suits people who want to verify BPM/TPB/order list first.
-enum E_post_load_page { POST_LOAD_INST_EDIT = 0, POST_LOAD_PATTERN_EDIT, POST_LOAD_SONG_CONFIG };
-#define POST_LOAD_PAGE_COUNT 3
+enum E_post_load_page {
+    POST_LOAD_PATTERN_EDIT = 0,
+    POST_LOAD_INST_EDIT,
+    POST_LOAD_PLAYSONG,        // F5 (Playsong page)
+    POST_LOAD_SONG_CONFIG,     // F11 (Order list / Song config)
+    POST_LOAD_SONG_MESSAGE     // F10 (Song message editor)
+};
+#define POST_LOAD_PAGE_COUNT 5
 
 
 //  New class ZTConf puts all global variables in one place

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -446,8 +446,13 @@ void switch_page(CUI_Page *page)
     if (ActivePage->UI)
         ActivePage->UI->full_refresh();
     // Clear any stale status message from the previous page so it
-    // doesn't bleed onto the newly activated page.
-    statusmsg = (char*)" ";
+    // doesn't bleed onto the newly activated page — but only when
+    // we're stopped. While playing, the playhead status line should
+    // carry through page changes; otherwise it briefly blanks and
+    // flashes back in on every F1/F2/F3/etc switch.
+    if (!ztPlayer || !ztPlayer->playing) {
+        statusmsg = (char*)" ";
+    }
 
 
   // <Manu> TO-DO Check if still needed, but not problematic if not
@@ -900,9 +905,20 @@ char *hex2note(char *str,unsigned char note)
 //
 void status(const char *msg,Drawable *S)
 {
-    printBG(col(3),row(INITIAL_ROW + 6),"                                                                            ",COLORS.Text,COLORS.Background,S);
+    // Wipe the full status row up to the right screen edge before
+    // drawing the new message. Hardcoded 76-space string left a stale
+    // strip at the right when a long Playing/Looping line shrank to
+    // "Stopped" on a window wider than 640px.
+    const int max_cols = INTERNAL_RESOLUTION_X / FONT_SIZE_X;
+    char wipe[256];
+    int n = max_cols - 3;
+    if (n < 0) n = 0;
+    if (n > (int)sizeof(wipe) - 1) n = sizeof(wipe) - 1;
+    memset(wipe, ' ', n);
+    wipe[n] = '\0';
+    printBG(col(3),row(INITIAL_ROW + 6),wipe,COLORS.Text,COLORS.Background,S);
     printBGCC(col(3),row(INITIAL_ROW + 6),msg,COLORS.Text,COLORS.Background,S);
-    screenmanager.Update(col(3),row(INITIAL_ROW + 6),col(80)-1,row(10));
+    screenmanager.Update(col(3),row(INITIAL_ROW + 6),col(max_cols)-1,row(10));
 }
 
 
@@ -928,25 +944,32 @@ void update_status(Drawable *S)
   int i,o=0;
   char str[10];
 
-  // Refresh the playing/looping status line on the pages where it makes
-  // sense (Pattern Editor + Play Song). Other pages (Help, Instrument
-  // Editor, Sys Config…) keep the status bar quiet so the playback line
-  // doesn't bleed over their own UI.
-  if (ztPlayer->playing && (cur_state == STATE_PEDIT || cur_state == STATE_PLAY)) {
+  // Refresh the playing/looping status line on every page so the user
+  // can always see where playback is, regardless of which view they're
+  // currently editing in.
+  if (ztPlayer->playing) {
+
+    char time[128],time2[64];
+    // Elapsed time: wall-clock since play() started. This is immune to
+    // row-quantization (calcSongMs jumps by tpb*bpm row chunks, which
+    // skips intermediate tenths — at BPM=120 TPB=4 the .4 tenth never
+    // shows because rows hit 0.375 and 0.500 with no value in between).
+    int ms = (int)((uint64_t)SDL_GetTicks() - ztPlayer->playback_start_ms);
+    int sec = ms / 1000;
+    int tenth = (ms % 1000) / 100;
+    sprintf(time2, "|H|%.2d|U|:|H|%.2d|U|.|H|%d|U|", sec/60, sec%60, tenth);
+    // Total time: still derived from song length (independent of playhead).
+    ms = calcSongMs();
+    sec = ms / 1000;
+    tenth = (ms % 1000) / 100;
+    sprintf(time, "%s/|H|%.2d|U|:|H|%.2d|U|.|H|%d|U|", time2, sec/60, sec%60, tenth);
 
     if (ztPlayer->playmode) {
-
-      char time[128],time2[64];
-      int sec;
-      sec = calcSongSeconds(ztPlayer->playing_cur_row, ztPlayer->playing_cur_order);
-      sprintf(time2, "|H|%.2d|U|:|H|%.2d|U|",sec/60,sec%60);
-      sec = calcSongSeconds();
-      sprintf(time, "%s/|H|%.2d|U|:|H|%.2d|U|",time2,sec/60,sec%60);
-      sprintf(szStatmsg,"Playing, Ord: |H|%.3d|U|/|H|%.3d|U|, Pat: |H|%.3d|U|/|H|255|U|, Row: |H|%.3d|U|/|H|%.3d|U|, Time: %s  ",ztPlayer->playing_cur_order,ztPlayer->num_real_orders,ztPlayer->playing_cur_pattern,ztPlayer->playing_cur_row,song->patterns[ztPlayer->playing_cur_pattern]->length,time);
+      sprintf(szStatmsg,"Playing, Ord: |H|%.3d|U|/|H|%.3d|U|, Pat: |H|%.3d|U|/|H|255|U|, Row: |H|%.3d|U|/|H|%.3d|U|, Time: %s, BPM: |H|%d|U|, TPB: |H|%d|U|, Step: |H|%d|U|  ",ztPlayer->playing_cur_order,ztPlayer->num_real_orders,ztPlayer->playing_cur_pattern,ztPlayer->playing_cur_row,song->patterns[ztPlayer->playing_cur_pattern]->length,time,song->bpm,song->tpb,cur_step);
     }
     else {
 
-      sprintf(szStatmsg,"Looping, Pattern: |H|%.3d|U|/|H|255|U|, Row: |H|%.3d|U|/|H|%.3d|U|  ",ztPlayer->playing_cur_pattern,ztPlayer->playing_cur_row,song->patterns[ztPlayer->playing_cur_pattern]->length);
+      sprintf(szStatmsg,"Looping, Pattern: |H|%.3d|U|/|H|255|U|, Row: |H|%.3d|U|/|H|%.3d|U|, Time: %s, BPM: |H|%d|U|, TPB: |H|%d|U|, Step: |H|%d|U|  ",ztPlayer->playing_cur_pattern,ztPlayer->playing_cur_row,song->patterns[ztPlayer->playing_cur_pattern]->length,time,song->bpm,song->tpb,cur_step);
     }
 
     statusmsg = szStatmsg;
@@ -958,10 +981,6 @@ void update_status(Drawable *S)
       cur_edit_row     = ztPlayer->playing_cur_row;
       need_refresh++;
     }
-  }
-  else if (ztPlayer->playing && cur_state != STATE_PEDIT && cur_state != STATE_PLAY) {
-    // Keep statusmsg quiet on Help/InstEdit/SysConfig/etc while playing.
-    statusmsg = (char*)" ";
   }
 
   if (S->lock() == 0) {

--- a/src/playback.cpp
+++ b/src/playback.cpp
@@ -249,6 +249,7 @@ player::player(int res,int prebuffer_rows, zt_module *ztm) {
     this->wTimerRes = res;
     this->fillbuff = this->playing = this->counter = this->wTimerID = 0;
     this->ztTimerID = 0;
+    this->playback_start_ms = 0;
 //  this->hr_timer = new hires_timer;
     this->playing_cur_row = 1;
     init();
@@ -641,8 +642,9 @@ void player::play(int row, int pattern,int pm, int loopmode)
   playing_buffer = play_buffer[cur_buf];
 
   playing = 1;
+  playback_start_ms = SDL_GetTicks();
   zt_set_window_title("zt - [playing]");
-}   
+}
 
 
 

--- a/src/playback.h
+++ b/src/playback.h
@@ -149,6 +149,11 @@ class player {
         int light_counter;
         int skip;
         int loop_mode;
+        // Wall-clock timestamp (SDL_GetTicks ms) when play() was invoked.
+        // Used by the status display to show real elapsed time, immune
+        // to row-quantization artifacts (.4s skip) that happen when
+        // calcSongMs jumps in tpb*bpm-row chunks.
+        uint64_t playback_start_ms;
 
         zt_module *song;
         pattern patt_memory;

--- a/src/zt.h
+++ b/src/zt.h
@@ -791,5 +791,6 @@ extern int pe_modification;
 extern Drawable * pe_buf;
 
 extern int calcSongSeconds(int cur_row = -1, int cur_ord = -1);
+extern int calcSongMs(int cur_row = -1, int cur_ord = -1);
 
 #endif


### PR DESCRIPTION
A focused tour of the three configuration pages — F11, F12, Ctrl+F12 —
plus a few widget-class fixes upstream that resolve a long tail of
visual bugs. Companion fixes for the status-line elapsed-time
display, save screen, F3 Inst editor frame, and a couple of CI /
build hygiene items.

> **Split out into separate PRs:**
> - macOS crash fixes → #62 (multi-MIDI-In use-after-free,
>   MIDI-thread NSWindow crash, Cmd+Q popup wedge)
> - Mouse/keyboard UX → #63 (OrderEditor click, F12 MIDI Enter/Space
>   toggle, build-mac.sh --run log surfacing)
>
> This PR is now strictly layout polish + widget upstream cleanup.

## Widget class cleanup (`src/UserInterface.{h,cpp}`, `src/Sliders.{h,cpp}`)

- **CheckBox**: removed the frame border outright. Every audit ended
  with the caller setting `frame=0`, and the border characters
  rendered as a yellow stripe next to the chip — adding no
  information. `CheckBox::draw` no longer paints the frame regardless
  of the flag, and the constructor defaults `frame=0`. Visible chip
  width capped at 3 (`Off` width) so legacy `xsize=5` callers don't
  bleed.
- **TextInput**: constructor initializes `str=NULL, length=0,
  xsize=0, frame=0` (was: only `cursor=0`). New TextInput callers no
  longer read garbage memory if they forget a field.
- **TextBox::full_width_xsize()**: new static helper returning
  `78 + ((INTERNAL_RESOLUTION_X - 640) / 8)`. Replaces 4 copy-paste
  sites in `CUI_Help.cpp` and `CUI_SongMessage.cpp`.
- **ValueSlider**: added `input_value` (raw typed number from the
  SliderInput popup, preserved before clamping) and `from_input`
  flag, so callers backed by a non-linear index table (TPB) can
  disambiguate typed-value vs arrow-step.

## Song Configuration (F11)

- Layout shifted +3 cols right (Order List exempt). All controls now
  at `x=20` with labels right-aligned ending col 18.
- Element IDs renumbered contiguously **0..9** (was 0..10 with a gap
  at 5) so `UP`/`DOWN` cycling no longer lands on a phantom slot.
- Labels renamed: `Row hl minor/major` → **Row Highlight / Row
  Lowlight**.
- **MIDI In Sync + Chase MIDI Tempo** moved here from F12/Ctrl+F12
  (they were duplicated). Frame removed.
- Send MIDI Clock + MIDI Stop/Start frame removed; xsize tightened.
- F11 entry: focuses OrderEditor on a fresh entry. Pressing F11
  while already on F11 now **ping-pongs** focus between OrderEditor
  and Title TextInput on every press (was: the third press was a
  no-op because LastPage stayed Songconfig and target was always
  Title). OrderEditor cursor is reset on fresh entry but preserved
  during the toggle.
- **TPB typed input**: pressing `4` used to set TPB=12 because the
  slider value is an INDEX into `tpb_tab[]={2,4,6,8,12,16,24,32,48}`,
  not the actual TPB. Songconfig now snaps typed input to the
  nearest valid TPB. Multi-digit `12`/`16`/`32`/`48` hit exact
  matches. Arrow keys still walk indices unchanged.

## System Configuration (F12)

- Left-column controls moved `x=19 → 20` so they align with Global
  Config. MIDI Out sub-controls (Latency / Bank / Alias) shifted in
  lockstep.
- `Go to page 2` button `x=2 → 4` so it starts at the same column as
  the `MIDI Out Device Selection` label below it.
- Panic on stop / Auto-open MIDI / Full Screen now sit on adjacent
  rows (was 2-row gaps), matching F11's tight checkbox-stack style.
- Skin Selection list `xsize 19+4 → 19+8` so its right edge ends at
  col 76, matching the MIDI device list right edge.
- **Record Velocity** moved here from Ctrl+F12.
- **MIDI In and MIDI Out columns SWAPPED**. MIDI In on the left,
  MIDI Out on the right — reading order matches signal flow.
  Latency/Bank/Alias controls follow MIDI Out to the right side.
  Alias TextInput xsize is responsive to screen width.
- **Full Screen** Space-toggle no longer double-toggles
  (`attempt_fullscreen_toggle` was being called twice on the same
  flag flip).

## Global Configuration (Ctrl+F12)

- Element IDs collapsed from 0..12 with gaps to a contiguous **0..7**.
- `Current Settings in memory` textbox: `y=28 → 26`, `x=1 → 4`,
  `xsize=78 → 72` so its right edge aligns with the F12 MIDI-list
  right edge at col 76 (was overshooting to col 79).
- `Go to page 1` button `x=2 → 4` so the button doesn't jump on page
  switch from F12.
- Default Dir TextInput `xsize=50 → 52` so its right edge matches the
  Autoload File textfield.
- **Default Dir Enter** (macOS): opens a native folder picker via
  `osascript`. The `popen` call is guarded behind `#ifdef __APPLE__`
  since `popen`/`pclose` are POSIX-only — without the guard the
  Windows MSVC CI build was failing with `C3861 identifier not
  found`.
- **Autoload File Enter** (macOS): opens a native file picker
  (mirrors the Default Dir flow). Lambda factored so both pickers
  share the same Enter-flush (so the Enter pressed inside the modal
  dialog doesn't bounce back and re-open the picker).
- **Default Pat Len** moved up one row (`y=22 → 21`) so the Post-Load
  Page slider on row 23 has a clear row above it and stops getting
  clipped.
- **Post-Load Page** enum reordered + extended to 5 entries with
  full descriptive names matching the keybinds: `Pattern Editor
  (F2)`, `Instrument Editor (F3)`, `Play Song (F5)`, `Song
  Configuration (F11)`, `Song Message (F10)`. Default flipped to
  Pattern Edit (was Inst Editor). Inline format width bumped 12 →
  25 chars. Existing `zt.conf` integers will silently re-map.
- Removed: Row Highlight, Row Lowlight (already in F11), Record
  Velocity (moved to F12).

## About zTracker (Alt+F12)

- Textbox shrunk by 5 rows so it ends well above the toolbar
  reserve. The previous height formula was a chain of accumulated
  +N deltas; tightened toward the actual screen layout.

## Status line / playback time

- Elapsed-time field now uses `SDL_GetTicks - playback_start_ms`
  (real wall-clock) instead of `calcSongMs(playing_cur_row, ...)`.
  The old approach computed time from the playhead position which
  jumps in row-sized increments — at BPM=120 TPB=4 each row is 125ms
  so the tenths went 0.0, 0.1, 0.2, 0.3, **0.5** with no value at
  0.4. Wall-clock ticks smoothly every 100ms.
- Status row wipe extended to full screen width. The Playing/Looping
  line contains BPM/TPB/Step at column 78+ on wider screens; the old
  hardcoded 76-space wipe left a stale strip when status dropped to
  `Stopped`.

## Inst Editor (F3)

- Frame extended to cover the instrument-number / used-mark column
  on the left.

## Save screen

- Save-as button stack tightened: TextInput → first button gap and
  between-button gap both reduced from 2 → 1 row. Stack no longer
  extends below the right-hand file list.

## ValueSliderOFF

- Numeric readout shifted 1 col left to align with ValueSlider
  readouts on the same column (Patch `127` was sitting one cell
  right of Default Length `024` below it).

## Test plan

- [ ] F11: cursor up/down cycles cleanly through Title → BPM → TPB →
      Send MIDI Clock → MIDI Stop/Start → Row Highlight → Row
      Lowlight → MIDI In Sync → Chase MIDI Tempo → OrderEditor and
      back. No phantom stops, no focus disappears.
- [ ] F11 ping-pong: from any other page, F11 lands on OrderEditor.
      Subsequent F11 presses alternate OrderEditor ↔ Title forever
      (no third-press dead-end).
- [ ] F11 TPB: pressing `4` sets TPB=4, `8` sets TPB=8, `9` sets
      TPB=8 (closest); typing `12`/`16` works. Arrow keys still walk
      `2,4,6,8,12,16,24,32,48`.
- [ ] F12: Go-to-page-2 button starts at col 4 (under MIDI Out
      header). Switching to Ctrl+F12: button stays at col 4. No
      visual jump.
- [ ] F12: MIDI In list on the left, MIDI Out list on the right.
      Latency/Bank/Alias appear under MIDI Out.
- [ ] F12 Full Screen: pressing Space once goes fullscreen and
      stays there (used to bounce back).
- [ ] Ctrl+F12: Default Pat Len has a clear row above Post-Load
      Page; Post-Load Page slider is no longer clipped.
- [ ] Ctrl+F12: Post-Load Page reads "Pattern Editor (F2)",
      "Instrument Editor (F3)", "Play Song (F5)", "Song
      Configuration (F11)", "Song Message (F10)" both in the slider
      label and the Current Settings textbox.
- [ ] Ctrl+F12: Enter on Default Dir opens macOS folder picker;
      Enter on Autoload File opens file picker. Confirming with
      Enter inside the dialog does not re-open the picker.
- [ ] Alt+F12 About: textbox bottom sits well above the toolbar
      buttons (no overlap).
- [ ] Status line: while playing at BPM=120 TPB=4, the tenths digit
      counts 0..9 smoothly (no skipped 0.4).
- [ ] Press Stop while a long Playing/Looping line is showing —
      the BPM/TPB/Step text on the right does not stay behind.
- [ ] Linux/macOS/Win-x86 MinGW/Win-x64 MSVC builds all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
