### PR TITLE
macOS crash fixes: MIDI-thread NSWindow + multi-MIDI-In + Cmd+Q wedge

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,6 +114,8 @@ CScreenUpdateManager screenmanager;
 Skin *CurrentSkin = NULL;
 
 SDL_Window *zt_main_window = NULL;
+char zt_pending_window_title[256] = "";
+volatile int zt_pending_window_title_dirty = 0;
 bool zt_text_input_is_active = false;
 static SDL_Renderer *zt_renderer = NULL;
 static SDL_Texture *zt_frame_texture = NULL;
@@ -3609,7 +3611,12 @@ int main(int argc, char *argv[])
             break;
 
           case SDL_EVENT_QUIT:
-            quit();
+            // macOS Cmd+Q / Dock "Quit" / system shutdown: honour the
+            // OS-level quit request immediately. Going through quit()
+            // pushed a RUSure popup that the OS-driven event loop
+            // never delivered keystrokes to (and repeated SDL_EVENT_QUIT
+            // events stacked further popups), wedging the app.
+            doquit();
             break;
 
           default:
@@ -3623,6 +3630,8 @@ int main(int argc, char *argv[])
       if (action(screen_buffer)) {
         break;
       }
+
+      zt_apply_pending_window_title();
 
       static int next_frame_redraw_all = 0;
       if(next_frame_redraw_all) {

--- a/src/midi-io.cpp
+++ b/src/midi-io.cpp
@@ -589,19 +589,10 @@ midiIn::~midiIn() {
 }
 
 UINT midiIn::AddDevice(int dev) {
-    intlist *t;
-    UINT error;
-    error = midiInDev[dev]->open();
+    UINT error = midiInDev[dev]->open();
     if (error != MMSYSERR_NOERROR)
         return error;
-    t = devlist_head;
-
-    if(devlist_head != NULL) {
-      
-      delete(devlist_head) ;
-    }
-
-    devlist_head = new intlist(dev,t);
+    devlist_head = new intlist(dev, devlist_head);
     return 0;
 }
 

--- a/src/zt.h
+++ b/src/zt.h
@@ -53,8 +53,28 @@ struct SDL_Window;
 extern SDL_Window *zt_main_window;
 extern bool zt_text_input_is_active;
 
+// Queued window title — written by anyone (including non-main threads
+// such as the CoreMIDI input callback), applied by the main loop on
+// the main thread. Touching SDL_SetWindowTitle from a worker thread
+// crashes on macOS because AppKit's NSWindow setTitle: is main-thread-
+// only.
+extern char zt_pending_window_title[256];
+extern volatile int zt_pending_window_title_dirty;
+
 static inline void zt_set_window_title(const char *title) {
-    if (zt_main_window) SDL_SetWindowTitle(zt_main_window, title);
+    if (!title) return;
+    size_t i = 0;
+    for (; i + 1 < sizeof(zt_pending_window_title) && title[i]; ++i) {
+        zt_pending_window_title[i] = title[i];
+    }
+    zt_pending_window_title[i] = '\0';
+    zt_pending_window_title_dirty = 1;
+}
+
+static inline void zt_apply_pending_window_title(void) {
+    if (!zt_pending_window_title_dirty) return;
+    zt_pending_window_title_dirty = 0;
+    if (zt_main_window) SDL_SetWindowTitle(zt_main_window, zt_pending_window_title);
 }
 
 static inline void zt_destroy_surface(SDL_Surface *surface) {


### PR DESCRIPTION
Two independent macOS crash fixes, lifted out of #61 so they can land
without waiting for the larger layout-polish review.

## 1. MIDI thread → NSWindow crash on Play with MIDI Sync + Chase Tempo

Stack trace from the field (Play with MIDI In Sync + Chase MIDI Tempo
enabled, external clock source connected):

```
NSInternalInconsistencyException: NSWindow geometry should
only be modified on the main thread!
...
SDL_SetWindowTitle
zt_coremidi_read_proc + 500
MIDIInPortThread::Run
```

Path: external sequencer sends MIDI Start (`0xFA`) → CoreMIDI
delivery thread runs `midiInCallback` → `ztPlayer->play()` →
`zt_set_window_title("zt - [playing]")` → `SDL_SetWindowTitle` →
AppKit `NSWindow setTitle:` on a worker thread → hard crash.

`zt_set_window_title` is now thread-safe: it copies the desired
title into a shared buffer + sets a dirty flag, and the main loop
calls `zt_apply_pending_window_title()` each tick, which is the
only place that touches `SDL_SetWindowTitle`. Safe to call from
any thread (CoreMIDI input, timer callback, counter_thread, etc.).

## 2. MIDI In: multi-device crash (use-after-free)

`midiIn::AddDevice` had a use-after-free that crashed the app the
second time any MIDI In was opened. The first AddDevice was safe
(list head was NULL); the second one freed the previous head and
linked the new node into that freed memory. So any user trying to
listen on more than one MIDI In source (e.g. IAC Bus 1 + a hardware
controller) hit a silent crash with no fanfare.

```cpp
// Before — use-after-free:
t = devlist_head;
if (devlist_head) delete devlist_head;
devlist_head = new intlist(dev, t);   // t is dangling

// After — plain prepend:
devlist_head = new intlist(dev, devlist_head);
```

The rest of the list infrastructure (`RemDevice`, `GetDevice`,
`GetNumOpenDevs`, `GetDevID`, destructor, callback dispatch) already
walked the linked list correctly — only AddDevice was broken.
Multiple simultaneous MIDI Ins now work as originally intended.

## 3. Cmd+Q "Sure to quit?" popup wedge

On macOS, Cmd+Q / Dock "Quit" / system shutdown post
`SDL_EVENT_QUIT`. We were routing that into `quit()` which pushed a
RUSure modal popup — but the OS-driven shutdown loop never
delivered keystrokes to the popup, and repeated `SDL_EVENT_QUIT`
events stacked further popups, wedging the app. Now
`SDL_EVENT_QUIT` calls `doquit()` directly so OS-level quit
requests exit cleanly. The "Sure to quit?" prompt still fires from
in-app exit paths (menu / exit button) where keyboard input is
live.

## Test plan

- [ ] Open IAC Bus 1 as MIDI In, then open a second MIDI In source
      (TouchOSC, hardware controller). App stays alive and both
      devices receive.
- [ ] Enable MIDI In Sync + Chase MIDI Tempo, connect an external
      clock source, press Play. zTracker stays alive — no NSWindow
      main-thread assertion in the log.
- [ ] Cmd+Q (or Dock → Quit, or shutdown the machine while
      zTracker is running) exits cleanly without stacking "Sure to
      quit?" popups.
- [ ] Win-x86 MinGW / Win-x64 MSVC / Linux / macOS arm64+x86_64
      builds all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
