### PR TITLE
Mouse / keyboard UX: order-list click, F12 MIDI Enter/Space, run-log

### DIFF
--- a/build-mac.sh
+++ b/build-mac.sh
@@ -112,10 +112,13 @@ fi
 echo "Built: $app_path"
 
 if ((run_after_build)); then
+  log_file="${ZT_RUN_LOG:-/tmp/zt-run.log}"
+  : > "$log_file"
+  echo "Logging stdout/stderr to: $log_file"
   if ((${#app_args[@]})); then
-    "$binary_path" "${app_args[@]}" >/dev/null 2>&1 &
+    "$binary_path" "${app_args[@]}" 2>&1 | tee "$log_file" &
   else
-    "$binary_path" >/dev/null 2>&1 &
+    "$binary_path" 2>&1 | tee "$log_file" &
   fi
   echo "Launched: $binary_path"
 fi

--- a/src/OrderEditor.cpp
+++ b/src/OrderEditor.cpp
@@ -32,11 +32,40 @@ int OrderEditor::mouseupdate(int cur_element) {
             need_refresh++;
             old_playing_ord = ztPlayer->playing_cur_order;
         }
-    } 
+    }
     else if (old_playing_ord != -1 && !ztPlayer->playing) {
         old_playing_ord = -1;
         need_redraw++;
         need_refresh++;
+    }
+
+    KBKey key = Keys.checkkey();
+    if (key == ((unsigned int)((SDL_EVENT_MOUSE_BUTTON_DOWN << 8) | SDL_BUTTON_LEFT))) {
+        // Indices column at col(x..x+3); value column with frame at
+        // col(x+4..x+7). Accept clicks anywhere in the widget bounds
+        // (col(x)..col(x+xsize)).
+        if (checkclick(col(this->x), row(this->y),
+                       col(this->x + this->xsize), row(this->y + this->ysize))) {
+            int clicked_row = (MousePressY / 8) - this->y;
+            if (clicked_row < 0) clicked_row = 0;
+            if (clicked_row >= ysize) clicked_row = ysize - 1;
+            int new_order = clicked_row + list_start;
+            if (new_order < 0) new_order = 0;
+            if (new_order >= ZTM_ORDERLIST_LEN) new_order = ZTM_ORDERLIST_LEN - 1;
+            cursor_y = clicked_row;
+            // If click landed in the value column, snap cursor_x to the
+            // digit column under the mouse; otherwise leave it alone.
+            int clicked_col = (MousePressX / 8) - this->x;
+            if (clicked_col >= 4 && clicked_col <= 6) {
+                cursor_x = clicked_col - 4;
+            }
+            cur_edit_order = new_order;
+            cur_edit_pattern = song->orderlist[new_order];
+            Keys.getkey();
+            need_redraw++;
+            need_refresh++;
+            return this->ID;   // request focus
+        }
     }
     return cur_element;
 }

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -2907,6 +2907,11 @@ void MidiOutDeviceOpener::OnChange() {
 //
 //
 void MidiOutDeviceOpener::OnSelect(LBNode *selected) {
+    if (selected && selected->int_data >= 0) {
+        midi_out_sel(selected->int_data);
+        OnChange();
+        need_redraw++;
+    }
     ListBox::OnSelect(selected);
 }
 
@@ -2937,8 +2942,13 @@ int MidiOutDeviceOpener::update() {
     b->sync();
     AliasTextInput *t = (AliasTextInput *)al;
     t->sync();
+    if (Keys.checkkey() == SDLK_SPACE) {
+        Keys.getkey();
+        OnSelect(getNode(cur_sel + y_start));
+        need_refresh++; need_redraw++;
+        return 0;
+    }
     return ListBox::update();
-    //return ret;
 }
 
 
@@ -3025,7 +3035,22 @@ void MidiInDeviceOpener::OnChange() {
 //
 //
 void MidiInDeviceOpener::OnSelect(LBNode *selected) {
+    if (selected && selected->int_data >= 0) {
+        midi_in_sel(selected->int_data);
+        OnChange();
+        need_redraw++;
+    }
     ListBox::OnSelect(selected);
+}
+
+int MidiInDeviceOpener::update() {
+    if (Keys.checkkey() == SDLK_SPACE) {
+        Keys.getkey();
+        OnSelect(getNode(cur_sel + y_start));
+        need_refresh++; need_redraw++;
+        return 0;
+    }
+    return ListBox::update();
 }
 
 

--- a/src/UserInterface.h
+++ b/src/UserInterface.h
@@ -379,7 +379,7 @@ class MidiInDeviceOpener : public ListBox {
         MidiInDeviceOpener ();
         ~MidiInDeviceOpener () = default ;
 
-//        virtual int update();
+        virtual int update();
 //        virtual void draw(Drawable *S, int active);
 
         virtual int mouseupdate(int cur_element);


### PR DESCRIPTION
Two unrelated UX fixes lifted out of #61 so they can land
independently of the larger layout-polish review.

## 1. F12 MIDI device list: Enter / Space toggle the highlighted device

Previously `MidiInDeviceOpener::OnSelect` and
`MidiOutDeviceOpener::OnSelect` were empty stubs — Enter on a MIDI
device list did nothing, and Space did nothing either, so the only
way to open or close a device was to Tab to the "Open device"
button below the list and click it.

Now both lists override `OnSelect` to call `midi_in_sel` /
`midi_out_sel` (mirroring the button's logic) and refresh the list
afterwards. `MidiInDeviceOpener` gains an `update()` override and
`MidiOutDeviceOpener::update()` extends the existing one to
intercept `SDLK_SPACE` before falling through to
`ListBox::update()` so Space also toggles. Enter and Space toggle
the highlighted row on both lists.

## 2. F11 Order List: left-click moves the cursor to the clicked row

`OrderEditor::mouseupdate` previously only refreshed the playhead
indicator and ignored mouse coordinates entirely — clicking
anywhere on the order list did nothing. The cursor only moved via
UP/DOWN.

Now a left-click inside the widget bounds:
- Moves `cursor_y` to the clicked row.
- Updates `cur_edit_order` and `cur_edit_pattern` to follow.
- Snaps `cursor_x` to the digit under the mouse if the click landed
  in the value column (cols `x+4..x+6`), so the user can
  immediately overwrite that digit.
- Returns `this->ID` so keyboard focus follows the click into the
  OrderEditor.

## 3. build-mac.sh --run: surface stdout/stderr to a log file

`./build-mac.sh --run` previously routed both streams to
`/dev/null`, so any crash during a session vanished. It now
streams them through `tee` to `/tmp/zt-run.log` (override with
`ZT_RUN_LOG=/path`). Crashes leave a readable trail without
needing to dig into `~/Library/Logs/DiagnosticReports/`.

## Test plan

- [ ] F12: highlight a MIDI In device, press Enter — device opens.
      Press Enter again — it closes. Same for Space.
- [ ] F12: same flow on the MIDI Out list.
- [ ] F11: click on an order row. Cursor jumps to that row,
      `cur_edit_order` and `cur_edit_pattern` follow. Click on a
      digit in the value column — `cursor_x` lands on that digit.
- [ ] `./build-mac.sh --run` writes the app's stdout/stderr to
      `/tmp/zt-run.log`.
- [ ] Win-x86 MinGW / Win-x64 MSVC / Linux / macOS arm64+x86_64
      builds all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
