### PR TITLE
Add CLAUDE.md — contributor notes for AI assistants

### DIFF
--- a/.claude/skills/ztrackerprime/SKILL.md
+++ b/.claude/skills/ztrackerprime/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ztrackerprime
-description: zTracker Prime (m6502/ztrackerprime) contributor skill — picks up context for zTracker development, PR management, and collaboration with maintainer Manuel Montoto (@m6502).
+description: zTracker Prime (m6502/ztrackerprime) contributor skill — context for zTracker development, conventions, recurring foot-guns, and PR workflow.
 domain: repository-specific
 source_repo: https://github.com/m6502/ztrackerprime
 source_platform: github
@@ -8,7 +8,7 @@ tags: [cpp, sdl3, tracker, midi, cross-platform]
 triggers:
   keywords:
     primary: [ztracker, ztrackerprime, zt, zTracker]
-    secondary: [m6502, manuel montoto, tracker, MIDI tracker, impulse tracker, paketti, SDL3 tracker]
+    secondary: [m6502, tracker, MIDI tracker, impulse tracker, SDL3 tracker]
 ---
 
 # zTracker Prime Development Skill
@@ -17,45 +17,44 @@ triggers:
 
 **zTracker Prime** (m6502/ztrackerprime) is Manuel Montoto's maintained fork of zTracker — an Impulse-Tracker-inspired MIDI tracker originally by Christopher Micali (2000–2001) with contributions from Daniel Kahlin. Manuel brought it to SDL 3 and cross-platform (Windows XP through 11, macOS, Linux).
 
-**Primary working directory:** `/Users/esaruoho/work/ztrackerprime` (main worktree — don't commit experiments here).
-
-Active feature branches live in the main worktree (no separate working dirs as of 2026-04-29). `git worktree list` if any have been created since.
+- **Language / build:** C++17, CMake, SDL 3.
+- **No audio:** zTracker is **MIDI-only**. There is no sample playback, no audio mixing. Pattern data drives MIDI Out events.
+- **Cross-platform:** Linux (apt), macOS (Homebrew SDL3), Windows MSVC (SDL3 dev zip), Windows MinGW XP-compat. CI builds all five.
 
 ## Collaboration model
 
-- **Esa has write access** to m6502/ztrackerprime. Push branches directly to `origin` (not a fork). Don't merge PRs without Manuel's approval — open them and let him review/merge.
-- `origin` = `git@github.com:m6502/ztrackerprime.git` (the upstream).
-- `esaruoho` = `git@github.com:esaruoho/ztrackerprime.git` (the old fork — keep it around as a safety net but don't push to it routinely anymore).
-- Manuel merges PRs in batches. Many have landed in one day. Expect async multi-day review cycles.
+- Push topic branches to `origin` and open PRs against `master`. Don't merge without maintainer approval.
+- Manuel reviews async, sometimes in batches. Expect multi-day cycles.
 
 ## Build system
 
-CMake. Each worktree needs `extlibs/` populated (libpng + zlib + lua):
-```bash
-cd <worktree>
-ditto /Users/esaruoho/work/ztrackerprime/extlibs extlibs   # or rsync / cp -R
-mkdir -p build && cd build
-cmake -G "Unix Makefiles" ..
-make -j8
-```
-Binary lands at `build/Program/zt` (or `build/Program/zt.app/Contents/MacOS/zt` on macOS with the .app-bundle branch).
+CMake. `extlibs/` (libpng + zlib + lua) must be populated; CI fetches them from upstream tarballs (see `.github/workflows/build.yml`).
 
-SDL3 comes from Homebrew on macOS (`brew install sdl3`). Manuel's CMakeLists finds it via pkg-config or explicit `SDL3_INCLUDE_DIR` / `SDL3_LIBRARY`.
+```sh
+mkdir -p build && cd build
+cmake -G "Unix Makefiles" ..   # or Ninja, MSVC, MinGW
+make -j8                       # produces build/Program/zt(.exe) (or zt.app on macOS)
+ctest --output-on-failure      # runs the unit-test harness
+```
+
+CMake option `ZT_BUILD_TESTS` (default ON) controls whether the `tests/` subdirectory builds. Production builds are unaffected.
+
+SDL3 comes from Homebrew on macOS (`brew install sdl3`).
 
 ## Launching the app on macOS
 
-Plain binary from a shell often exits silently when stdin is detached. Use one of:
-- `open <path>/zt.app` (for the .app bundle branch)
-- `open <path>/zt` (raw binary, opens via Finder's open)
+A plain binary launched from a backgrounded shell can exit silently when stdin is detached. Prefer:
+- `open <path>/zt.app` (for the .app bundle build)
+- `open <path>/zt` (raw binary, opens via Finder)
 - Run from Terminal.app directly
 
-Never `./zt &` from within Claude's bash tool — it will exit on exit-code 0 without rendering. `open` gives it its own session.
+Avoid `./zt &` from a non-interactive shell — it can exit with code 0 without rendering. `open` gives the app its own session.
 
 ## Screenshot automation (macOS dev tool)
 
-`scripts/zt-screenshot.sh` on the PR-L branch. Launches zt.app, presses F1/F2/F3/F11/F12/Ctrl+F12, crops each page via `screencapture -R` using AppleScript to read the zt window's position+size. Output at `/tmp/zt-shots/`. macOS-only — uses AppleScript + screencapture.
+`scripts/zt-screenshot.sh` launches zt.app and captures F1/F2/F3/F11/F12/Ctrl+F12 via `screencapture -R` using AppleScript to read window position+size. Output at `/tmp/zt-shots/`. macOS-only.
 
-**Use it to self-verify layout changes instead of asking the user to visually re-test every iteration.** The user gets frustrated fast when you keep asking them to screenshot.
+Use it to self-verify layout changes rather than asking the user to re-screenshot every iteration.
 
 ## Key files
 
@@ -76,13 +75,15 @@ Never `./zt &` from within Claude's bash tool — it will exit on exit-code 0 wi
 | `src/page_sync.h` | F4/Shift+F4 widget↔data sync helpers. Prevents the "preset reverts on next frame" class of bug. |
 | `src/save_key_dispatch.h` | Global Ctrl-S dispatch decision (open save dialog / pass through / let page handle / swallow). Unit-tested. |
 | `src/editor_layout.h` | Shared character-grid constants for F4/Shift+F4 (label right-edge, input start). |
-| `tests/` | Unit-test executables (CTest). 5 suites, 285+ checks. Run via `ctest --test-dir build`. See "Test harness" section. |
+| `tests/` | Unit-test executables (CTest). Suites cover preset logic, listbox decisions, page sync, save-key dispatch, and the keybuffer. Run via `ctest --test-dir build`. |
 | `CMakeLists.txt` | Build, includes Lua static lib + tests subdirectory (gated on `ZT_BUILD_TESTS`, default ON) |
-| `doc/help.txt` | In-app F1 help — update when adding keybinds. Has a Command-Line Arguments section as of PR #68. |
+| `doc/help.txt` | In-app F1 help — update when adding keybinds or CLI flags. |
 | `doc/CHANGELOG.txt` | Release notes style, chronological |
 | `.github/workflows/build.yml` | Multi-platform CI (Win x86/x64, macOS arm64/x86_64, Linux x86_64). Linux job runs `ctest`. |
 
-## Coordinate system (tripped me up multiple times)
+For the live PR queue: `gh pr list --repo m6502/ztrackerprime`.
+
+## Coordinate system (has tripped up multiple changes)
 
 - `row(N)` = `N * FONT_SIZE_Y` = `N * 8` pixels (returned as a Y-pixel offset but named for character rows)
 - `col(M)` = `M * FONT_SIZE_X` = `M * 8` pixels
@@ -92,33 +93,24 @@ Never `./zt &` from within Claude's bash tool — it will exit on exit-code 0 wi
 Layout macros:
 - `INITIAL_ROW = 1`
 - `PAGE_TITLE_ROW_Y = INITIAL_ROW + 8 = 9` (title separator row)
-- `TRACKS_ROW_Y = PAGE_TITLE_ROW_Y + 2 = 11` (track-frame top in Pattern Editor; user's preference)
+- `TRACKS_ROW_Y = PAGE_TITLE_ROW_Y + 2 = 11` (track-frame top in Pattern Editor)
 - `HEADER_ROW = 1`
 
 ## Keyboard conventions
 
 - **macOS Cmd key** is `KS_META`. On Apple, `SDL_KMOD_GUI` maps to `KS_META | KS_ALT` so every Alt+ shortcut works as Cmd+ too.
 - Use `KS_HAS_ALT(kstate)` macro for Alt-accepts-Cmd checks. Bare `kstate == KS_ALT` fails on macOS because Cmd produces a compound state.
-- **§ key on Finnish/EU ISO keyboards** sends `SDL_SCANCODE_NONUSBACKSLASH` (sometimes INTERNATIONAL1/2/3). In `keyhandler()` (main.cpp), we remap those scancodes to `SDLK_GRAVE` so existing bindings (§ = Note Off, Shift+§ = drawmode toggle) work on non-US layouts.
+- **§ key on Finnish/EU ISO keyboards** sends `SDL_SCANCODE_NONUSBACKSLASH` (sometimes INTERNATIONAL1/2/3). In `keyhandler()` (main.cpp), those scancodes are remapped to `SDLK_GRAVE` so existing bindings (§ = Note Off, Shift+§ = drawmode toggle) work on non-US layouts.
+- macOS `Cmd-Q` is stripped from the auto-created NSApp menu so the Pattern Editor can use it (Transpose-Up). macOS `Cmd-W` is stripped similarly.
 - When adding shortcuts, also update `doc/help.txt`.
 
 ## PR discipline
 
-- **Keep PRs small and focused.** Manuel's preferred size: 1 feature, ~30–300 LOC.
+- **Keep PRs small and focused.** Preferred size: 1 feature, ~30–300 LOC.
 - `doc/CHANGELOG.txt` gets a section per PR.
-- Tag commits with `Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>`.
-- Title format Manuel prefers: descriptive. No enforced convention but keep it under ~80 chars.
-- **Don't duplicate content across PRs.** If PR-B has pattern ops and PR-L wants them too, either (a) merge PR-B first then rebase PR-L, or (b) drop them from PR-L.
-
-## PR #21 (kitchen sink) policy
-
-The `.app`-bundle PR grew to 36 commits covering many concerns. Manuel tolerated this but asked for it to be well-documented. Body has 11 numbered sections. Don't add more unrelated features to it; open separate PRs.
-
-## Coordinate with Manuel
-
-- He reviews async. Respond to his questions promptly and specifically — he appreciates code snippets and "why" explanations, not just "done".
-- When he says something is "on him" (like the mouse-wheel window-resize bug), offer to tackle it as a separate PR rather than bundling into an existing one.
-- Tag him (`@m6502`) when you want review; he doesn't always watch inbox otherwise.
+- Tag commits with `Co-Authored-By: Claude <noreply@anthropic.com>` (or current model identifier) when AI-assisted.
+- Title format: descriptive, under ~80 chars.
+- **Don't duplicate content across PRs.** If two branches need the same change, merge one first then rebase the other, or drop the duplicate.
 
 ## Fix widget bugs upstream, not at every caller
 
@@ -129,47 +121,51 @@ If you find yourself editing the same property (`xsize`, `frame`, color, padding
 Concrete patterns this catches:
 - **Default values in the constructor.** If every caller sets `cb->xsize = 5` (or 3, or anything), set it once in `CheckBox::CheckBox()` and let callers omit it.
 - **Cap or ignore caller-supplied values inside `::draw()`** when callers historically passed bad values. Example: `CheckBox::draw` caps the wipe extent at 3 (the "Off" width) regardless of `xsize`, so legacy `xsize=5` callers don't bleed.
-- **Make a flag a no-op** if every caller's correct value is the same. Example: `CheckBox::frame` is now a no-op — every checkbox audit ended with removing `frame=1`, so the frame block was deleted from `CheckBox::draw` entirely.
+- **Make a flag a no-op** if every caller's correct value is the same. Example: `CheckBox::frame` is a no-op — every audit ended with removing `frame=1`, so the frame block was deleted from `CheckBox::draw` entirely.
 - **Sentinel cases stay in the caller.** A `MidiOutDeviceOpener` with a custom xsize, a `BankSelectCheckBox` overriding click behavior — those *are* per-caller. Don't push genuinely-distinct logic into the base widget.
 
-Real-world example (commit `ab4996d`, 2026-04-27): user kept reporting yellow-stripe bleed next to On/Off checkboxes across F11, F12, Ctrl+F12 over multiple turns. Each round I patched per-caller `cb->xsize` and `cb->frame`. The right fix was always (a) cap the wipe in `CheckBox::draw`, and (b) delete the `if (frame) {...}` block. Two upstream commits would have replaced ~10 downstream edits and a dozen messages.
+Heuristic: if a series of caller-side edits keep fixing the same visual issue, the next fix should be upstream.
 
-The user's word for the upstream-fix instinct: **"clever"**. Treat that as a reminder that downstream churn is a code smell, not a workflow.
+## Test harness
 
-## Test harness (PR #64+)
+`tests/` has CTest-driven unit-test executables covering:
 
-`tests/` has CTest-driven unit-test executables. 5 suites, 285 checks total at last count.
+- preset arrays + apply functions
+- listbox click / arrow / Space / P-cycle decision logic
+- page sync (apply→refresh→sync per-frame cycle)
+- global Ctrl-S dispatch
+- the real `KeyBuffer` (compiled SDL-free)
 
-Run all: `cd build && ctest --output-on-failure`. Each suite is a standalone executable: `build/tests/test_presets`, `test_selector`, `test_page_sync`, `test_save_key`, `test_keybuffer`. CI runs them on the Linux job after every push.
+Run all: `cd build && ctest --output-on-failure`. CI runs them on the Linux job after every push.
 
 The harness stays SDL-free by:
-- Linking against `tests/module_stub.cpp` (minimal `arpeggio` / `midimacro` constructors only) instead of the full `src/module.cpp` (which `#include`s `zt.h` and pulls in the world).
+- Linking against `tests/module_stub.cpp` (minimal `arpeggio` / `midimacro` constructors) instead of the full `src/module.cpp` (which `#include`s `zt.h` and pulls in the world).
 - For `test_keybuffer`: defines `ZT_TEST_NO_SDL` so `keybuffer.h` includes `tests/sdl_stub.h` (a tiny header providing only the `SDL_KMOD_*` constants and a few `SDLK_*` codes used by the keybuffer logic) instead of `<SDL.h>`. This lets the production `keybuffer.cpp` compile straight into the test binary.
 
-When you fix a class of bug that has bitten more than once (preset apply, save-key dispatch, button-up consumption, etc.), extract the decision logic into a header (`preset_selector.h`, `save_key_dispatch.h`, `page_sync.h`) and add tests. Bug-class regression test scaffolding has already paid off multiple times in the F4/Shift+F4 work.
+When fixing a class of bug that has bitten more than once (preset apply, save-key dispatch, button-up consumption, etc.), extract the decision logic into a header (`preset_selector.h`, `save_key_dispatch.h`, `page_sync.h`) and add tests.
 
 ## ListBox subclass mousestate gotcha (recurring foot-gun)
 
 `ListBox::mouseupdate` has a subtle invariant: it relies on `mousestate` being non-zero when `BUTTON_UP_LEFT` arrives, because `act++` is gated on it. Two ways this gets clobbered:
 
-1. **Pre-switch reset.** `if (!bMouseIsDown) mousestate = 0;` AT THE TOP OF mouseupdate (which the original code had) clears mousestate BEFORE the switch sees BUTTON_UP. Result: the up event never increments `act`, `Keys.getkey()` is never called, the up event sits forever in the FIFO blocking every subsequent input. The fix (in PR #65 / commit `87b2713`): move that reset to AFTER the switch so the BUTTON_UP_LEFT case can still observe `mousestate==1` for the listbox that actually owns the click.
+1. **Pre-switch reset.** `if (!bMouseIsDown) mousestate = 0;` AT THE TOP OF `mouseupdate` clears mousestate BEFORE the switch sees BUTTON_UP. Result: the up event never increments `act`, `Keys.getkey()` is never called, the up event sits forever in the FIFO blocking every subsequent input. The reset must run AFTER the switch so the BUTTON_UP_LEFT case can still observe `mousestate==1` for the listbox that owns the click.
 
-2. **Premature `ListBox::OnSelect(selected)` call.** The base `ListBox::OnSelect` sets `mousestate = 0`. If a subclass override calls it during click handling (i.e. between BUTTON_DOWN and BUTTON_UP), mousestate gets cleared early — same freeze pattern. The fix in `ArPresetSelector::OnSelect` / `MmPresetSelector::OnSelect`: don't call `ListBox::OnSelect`. The natural BUTTON_UP_LEFT case clears mousestate itself.
+2. **Premature `ListBox::OnSelect(selected)` call.** The base `ListBox::OnSelect` sets `mousestate = 0`. If a subclass override calls it during click handling (between BUTTON_DOWN and BUTTON_UP), mousestate gets cleared early — same freeze pattern. Don't call `ListBox::OnSelect` from a subclass; the BUTTON_UP_LEFT case clears mousestate itself.
 
-If a user reports "click on widget freezes the UI; Cmd-Tab unfreezes it" — that's this. `Cmd-Tab → SDL_EVENT_WINDOW_FOCUS_GAINED → Keys.flush()` is the unfreeze path (see `src/main.cpp::zt_handle_platform_window_event`).
+Symptom: "click on widget freezes the UI; Cmd-Tab unfreezes it." The Cmd-Tab unfreeze is `SDL_EVENT_WINDOW_FOCUS_GAINED → Keys.flush()` (see `src/main.cpp::zt_handle_platform_window_event`).
 
 ## Keyjazz slot pattern (Shift+F4)
 
-The Arpeggio editor uses a dedicated focusable UIE (`ArKeyjazzFocus`, id `KEYJAZZ_ID`) as the keyjazz target. Pattern:
+The Arpeggio editor uses a dedicated focusable UIE (`ArKeyjazzFocus`, id `KEYJAZZ_ID`) as the keyjazz target:
 
 - The stub UIE has a non-trivial `xsize`/`ysize` so click-to-focus works.
 - `update()` is a no-op; `mouseupdate()` handles click-to-focus and returns `this->ID`.
 - `draw()` is empty — the page-level `draw()` paints the visible Keyjazz panel and switches its colors based on `UI->cur_element == KEYJAZZ_ID` (active = highlighted, inactive = dim).
-- The page-level keypress handler gates on `focused == KEYJAZZ_ID` to fire `MidiOut->noteOn` + `jazz_set_state(sym, note, chan)`. main.cpp's existing key-up path (line 2578-area) detects `jazz_note_is_active(sym)` on release and fires `noteOff` automatically.
+- The page-level keypress handler gates on `focused == KEYJAZZ_ID` to fire `MidiOut->noteOn` + `jazz_set_state(sym, note, chan)`. main.cpp's existing key-up path detects `jazz_note_is_active(sym)` on release and fires `noteOff` automatically.
 
-This pattern is preferable to "always-on" keyjazz (which competes with letter-key handlers in TextInputs / listbox typeahead) because the user has an explicit, visible mode toggle.
+Preferable to "always-on" keyjazz, which competes with letter-key handlers in TextInputs / listbox typeahead — the slot gives an explicit, visible mode toggle.
 
-## CLI flags + Copy Relaunch Command (PR #68/#69)
+## CLI flags + Copy Relaunch Command
 
 zt accepts named CLI flags (parsed by `zt_parse_cli` in `main.cpp`):
 
@@ -182,69 +178,40 @@ Order-independent. Accepts both `--flag value` and `--flag=value`. Dash-count to
 
 The ESC main-menu entry "Copy Relaunch Command" (under File) reads the current session state and emits a one-line `zt --midi-clock ... --midi-in ... song.zt` invocation to the system clipboard via `SDL_SetClipboardText`. Pairs with the CLI flags for stage / live / chat-handoff workflows.
 
-## Common user behaviors / preferences (learned)
+## HARD RULE: User-reported inputs are ground truth
 
-- **"Launch the app"** = they want the app visibly running on their desktop, not just a process ID. Use `open .../zt.app` and verify with AppleScript visible-process check if needed.
-- **"TEST" is a four-letter word** — don't ask the user to test until you've launched the app yourself and verified at least basic rendering. Use the screenshot script where possible.
-- They conflate *.app, *.exe, and binary in casual speech. Disambiguate when it matters.
-- They use Finnish keyboard layout. The § key is critical. Plain § → Note Off, Shift+§ → drawmode.
-- They want PR quality over PR count. Stop spawning speculative PRs; finish one well before starting the next.
-- When they push back ("that's not right / you're fucking around"), they mean it. Stop, re-read their message literally, and ask a clarifying question if uncertain. Do not make 3 successive edits trying to guess.
-- **Don't lecture.** Be specific, show diffs, explain *why*, then act.
-
-## HARD RULE: User-reported inputs are ground truth. Never substitute.
-
-When the user says "I pressed Ctrl-S", that IS what they pressed. Do not respond with "you were probably pressing Cmd-S" / "you might have meant X" / "most likely cause is you actually pressed Y". That is gaslighting — overwriting their observation with a hypothesis that's more convenient for me because my mental model can't account for the bug.
+When the user reports a specific input ("I pressed Ctrl-S"), that IS what they pressed. Do not respond by substituting a different input ("you were probably pressing Cmd-S" / "you might have meant X" / "most likely cause is you actually pressed Y"). That is gaslighting — overwriting their observation with a hypothesis convenient for the model.
 
 Banned phrasings (any variant):
 - "Most likely cause: you were pressing X (instead of what you said)"
 - "You probably / likely / actually pressed [something else]"
-- "It might be that what you meant was..."
 - "Maybe you're hitting [different key]"
-- Any sentence whose effect is to substitute the user's reported input with my speculation.
+- Any sentence whose effect is to substitute the user's reported input with model speculation.
 
-When I trace the reported input through the code and can't see how it produces the reported symptom, the model is wrong, not the user. Allowed responses in that situation:
+When tracing the reported input through the code can't explain the symptom, the model is wrong, not the user. Allowed responses:
 
-1. **Say I'm stuck.** "I traced Ctrl-S through the dispatch and can't see why it would freeze. The code path I see drains the buffer and returns. I'm missing something."
-2. **Ask for more detail.** "Can you describe the freeze — is the cursor still moving, do the toolbar buttons still respond to clicks, or is the whole window unresponsive? Does the status bar update? When you press another key after Ctrl-S, does anything happen?"
-3. **Ask them to verify the binary.** "Are you running build/Program/zt.app or build-mac/Program/zt.app? The latter is older."
-4. **Add diagnostic output.** Insert a status_change=1 + statusmsg= line in the suspected code path so the next time they reproduce, the message tells us which branch fired.
+1. **Say so.** "I traced Ctrl-S through the dispatch and can't see why it would freeze. I'm missing something."
+2. **Ask for more detail.** "Is the cursor still moving? Do toolbar clicks still respond? Does the status bar update?"
+3. **Ask them to verify the binary.** "Are you running build/Program/zt.app or build-mac/Program/zt.app?"
+4. **Add diagnostic output.** Insert a status_change=1 + statusmsg= line in the suspected branch.
 
-This rule overrides any pull toward "be helpful" or "make progress" — substituting the user's input is not helpful, it's destructive. Reason: the 2026-04-28 Ctrl-S incident, when the user reported Ctrl-S freezing F4 and I responded with "most likely you were pressing Cmd-S (macOS habit)" despite their explicit report. They called it disrespect. They were right.
+## Paketti as a feature reference
 
-## Paketti inspiration
-
-Paketti (the Renoise tool by Esa) is a reference for the *quality-of-life* tracker features esaruoho wants ported to zTracker. Relevant bits already landed: Replicate at Cursor (PR #14), Clone Pattern (PR #14), Humanize Velocities (PR #22), MIDI Macro + Arpeggio editors (PR #64).
+Paketti (a Renoise tool) is a reference for tracker quality-of-life features that have been ported or are candidates for porting to zTracker. Already landed: Replicate at Cursor, Clone Pattern, Humanize Velocities, MIDI Macro + Arpeggio editors.
 
 Future candidates: Fill-selection-with-note-at-cursor, Find/Replace note, Transpose selection, Groove/swing templates, Chord memory.
 
 zTracker is MIDI-only (no samples/audio), so Paketti's sample-editor features are N/A.
 
-## Branch/worktree cleanup
+## Branch / worktree cleanup
 
-Delete local and remote branches confirmed merged to `origin/master` via:
+Delete local and remote branches confirmed merged to `origin/master`:
 ```bash
 git branch --merged origin/master          # locals
 git branch -r --merged origin/master       # remotes
 ```
-Be careful of worktrees — must `git worktree remove <path>` before `git branch -D <name>`. The main worktree can't be removed; just switch it to `master`.
-
-## Current open PR queue (as of 2026-04-29)
-
-| PR | Branch | Purpose | Depends |
-|---|---|---|---|
-| #65 | esa/hotfixes-again | F3 InstEditor frame revert (PR #61 regression) + dedicated Keyjazz slot in Shift+F4 + DISABLE_UNFINISHED_F4_*/F10_* gate cleanup | — |
-| #66 | esa/vu-meters | Re-enable VU meters; harden `VUPlay::draw` + `draw_one_row` against null/stale instrument deref | — |
-| #67 | esa/vu-bar-formula | VU bar math: replace 6-level Frankenstein cast chain with `init_vol * longevity / (init_longevity * 8)` | #66 |
-| #68 | esa/cli-midi-args | `--help`, `--list-midi-in`, `--midi-in <port>` (repeatable), `--midi-clock <port>` (sets `midi_in_sync` + `midi_in_sync_chase_tempo`) | — |
-| #69 | esa/copy-relaunch-cmd | ESC main-menu "Copy Relaunch Command" — captures session state to clipboard as a `zt --midi-clock ... --midi-in ... song.zt` line | #68 |
-
-All `MERGEABLE`. CI green across all 5 platforms. Manu emailed the bundle 2026-04-29.
-
-## Merged landmarks (most recent)
-
-`eba3cf6` PR #64 MIDI Macro + Arpeggio editors + R/Z effect playback + 285-check unit-test harness · `eccfca3` PR #63 mouse/keyboard UX + run-log · `fea7e2b` PR #62 macOS crash fixes (MIDI-thread NSWindow + multi-MIDI-In + Cmd+Q wedge) · `b2e037c` PR #61 F11/F12/Ctrl+F12 layout polish + widget upstream cleanup · `78efde8` PR #23 mouse-wheel zoom · `a051975` PR #22 Humanize · `2818686` PR #20 multichannel MIDI · `c6ebf8c` PR #14 pattern ops · `4dc5d56` PR #13 keybindings.
+Worktrees must be removed (`git worktree remove <path>`) before `git branch -D <name>`. The main worktree can't be removed; switch it back to `master` instead.
 
 ---
 
-*Update this skill when the project's context shifts materially (new PR, architecture change, new feature area).*
+*Update this skill when the project's context shifts materially (new architecture area, new feature region, new recurring foot-gun).*

--- a/.claude/skills/ztrackerprime/SKILL.md
+++ b/.claude/skills/ztrackerprime/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ztrackerprime
-description: zTracker Prime (m6502/ztrackerprime) contributor skill — context for zTracker development, conventions, recurring foot-guns, and PR workflow.
+description: zTracker Prime (m6502/ztrackerprime) contributor skill — orienting context, key files, and pointers to deeper reference material.
 domain: repository-specific
 source_repo: https://github.com/m6502/ztrackerprime
 source_platform: github
@@ -13,205 +13,92 @@ triggers:
 
 # zTracker Prime Development Skill
 
-## Repository Overview
+## What this is
 
-**zTracker Prime** (m6502/ztrackerprime) is Manuel Montoto's maintained fork of zTracker — an Impulse-Tracker-inspired MIDI tracker originally by Christopher Micali (2000–2001) with contributions from Daniel Kahlin. Manuel brought it to SDL 3 and cross-platform (Windows XP through 11, macOS, Linux).
+**zTracker Prime** (m6502/ztrackerprime) is Manuel Montoto's maintained fork of zTracker — an Impulse-Tracker-inspired MIDI tracker originally by Christopher Micali (2000–2001) with contributions from Daniel Kahlin. SDL 3, cross-platform (Windows XP through 11, macOS, Linux). C++17, CMake.
 
-- **Language / build:** C++17, CMake, SDL 3.
-- **No audio:** zTracker is **MIDI-only**. There is no sample playback, no audio mixing. Pattern data drives MIDI Out events.
-- **Cross-platform:** Linux (apt), macOS (Homebrew SDL3), Windows MSVC (SDL3 dev zip), Windows MinGW XP-compat. CI builds all five.
+**MIDI-only.** No sample playback, no audio mixing. Pattern data drives MIDI Out events.
 
-## Collaboration model
-
-- Push topic branches to `origin` and open PRs against `master`. Don't merge without maintainer approval.
-- Manuel reviews async, sometimes in batches. Expect multi-day cycles.
-
-## Build system
-
-CMake. `extlibs/` (libpng + zlib + lua) must be populated; CI fetches them from upstream tarballs (see `.github/workflows/build.yml`).
+## Build
 
 ```sh
 mkdir -p build && cd build
 cmake -G "Unix Makefiles" ..   # or Ninja, MSVC, MinGW
-make -j8                       # produces build/Program/zt(.exe) (or zt.app on macOS)
-ctest --output-on-failure      # runs the unit-test harness
+make -j8                       # → build/Program/zt(.exe) or build/Program/zt.app
+ctest --output-on-failure      # unit-test harness (Linux CI runs this)
 ```
 
-CMake option `ZT_BUILD_TESTS` (default ON) controls whether the `tests/` subdirectory builds. Production builds are unaffected.
+`extlibs/` (libpng + zlib + lua) must be populated; CI fetches them from upstream tarballs (see `.github/workflows/build.yml`). SDL3 from Homebrew on macOS (`brew install sdl3`).
 
-SDL3 comes from Homebrew on macOS (`brew install sdl3`).
+`ZT_BUILD_TESTS` CMake option (default ON) controls whether `tests/` builds. Production binaries are unaffected.
 
 ## Launching the app on macOS
 
-A plain binary launched from a backgrounded shell can exit silently when stdin is detached. Prefer:
-- `open <path>/zt.app` (for the .app bundle build)
-- `open <path>/zt` (raw binary, opens via Finder)
-- Run from Terminal.app directly
+`open <path>/zt.app` (or `open <path>/zt`) — gives the app its own session. Avoid `./zt &` from a non-interactive shell; it can exit silently when stdin is detached.
 
-Avoid `./zt &` from a non-interactive shell — it can exit with code 0 without rendering. `open` gives the app its own session.
-
-## Screenshot automation (macOS dev tool)
-
-`scripts/zt-screenshot.sh` launches zt.app and captures F1/F2/F3/F11/F12/Ctrl+F12 via `screencapture -R` using AppleScript to read window position+size. Output at `/tmp/zt-shots/`. macOS-only.
-
-Use it to self-verify layout changes rather than asking the user to re-screenshot every iteration.
+`scripts/zt-screenshot.sh` (macOS) launches zt.app and captures F1/F2/F3/F11/F12/Ctrl+F12 via `screencapture -R` + AppleScript. Output at `/tmp/zt-shots/`. Use it to self-verify layout changes.
 
 ## Key files
 
 | File | Purpose |
 |---|---|
-| `src/main.cpp` | Entry, main loop, key dispatch, video mode, `switch_page`, CLI parser (`zt_parse_cli` + `ZtCliArgs`) |
-| `src/CUI_Patterneditor.cpp` | Pattern editor page + 10+ pattern operations |
-| `src/CUI_*.cpp` | Other pages (Sysconfig, Songconfig, Help, InstEditor, Config, MIDI Macro, Arpeggio, etc.) |
-| `src/keybuffer.{h,cpp}` | Key state (KS_ALT, KS_CTRL, KS_META, KS_SHIFT) + KS_HAS_ALT macro. Use `ZT_TEST_NO_SDL` to compile against `tests/sdl_stub.h` for unit tests. |
+| `src/main.cpp` | Entry, main loop, key dispatch, `switch_page`, CLI parser |
+| `src/CUI_Patterneditor.cpp` | Pattern editor (F2) + 10+ pattern operations |
+| `src/CUI_Midimacroeditor.cpp` / `CUI_Arpeggioeditor.cpp` | F4 / Shift+F4 editors |
+| `src/CUI_*.cpp` | Other pages (Sysconfig, Songconfig, Help, InstEditor, MainMenu, Playsong, etc.) |
+| `src/CUI_Page.{h,cpp}` | Base class for pages |
+| `src/UserInterface.{h,cpp}` | Widget classes — `CheckBox`, `ValueSlider`, `TextInput`, `Frame`, `Button`, `TextBox`, `ListBox`, `MidiOutDeviceOpener`, `SkinSelector`, `VUPlay`. Fix rendering bugs HERE, not in callers. |
+| `src/keybuffer.{h,cpp}` | Key state (KS_ALT/KS_CTRL/KS_META/KS_SHIFT) + `KS_HAS_ALT` macro. `ZT_TEST_NO_SDL` guard for SDL-free unit tests. |
 | `src/font.cpp` | `print()` / `printtitle()` / `printBG()` drawing primitives |
-| `src/UserInterface.{h,cpp}` | **Widget classes**: `CheckBox`, `ValueSlider`, `TextInput`, `Frame`, `Button`, `TextBox`, `ListBox`, `MidiOutDeviceOpener`, `SkinSelector`, `VUPlay`. Each has its own `::draw(Drawable*, int active)`. Fix rendering bugs HERE, not in callers. |
-| `src/zt.h` | STATE_ enum, CMD_ enum, page globals, layout macros |
-| `src/conf.{h,cpp}` | zt.conf parsing, zt_config_globals struct |
-| `src/module.{h,cpp}` | Song data: patterns, tracks, events, instruments, arpeggios, midimacros |
-| `src/playback.{h,cpp}` | MIDI output timing, playback state, R-effect arpeggio + Z-effect macro dispatch |
-| `src/preset_data.h` | F4/Shift+F4 preset arrays + pure `*_apply_preset_to(struct*, idx)` functions. Pure data, header-only. |
-| `src/preset_selector.h` | F4/Shift+F4 preset listbox decision logic (click / arrow / Space / P-cycle). Pure functions, exhaustively unit-tested. |
-| `src/page_sync.h` | F4/Shift+F4 widget↔data sync helpers. Prevents the "preset reverts on next frame" class of bug. |
-| `src/save_key_dispatch.h` | Global Ctrl-S dispatch decision (open save dialog / pass through / let page handle / swallow). Unit-tested. |
-| `src/editor_layout.h` | Shared character-grid constants for F4/Shift+F4 (label right-edge, input start). |
-| `tests/` | Unit-test executables (CTest). Suites cover preset logic, listbox decisions, page sync, save-key dispatch, and the keybuffer. Run via `ctest --test-dir build`. |
-| `CMakeLists.txt` | Build, includes Lua static lib + tests subdirectory (gated on `ZT_BUILD_TESTS`, default ON) |
-| `doc/help.txt` | In-app F1 help — update when adding keybinds or CLI flags. |
-| `doc/CHANGELOG.txt` | Release notes style, chronological |
-| `.github/workflows/build.yml` | Multi-platform CI (Win x86/x64, macOS arm64/x86_64, Linux x86_64). Linux job runs `ctest`. |
+| `src/zt.h` | STATE_/CMD_ enums, page globals, layout macros |
+| `src/conf.{h,cpp}` | zt.conf parsing, `zt_config_globals` |
+| `src/module.{h,cpp}` | Song data (patterns, tracks, events, instruments, arpeggios, midimacros) |
+| `src/playback.{h,cpp}` | MIDI output timing, R-effect arpeggio + Z-effect macro dispatch |
+| `src/preset_data.h` | F4/Shift+F4 preset arrays + pure apply functions |
+| `src/preset_selector.h` | Pure listbox decision logic (click / arrow / Space / P-cycle) |
+| `src/page_sync.h` | F4/Shift+F4 widget↔data sync helpers |
+| `src/save_key_dispatch.h` | Global Ctrl-S dispatch decision |
+| `src/editor_layout.h` | Shared character-grid constants for F4/Shift+F4 |
+| `tests/` | CTest unit-test executables (preset / selector / page-sync / save-key / keybuffer) |
+| `doc/help.txt` | In-app F1 help — update when adding keybinds or CLI flags |
+| `doc/CHANGELOG.txt` | Release notes, chronological |
+| `.github/workflows/build.yml` | 5-platform CI matrix; Linux job runs `ctest` |
 
 For the live PR queue: `gh pr list --repo m6502/ztrackerprime`.
 
-## Coordinate system (has tripped up multiple changes)
+## Coordinate system
 
-- `row(N)` = `N * FONT_SIZE_Y` = `N * 8` pixels (returned as a Y-pixel offset but named for character rows)
-- `col(M)` = `M * FONT_SIZE_X` = `M * 8` pixels
-- `print(x, y, str, color, drawable)` — x first, then y
-- **Some legacy code calls `print(row(2), col(13), ...)`** — that's `x = row(2)` (16 px) and `y = col(13)` (104 px = character row 13). Confusing but works because FONT_SIZE_X == FONT_SIZE_Y.
+- `row(N)` = `N * 8` pixels (Y offset). Named for character rows but returns pixels.
+- `col(M)` = `M * 8` pixels (X offset).
+- `print(x, y, str, color, drawable)` — x first, y second.
+- Some legacy code calls `print(row(2), col(13), ...)` — this works only because `FONT_SIZE_X == FONT_SIZE_Y == 8`. Confusing; don't propagate.
 
-Layout macros:
-- `INITIAL_ROW = 1`
-- `PAGE_TITLE_ROW_Y = INITIAL_ROW + 8 = 9` (title separator row)
-- `TRACKS_ROW_Y = PAGE_TITLE_ROW_Y + 2 = 11` (track-frame top in Pattern Editor)
-- `HEADER_ROW = 1`
+Layout macros: `INITIAL_ROW=1`, `PAGE_TITLE_ROW_Y=9`, `TRACKS_ROW_Y=11`, `SPACE_AT_BOTTOM=8`.
 
-## Keyboard conventions
+## Deeper references (load on demand)
 
-- **macOS Cmd key** is `KS_META`. On Apple, `SDL_KMOD_GUI` maps to `KS_META | KS_ALT` so every Alt+ shortcut works as Cmd+ too.
-- Use `KS_HAS_ALT(kstate)` macro for Alt-accepts-Cmd checks. Bare `kstate == KS_ALT` fails on macOS because Cmd produces a compound state.
-- **§ key on Finnish/EU ISO keyboards** sends `SDL_SCANCODE_NONUSBACKSLASH` (sometimes INTERNATIONAL1/2/3). In `keyhandler()` (main.cpp), those scancodes are remapped to `SDLK_GRAVE` so existing bindings (§ = Note Off, Shift+§ = drawmode toggle) work on non-US layouts.
-- macOS `Cmd-Q` is stripped from the auto-created NSApp menu so the Pattern Editor can use it (Transpose-Up). macOS `Cmd-W` is stripped similarly.
-- When adding shortcuts, also update `doc/help.txt`.
+- [`references/foot-guns.md`](references/foot-guns.md) — recurring bug classes: ListBox mousestate fragility, widget-upstream rule, user-reported-inputs-as-ground-truth.
+- [`references/keyjazz-slot.md`](references/keyjazz-slot.md) — Shift+F4 keyjazz UIE pattern.
+- [`references/test-harness.md`](references/test-harness.md) — sdl_stub / module_stub / `ZT_TEST_NO_SDL`.
+- [`references/cli-flags.md`](references/cli-flags.md) — `zt_parse_cli` + Copy Relaunch Command.
+- [`references/keyboard.md`](references/keyboard.md) — Cmd→KS_META, `KS_HAS_ALT`, § remap, Cmd-Q strip.
+- [`references/conventions.md`](references/conventions.md) — coding conventions, status-bar diagnostic idiom.
+- [`recipes/add-test-suite.md`](recipes/add-test-suite.md) — adding a new CTest executable.
+- [`glossary.md`](glossary.md) — abbreviation lookup (TPB, MMAC, ARPG, KS_/CMD_/STATE_, etc.).
+- [`effects.md`](effects.md) — pattern-effect letter table.
 
 ## PR discipline
 
-- **Keep PRs small and focused.** Preferred size: 1 feature, ~30–300 LOC.
+- Push topic branches to `origin`, open PRs against `master`, don't merge without maintainer approval.
+- Keep PRs small and focused: 1 feature, ~30–300 LOC.
 - `doc/CHANGELOG.txt` gets a section per PR.
-- Tag commits with `Co-Authored-By: Claude <noreply@anthropic.com>` (or current model identifier) when AI-assisted.
-- Title format: descriptive, under ~80 chars.
-- **Don't duplicate content across PRs.** If two branches need the same change, merge one first then rebase the other, or drop the duplicate.
-
-## Fix widget bugs upstream, not at every caller
-
-When a rendering or behavior bug appears on **multiple pages with the same widget**, the fix belongs in `src/UserInterface.cpp` (the widget class), not in each `CUI_*.cpp` caller.
-
-If you find yourself editing the same property (`xsize`, `frame`, color, padding) across more than two callers to fix the *same visual problem*, **stop and refactor**. The call sites are symptomatic; the widget's `::draw()` or constructor is the real bug.
-
-Concrete patterns this catches:
-- **Default values in the constructor.** If every caller sets `cb->xsize = 5` (or 3, or anything), set it once in `CheckBox::CheckBox()` and let callers omit it.
-- **Cap or ignore caller-supplied values inside `::draw()`** when callers historically passed bad values. Example: `CheckBox::draw` caps the wipe extent at 3 (the "Off" width) regardless of `xsize`, so legacy `xsize=5` callers don't bleed.
-- **Make a flag a no-op** if every caller's correct value is the same. Example: `CheckBox::frame` is a no-op — every audit ended with removing `frame=1`, so the frame block was deleted from `CheckBox::draw` entirely.
-- **Sentinel cases stay in the caller.** A `MidiOutDeviceOpener` with a custom xsize, a `BankSelectCheckBox` overriding click behavior — those *are* per-caller. Don't push genuinely-distinct logic into the base widget.
-
-Heuristic: if a series of caller-side edits keep fixing the same visual issue, the next fix should be upstream.
-
-## Test harness
-
-`tests/` has CTest-driven unit-test executables covering:
-
-- preset arrays + apply functions
-- listbox click / arrow / Space / P-cycle decision logic
-- page sync (apply→refresh→sync per-frame cycle)
-- global Ctrl-S dispatch
-- the real `KeyBuffer` (compiled SDL-free)
-
-Run all: `cd build && ctest --output-on-failure`. CI runs them on the Linux job after every push.
-
-The harness stays SDL-free by:
-- Linking against `tests/module_stub.cpp` (minimal `arpeggio` / `midimacro` constructors) instead of the full `src/module.cpp` (which `#include`s `zt.h` and pulls in the world).
-- For `test_keybuffer`: defines `ZT_TEST_NO_SDL` so `keybuffer.h` includes `tests/sdl_stub.h` (a tiny header providing only the `SDL_KMOD_*` constants and a few `SDLK_*` codes used by the keybuffer logic) instead of `<SDL.h>`. This lets the production `keybuffer.cpp` compile straight into the test binary.
-
-When fixing a class of bug that has bitten more than once (preset apply, save-key dispatch, button-up consumption, etc.), extract the decision logic into a header (`preset_selector.h`, `save_key_dispatch.h`, `page_sync.h`) and add tests.
-
-## ListBox subclass mousestate gotcha (recurring foot-gun)
-
-`ListBox::mouseupdate` has a subtle invariant: it relies on `mousestate` being non-zero when `BUTTON_UP_LEFT` arrives, because `act++` is gated on it. Two ways this gets clobbered:
-
-1. **Pre-switch reset.** `if (!bMouseIsDown) mousestate = 0;` AT THE TOP OF `mouseupdate` clears mousestate BEFORE the switch sees BUTTON_UP. Result: the up event never increments `act`, `Keys.getkey()` is never called, the up event sits forever in the FIFO blocking every subsequent input. The reset must run AFTER the switch so the BUTTON_UP_LEFT case can still observe `mousestate==1` for the listbox that owns the click.
-
-2. **Premature `ListBox::OnSelect(selected)` call.** The base `ListBox::OnSelect` sets `mousestate = 0`. If a subclass override calls it during click handling (between BUTTON_DOWN and BUTTON_UP), mousestate gets cleared early — same freeze pattern. Don't call `ListBox::OnSelect` from a subclass; the BUTTON_UP_LEFT case clears mousestate itself.
-
-Symptom: "click on widget freezes the UI; Cmd-Tab unfreezes it." The Cmd-Tab unfreeze is `SDL_EVENT_WINDOW_FOCUS_GAINED → Keys.flush()` (see `src/main.cpp::zt_handle_platform_window_event`).
-
-## Keyjazz slot pattern (Shift+F4)
-
-The Arpeggio editor uses a dedicated focusable UIE (`ArKeyjazzFocus`, id `KEYJAZZ_ID`) as the keyjazz target:
-
-- The stub UIE has a non-trivial `xsize`/`ysize` so click-to-focus works.
-- `update()` is a no-op; `mouseupdate()` handles click-to-focus and returns `this->ID`.
-- `draw()` is empty — the page-level `draw()` paints the visible Keyjazz panel and switches its colors based on `UI->cur_element == KEYJAZZ_ID` (active = highlighted, inactive = dim).
-- The page-level keypress handler gates on `focused == KEYJAZZ_ID` to fire `MidiOut->noteOn` + `jazz_set_state(sym, note, chan)`. main.cpp's existing key-up path detects `jazz_note_is_active(sym)` on release and fires `noteOff` automatically.
-
-Preferable to "always-on" keyjazz, which competes with letter-key handlers in TextInputs / listbox typeahead — the slot gives an explicit, visible mode toggle.
-
-## CLI flags + Copy Relaunch Command
-
-zt accepts named CLI flags (parsed by `zt_parse_cli` in `main.cpp`):
-
-- `-h`, `--help` — print usage + exit (works without SDL/MIDI/display).
-- `--list-midi-in` — list MIDI input ports + exit.
-- `--midi-in <name|index>` — open the named port at startup; repeatable.
-- `--midi-clock <name|index>` — open + enable `midi_in_sync` + `midi_in_sync_chase_tempo`.
-
-Order-independent. Accepts both `--flag value` and `--flag=value`. Dash-count tolerant (`-flag` works as well as `--flag`). First positional arg = .zt song to load.
-
-The ESC main-menu entry "Copy Relaunch Command" (under File) reads the current session state and emits a one-line `zt --midi-clock ... --midi-in ... song.zt` invocation to the system clipboard via `SDL_SetClipboardText`. Pairs with the CLI flags for stage / live / chat-handoff workflows.
-
-## HARD RULE: User-reported inputs are ground truth
-
-When the user reports a specific input ("I pressed Ctrl-S"), that IS what they pressed. Do not respond by substituting a different input ("you were probably pressing Cmd-S" / "you might have meant X" / "most likely cause is you actually pressed Y"). That is gaslighting — overwriting their observation with a hypothesis convenient for the model.
-
-Banned phrasings (any variant):
-- "Most likely cause: you were pressing X (instead of what you said)"
-- "You probably / likely / actually pressed [something else]"
-- "Maybe you're hitting [different key]"
-- Any sentence whose effect is to substitute the user's reported input with model speculation.
-
-When tracing the reported input through the code can't explain the symptom, the model is wrong, not the user. Allowed responses:
-
-1. **Say so.** "I traced Ctrl-S through the dispatch and can't see why it would freeze. I'm missing something."
-2. **Ask for more detail.** "Is the cursor still moving? Do toolbar clicks still respond? Does the status bar update?"
-3. **Ask them to verify the binary.** "Are you running build/Program/zt.app or build-mac/Program/zt.app?"
-4. **Add diagnostic output.** Insert a status_change=1 + statusmsg= line in the suspected branch.
+- Tag AI-assisted commits: `Co-Authored-By: Claude <noreply@anthropic.com>` (or current model identifier).
+- Don't duplicate content across PRs.
 
 ## Paketti as a feature reference
 
-Paketti (a Renoise tool) is a reference for tracker quality-of-life features that have been ported or are candidates for porting to zTracker. Already landed: Replicate at Cursor, Clone Pattern, Humanize Velocities, MIDI Macro + Arpeggio editors.
-
-Future candidates: Fill-selection-with-note-at-cursor, Find/Replace note, Transpose selection, Groove/swing templates, Chord memory.
-
-zTracker is MIDI-only (no samples/audio), so Paketti's sample-editor features are N/A.
-
-## Branch / worktree cleanup
-
-Delete local and remote branches confirmed merged to `origin/master`:
-```bash
-git branch --merged origin/master          # locals
-git branch -r --merged origin/master       # remotes
-```
-Worktrees must be removed (`git worktree remove <path>`) before `git branch -D <name>`. The main worktree can't be removed; switch it back to `master` instead.
+Paketti (a Renoise tool) is a reference for tracker quality-of-life features ported / portable to zTracker. Already landed: Replicate at Cursor, Clone Pattern, Humanize Velocities, MIDI Macro + Arpeggio editors. Future candidates: Fill-with-note-at-cursor, Find/Replace note, Transpose selection, Groove templates, Chord memory. zTracker is MIDI-only, so sample-editor features are N/A.
 
 ---
 
-*Update this skill when the project's context shifts materially (new architecture area, new feature region, new recurring foot-gun).*
+*Update this skill (and the relevant reference file) when the project's context shifts materially: new architecture area, new feature region, new recurring foot-gun.*

--- a/.claude/skills/ztrackerprime/SKILL.md
+++ b/.claude/skills/ztrackerprime/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: ztrackerprime
+description: zTracker Prime (m6502/ztrackerprime) contributor skill — picks up context for zTracker development, PR management, and collaboration with maintainer Manuel Montoto (@m6502).
+domain: repository-specific
+source_repo: https://github.com/m6502/ztrackerprime
+source_platform: github
+tags: [cpp, sdl3, tracker, midi, cross-platform]
+triggers:
+  keywords:
+    primary: [ztracker, ztrackerprime, zt, zTracker]
+    secondary: [m6502, manuel montoto, tracker, MIDI tracker, impulse tracker, paketti, SDL3 tracker]
+---
+
+# zTracker Prime Development Skill
+
+## Repository Overview
+
+**zTracker Prime** (m6502/ztrackerprime) is Manuel Montoto's maintained fork of zTracker — an Impulse-Tracker-inspired MIDI tracker originally by Christopher Micali (2000–2001) with contributions from Daniel Kahlin. Manuel brought it to SDL 3 and cross-platform (Windows XP through 11, macOS, Linux).
+
+**Primary working directory:** `/Users/esaruoho/work/ztrackerprime` (main worktree — don't commit experiments here).
+
+Active feature branches live in the main worktree (no separate working dirs as of 2026-04-29). `git worktree list` if any have been created since.
+
+## Collaboration model
+
+- **Esa has write access** to m6502/ztrackerprime. Push branches directly to `origin` (not a fork). Don't merge PRs without Manuel's approval — open them and let him review/merge.
+- `origin` = `git@github.com:m6502/ztrackerprime.git` (the upstream).
+- `esaruoho` = `git@github.com:esaruoho/ztrackerprime.git` (the old fork — keep it around as a safety net but don't push to it routinely anymore).
+- Manuel merges PRs in batches. Many have landed in one day. Expect async multi-day review cycles.
+
+## Build system
+
+CMake. Each worktree needs `extlibs/` populated (libpng + zlib + lua):
+```bash
+cd <worktree>
+ditto /Users/esaruoho/work/ztrackerprime/extlibs extlibs   # or rsync / cp -R
+mkdir -p build && cd build
+cmake -G "Unix Makefiles" ..
+make -j8
+```
+Binary lands at `build/Program/zt` (or `build/Program/zt.app/Contents/MacOS/zt` on macOS with the .app-bundle branch).
+
+SDL3 comes from Homebrew on macOS (`brew install sdl3`). Manuel's CMakeLists finds it via pkg-config or explicit `SDL3_INCLUDE_DIR` / `SDL3_LIBRARY`.
+
+## Launching the app on macOS
+
+Plain binary from a shell often exits silently when stdin is detached. Use one of:
+- `open <path>/zt.app` (for the .app bundle branch)
+- `open <path>/zt` (raw binary, opens via Finder's open)
+- Run from Terminal.app directly
+
+Never `./zt &` from within Claude's bash tool — it will exit on exit-code 0 without rendering. `open` gives it its own session.
+
+## Screenshot automation (macOS dev tool)
+
+`scripts/zt-screenshot.sh` on the PR-L branch. Launches zt.app, presses F1/F2/F3/F11/F12/Ctrl+F12, crops each page via `screencapture -R` using AppleScript to read the zt window's position+size. Output at `/tmp/zt-shots/`. macOS-only — uses AppleScript + screencapture.
+
+**Use it to self-verify layout changes instead of asking the user to visually re-test every iteration.** The user gets frustrated fast when you keep asking them to screenshot.
+
+## Key files
+
+| File | Purpose |
+|---|---|
+| `src/main.cpp` | Entry, main loop, key dispatch, video mode, `switch_page`, CLI parser (`zt_parse_cli` + `ZtCliArgs`) |
+| `src/CUI_Patterneditor.cpp` | Pattern editor page + 10+ pattern operations |
+| `src/CUI_*.cpp` | Other pages (Sysconfig, Songconfig, Help, InstEditor, Config, MIDI Macro, Arpeggio, etc.) |
+| `src/keybuffer.{h,cpp}` | Key state (KS_ALT, KS_CTRL, KS_META, KS_SHIFT) + KS_HAS_ALT macro. Use `ZT_TEST_NO_SDL` to compile against `tests/sdl_stub.h` for unit tests. |
+| `src/font.cpp` | `print()` / `printtitle()` / `printBG()` drawing primitives |
+| `src/UserInterface.{h,cpp}` | **Widget classes**: `CheckBox`, `ValueSlider`, `TextInput`, `Frame`, `Button`, `TextBox`, `ListBox`, `MidiOutDeviceOpener`, `SkinSelector`, `VUPlay`. Each has its own `::draw(Drawable*, int active)`. Fix rendering bugs HERE, not in callers. |
+| `src/zt.h` | STATE_ enum, CMD_ enum, page globals, layout macros |
+| `src/conf.{h,cpp}` | zt.conf parsing, zt_config_globals struct |
+| `src/module.{h,cpp}` | Song data: patterns, tracks, events, instruments, arpeggios, midimacros |
+| `src/playback.{h,cpp}` | MIDI output timing, playback state, R-effect arpeggio + Z-effect macro dispatch |
+| `src/preset_data.h` | F4/Shift+F4 preset arrays + pure `*_apply_preset_to(struct*, idx)` functions. Pure data, header-only. |
+| `src/preset_selector.h` | F4/Shift+F4 preset listbox decision logic (click / arrow / Space / P-cycle). Pure functions, exhaustively unit-tested. |
+| `src/page_sync.h` | F4/Shift+F4 widget↔data sync helpers. Prevents the "preset reverts on next frame" class of bug. |
+| `src/save_key_dispatch.h` | Global Ctrl-S dispatch decision (open save dialog / pass through / let page handle / swallow). Unit-tested. |
+| `src/editor_layout.h` | Shared character-grid constants for F4/Shift+F4 (label right-edge, input start). |
+| `tests/` | Unit-test executables (CTest). 5 suites, 285+ checks. Run via `ctest --test-dir build`. See "Test harness" section. |
+| `CMakeLists.txt` | Build, includes Lua static lib + tests subdirectory (gated on `ZT_BUILD_TESTS`, default ON) |
+| `doc/help.txt` | In-app F1 help — update when adding keybinds. Has a Command-Line Arguments section as of PR #68. |
+| `doc/CHANGELOG.txt` | Release notes style, chronological |
+| `.github/workflows/build.yml` | Multi-platform CI (Win x86/x64, macOS arm64/x86_64, Linux x86_64). Linux job runs `ctest`. |
+
+## Coordinate system (tripped me up multiple times)
+
+- `row(N)` = `N * FONT_SIZE_Y` = `N * 8` pixels (returned as a Y-pixel offset but named for character rows)
+- `col(M)` = `M * FONT_SIZE_X` = `M * 8` pixels
+- `print(x, y, str, color, drawable)` — x first, then y
+- **Some legacy code calls `print(row(2), col(13), ...)`** — that's `x = row(2)` (16 px) and `y = col(13)` (104 px = character row 13). Confusing but works because FONT_SIZE_X == FONT_SIZE_Y.
+
+Layout macros:
+- `INITIAL_ROW = 1`
+- `PAGE_TITLE_ROW_Y = INITIAL_ROW + 8 = 9` (title separator row)
+- `TRACKS_ROW_Y = PAGE_TITLE_ROW_Y + 2 = 11` (track-frame top in Pattern Editor; user's preference)
+- `HEADER_ROW = 1`
+
+## Keyboard conventions
+
+- **macOS Cmd key** is `KS_META`. On Apple, `SDL_KMOD_GUI` maps to `KS_META | KS_ALT` so every Alt+ shortcut works as Cmd+ too.
+- Use `KS_HAS_ALT(kstate)` macro for Alt-accepts-Cmd checks. Bare `kstate == KS_ALT` fails on macOS because Cmd produces a compound state.
+- **§ key on Finnish/EU ISO keyboards** sends `SDL_SCANCODE_NONUSBACKSLASH` (sometimes INTERNATIONAL1/2/3). In `keyhandler()` (main.cpp), we remap those scancodes to `SDLK_GRAVE` so existing bindings (§ = Note Off, Shift+§ = drawmode toggle) work on non-US layouts.
+- When adding shortcuts, also update `doc/help.txt`.
+
+## PR discipline
+
+- **Keep PRs small and focused.** Manuel's preferred size: 1 feature, ~30–300 LOC.
+- `doc/CHANGELOG.txt` gets a section per PR.
+- Tag commits with `Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>`.
+- Title format Manuel prefers: descriptive. No enforced convention but keep it under ~80 chars.
+- **Don't duplicate content across PRs.** If PR-B has pattern ops and PR-L wants them too, either (a) merge PR-B first then rebase PR-L, or (b) drop them from PR-L.
+
+## PR #21 (kitchen sink) policy
+
+The `.app`-bundle PR grew to 36 commits covering many concerns. Manuel tolerated this but asked for it to be well-documented. Body has 11 numbered sections. Don't add more unrelated features to it; open separate PRs.
+
+## Coordinate with Manuel
+
+- He reviews async. Respond to his questions promptly and specifically — he appreciates code snippets and "why" explanations, not just "done".
+- When he says something is "on him" (like the mouse-wheel window-resize bug), offer to tackle it as a separate PR rather than bundling into an existing one.
+- Tag him (`@m6502`) when you want review; he doesn't always watch inbox otherwise.
+
+## Fix widget bugs upstream, not at every caller
+
+When a rendering or behavior bug appears on **multiple pages with the same widget**, the fix belongs in `src/UserInterface.cpp` (the widget class), not in each `CUI_*.cpp` caller.
+
+If you find yourself editing the same property (`xsize`, `frame`, color, padding) across more than two callers to fix the *same visual problem*, **stop and refactor**. The call sites are symptomatic; the widget's `::draw()` or constructor is the real bug.
+
+Concrete patterns this catches:
+- **Default values in the constructor.** If every caller sets `cb->xsize = 5` (or 3, or anything), set it once in `CheckBox::CheckBox()` and let callers omit it.
+- **Cap or ignore caller-supplied values inside `::draw()`** when callers historically passed bad values. Example: `CheckBox::draw` caps the wipe extent at 3 (the "Off" width) regardless of `xsize`, so legacy `xsize=5` callers don't bleed.
+- **Make a flag a no-op** if every caller's correct value is the same. Example: `CheckBox::frame` is now a no-op — every checkbox audit ended with removing `frame=1`, so the frame block was deleted from `CheckBox::draw` entirely.
+- **Sentinel cases stay in the caller.** A `MidiOutDeviceOpener` with a custom xsize, a `BankSelectCheckBox` overriding click behavior — those *are* per-caller. Don't push genuinely-distinct logic into the base widget.
+
+Real-world example (commit `ab4996d`, 2026-04-27): user kept reporting yellow-stripe bleed next to On/Off checkboxes across F11, F12, Ctrl+F12 over multiple turns. Each round I patched per-caller `cb->xsize` and `cb->frame`. The right fix was always (a) cap the wipe in `CheckBox::draw`, and (b) delete the `if (frame) {...}` block. Two upstream commits would have replaced ~10 downstream edits and a dozen messages.
+
+The user's word for the upstream-fix instinct: **"clever"**. Treat that as a reminder that downstream churn is a code smell, not a workflow.
+
+## Test harness (PR #64+)
+
+`tests/` has CTest-driven unit-test executables. 5 suites, 285 checks total at last count.
+
+Run all: `cd build && ctest --output-on-failure`. Each suite is a standalone executable: `build/tests/test_presets`, `test_selector`, `test_page_sync`, `test_save_key`, `test_keybuffer`. CI runs them on the Linux job after every push.
+
+The harness stays SDL-free by:
+- Linking against `tests/module_stub.cpp` (minimal `arpeggio` / `midimacro` constructors only) instead of the full `src/module.cpp` (which `#include`s `zt.h` and pulls in the world).
+- For `test_keybuffer`: defines `ZT_TEST_NO_SDL` so `keybuffer.h` includes `tests/sdl_stub.h` (a tiny header providing only the `SDL_KMOD_*` constants and a few `SDLK_*` codes used by the keybuffer logic) instead of `<SDL.h>`. This lets the production `keybuffer.cpp` compile straight into the test binary.
+
+When you fix a class of bug that has bitten more than once (preset apply, save-key dispatch, button-up consumption, etc.), extract the decision logic into a header (`preset_selector.h`, `save_key_dispatch.h`, `page_sync.h`) and add tests. Bug-class regression test scaffolding has already paid off multiple times in the F4/Shift+F4 work.
+
+## ListBox subclass mousestate gotcha (recurring foot-gun)
+
+`ListBox::mouseupdate` has a subtle invariant: it relies on `mousestate` being non-zero when `BUTTON_UP_LEFT` arrives, because `act++` is gated on it. Two ways this gets clobbered:
+
+1. **Pre-switch reset.** `if (!bMouseIsDown) mousestate = 0;` AT THE TOP OF mouseupdate (which the original code had) clears mousestate BEFORE the switch sees BUTTON_UP. Result: the up event never increments `act`, `Keys.getkey()` is never called, the up event sits forever in the FIFO blocking every subsequent input. The fix (in PR #65 / commit `87b2713`): move that reset to AFTER the switch so the BUTTON_UP_LEFT case can still observe `mousestate==1` for the listbox that actually owns the click.
+
+2. **Premature `ListBox::OnSelect(selected)` call.** The base `ListBox::OnSelect` sets `mousestate = 0`. If a subclass override calls it during click handling (i.e. between BUTTON_DOWN and BUTTON_UP), mousestate gets cleared early — same freeze pattern. The fix in `ArPresetSelector::OnSelect` / `MmPresetSelector::OnSelect`: don't call `ListBox::OnSelect`. The natural BUTTON_UP_LEFT case clears mousestate itself.
+
+If a user reports "click on widget freezes the UI; Cmd-Tab unfreezes it" — that's this. `Cmd-Tab → SDL_EVENT_WINDOW_FOCUS_GAINED → Keys.flush()` is the unfreeze path (see `src/main.cpp::zt_handle_platform_window_event`).
+
+## Keyjazz slot pattern (Shift+F4)
+
+The Arpeggio editor uses a dedicated focusable UIE (`ArKeyjazzFocus`, id `KEYJAZZ_ID`) as the keyjazz target. Pattern:
+
+- The stub UIE has a non-trivial `xsize`/`ysize` so click-to-focus works.
+- `update()` is a no-op; `mouseupdate()` handles click-to-focus and returns `this->ID`.
+- `draw()` is empty — the page-level `draw()` paints the visible Keyjazz panel and switches its colors based on `UI->cur_element == KEYJAZZ_ID` (active = highlighted, inactive = dim).
+- The page-level keypress handler gates on `focused == KEYJAZZ_ID` to fire `MidiOut->noteOn` + `jazz_set_state(sym, note, chan)`. main.cpp's existing key-up path (line 2578-area) detects `jazz_note_is_active(sym)` on release and fires `noteOff` automatically.
+
+This pattern is preferable to "always-on" keyjazz (which competes with letter-key handlers in TextInputs / listbox typeahead) because the user has an explicit, visible mode toggle.
+
+## CLI flags + Copy Relaunch Command (PR #68/#69)
+
+zt accepts named CLI flags (parsed by `zt_parse_cli` in `main.cpp`):
+
+- `-h`, `--help` — print usage + exit (works without SDL/MIDI/display).
+- `--list-midi-in` — list MIDI input ports + exit.
+- `--midi-in <name|index>` — open the named port at startup; repeatable.
+- `--midi-clock <name|index>` — open + enable `midi_in_sync` + `midi_in_sync_chase_tempo`.
+
+Order-independent. Accepts both `--flag value` and `--flag=value`. Dash-count tolerant (`-flag` works as well as `--flag`). First positional arg = .zt song to load.
+
+The ESC main-menu entry "Copy Relaunch Command" (under File) reads the current session state and emits a one-line `zt --midi-clock ... --midi-in ... song.zt` invocation to the system clipboard via `SDL_SetClipboardText`. Pairs with the CLI flags for stage / live / chat-handoff workflows.
+
+## Common user behaviors / preferences (learned)
+
+- **"Launch the app"** = they want the app visibly running on their desktop, not just a process ID. Use `open .../zt.app` and verify with AppleScript visible-process check if needed.
+- **"TEST" is a four-letter word** — don't ask the user to test until you've launched the app yourself and verified at least basic rendering. Use the screenshot script where possible.
+- They conflate *.app, *.exe, and binary in casual speech. Disambiguate when it matters.
+- They use Finnish keyboard layout. The § key is critical. Plain § → Note Off, Shift+§ → drawmode.
+- They want PR quality over PR count. Stop spawning speculative PRs; finish one well before starting the next.
+- When they push back ("that's not right / you're fucking around"), they mean it. Stop, re-read their message literally, and ask a clarifying question if uncertain. Do not make 3 successive edits trying to guess.
+- **Don't lecture.** Be specific, show diffs, explain *why*, then act.
+
+## HARD RULE: User-reported inputs are ground truth. Never substitute.
+
+When the user says "I pressed Ctrl-S", that IS what they pressed. Do not respond with "you were probably pressing Cmd-S" / "you might have meant X" / "most likely cause is you actually pressed Y". That is gaslighting — overwriting their observation with a hypothesis that's more convenient for me because my mental model can't account for the bug.
+
+Banned phrasings (any variant):
+- "Most likely cause: you were pressing X (instead of what you said)"
+- "You probably / likely / actually pressed [something else]"
+- "It might be that what you meant was..."
+- "Maybe you're hitting [different key]"
+- Any sentence whose effect is to substitute the user's reported input with my speculation.
+
+When I trace the reported input through the code and can't see how it produces the reported symptom, the model is wrong, not the user. Allowed responses in that situation:
+
+1. **Say I'm stuck.** "I traced Ctrl-S through the dispatch and can't see why it would freeze. The code path I see drains the buffer and returns. I'm missing something."
+2. **Ask for more detail.** "Can you describe the freeze — is the cursor still moving, do the toolbar buttons still respond to clicks, or is the whole window unresponsive? Does the status bar update? When you press another key after Ctrl-S, does anything happen?"
+3. **Ask them to verify the binary.** "Are you running build/Program/zt.app or build-mac/Program/zt.app? The latter is older."
+4. **Add diagnostic output.** Insert a status_change=1 + statusmsg= line in the suspected code path so the next time they reproduce, the message tells us which branch fired.
+
+This rule overrides any pull toward "be helpful" or "make progress" — substituting the user's input is not helpful, it's destructive. Reason: the 2026-04-28 Ctrl-S incident, when the user reported Ctrl-S freezing F4 and I responded with "most likely you were pressing Cmd-S (macOS habit)" despite their explicit report. They called it disrespect. They were right.
+
+## Paketti inspiration
+
+Paketti (the Renoise tool by Esa) is a reference for the *quality-of-life* tracker features esaruoho wants ported to zTracker. Relevant bits already landed: Replicate at Cursor (PR #14), Clone Pattern (PR #14), Humanize Velocities (PR #22), MIDI Macro + Arpeggio editors (PR #64).
+
+Future candidates: Fill-selection-with-note-at-cursor, Find/Replace note, Transpose selection, Groove/swing templates, Chord memory.
+
+zTracker is MIDI-only (no samples/audio), so Paketti's sample-editor features are N/A.
+
+## Branch/worktree cleanup
+
+Delete local and remote branches confirmed merged to `origin/master` via:
+```bash
+git branch --merged origin/master          # locals
+git branch -r --merged origin/master       # remotes
+```
+Be careful of worktrees — must `git worktree remove <path>` before `git branch -D <name>`. The main worktree can't be removed; just switch it to `master`.
+
+## Current open PR queue (as of 2026-04-29)
+
+| PR | Branch | Purpose | Depends |
+|---|---|---|---|
+| #65 | esa/hotfixes-again | F3 InstEditor frame revert (PR #61 regression) + dedicated Keyjazz slot in Shift+F4 + DISABLE_UNFINISHED_F4_*/F10_* gate cleanup | — |
+| #66 | esa/vu-meters | Re-enable VU meters; harden `VUPlay::draw` + `draw_one_row` against null/stale instrument deref | — |
+| #67 | esa/vu-bar-formula | VU bar math: replace 6-level Frankenstein cast chain with `init_vol * longevity / (init_longevity * 8)` | #66 |
+| #68 | esa/cli-midi-args | `--help`, `--list-midi-in`, `--midi-in <port>` (repeatable), `--midi-clock <port>` (sets `midi_in_sync` + `midi_in_sync_chase_tempo`) | — |
+| #69 | esa/copy-relaunch-cmd | ESC main-menu "Copy Relaunch Command" — captures session state to clipboard as a `zt --midi-clock ... --midi-in ... song.zt` line | #68 |
+
+All `MERGEABLE`. CI green across all 5 platforms. Manu emailed the bundle 2026-04-29.
+
+## Merged landmarks (most recent)
+
+`eba3cf6` PR #64 MIDI Macro + Arpeggio editors + R/Z effect playback + 285-check unit-test harness · `eccfca3` PR #63 mouse/keyboard UX + run-log · `fea7e2b` PR #62 macOS crash fixes (MIDI-thread NSWindow + multi-MIDI-In + Cmd+Q wedge) · `b2e037c` PR #61 F11/F12/Ctrl+F12 layout polish + widget upstream cleanup · `78efde8` PR #23 mouse-wheel zoom · `a051975` PR #22 Humanize · `2818686` PR #20 multichannel MIDI · `c6ebf8c` PR #14 pattern ops · `4dc5d56` PR #13 keybindings.
+
+---
+
+*Update this skill when the project's context shifts materially (new PR, architecture change, new feature area).*

--- a/.claude/skills/ztrackerprime/effects.md
+++ b/.claude/skills/ztrackerprime/effects.md
@@ -1,0 +1,42 @@
+# Pattern effect reference
+
+Effects are letters in the effect column of a pattern row. Each takes up to 4 hex digits of parameter. Dispatched in `src/playback.cpp`.
+
+| Letter | Mnemonic | Effect |
+|---|---|---|
+| `A..xx` | TPB | Set Ticks Per Beat. |
+| `B 00` | Marker `[` | Set "[" marker in MIDI export. |
+| `B 01` | Marker `]` | Set "]" marker in MIDI export. |
+| `Cxxxx` | Pattern break | End the pattern; jump to next pattern, row 0 (`C0000`). |
+| `D..xx` | Delay | Delay note/volume/cut by xxxx sub-ticks. |
+| `Exxxx` | Pitch slide down | `E0000` repeats the last portamento command. |
+| `Fxxxx` | Pitch slide up | `F0000` repeats the last portamento (down) command. |
+| `P....` | Program change | Send program change for the current instrument. |
+| `Q..xx` | Retrigger | Retrig note every xx subticks. |
+| `R..xx` | Arpeggio | Start arpeggio xx (from the song's ARPG chunk). `R0000` continues the last. |
+| `Sxxyy` | CC | Send Continuous Controller xx with value yy (yy < 0x80). yy ≥ 0x80 sends last value. Example: `S0142` sets CC#01 (Mod Wheel) to 0x42. |
+| `T..xx` | Tempo | Set tempo to xx BPM. |
+| `Wxxxx` | Pitch bend (absolute) | 0..0x3FFF; 0x2000 = no bend, 0 = max down, 0x3FFF = max up. |
+| `X..xx` | Pan | 00 = left, 40 = center, 7F = right. |
+| `Zxxyy` | MIDI Macro | Send macro xx (from the song's MMAC chunk) with parameter yy. `00` repeats the last value. |
+
+## Where each is implemented
+
+Most effects are dispatched from a switch in `playback.cpp` keyed on the effect letter. R (arpeggio) and Z (MIDI macro) read from the song's ARPG / MMAC chunks; their definitions come from the F4 and Shift+F4 editors.
+
+When adding a new effect:
+1. Pick an unused letter.
+2. Add the dispatch case in `playback.cpp`.
+3. Document in `doc/help.txt` (Effects section).
+4. If the effect references a song-level data structure (like Z → MMAC), wire the editor to populate it.
+
+## Effects that "remember"
+
+Several effects use `0000` as "repeat last":
+- `E0000` — repeat last portamento.
+- `F0000` — repeat last portamento (down).
+- `R0000` — continue last arpeggio.
+- `Z..00` — repeat last MIDI macro parameter.
+- `Sxx80` and above — send CC's last value rather than a new one.
+
+If you add an effect with state, follow the pattern (zero-param or high-bit means reuse).

--- a/.claude/skills/ztrackerprime/glossary.md
+++ b/.claude/skills/ztrackerprime/glossary.md
@@ -1,0 +1,71 @@
+# Glossary
+
+Codebase abbreviations, acronyms, and prefixes. Look here before guessing or grepping.
+
+## Tracker / MIDI domain
+
+| Term | Meaning |
+|---|---|
+| TPB | Ticks Per Beat — set by effect `Axx`. Pattern-row resolution. |
+| BPM | Beats Per Minute — set by effect `Txx`. |
+| MMAC | MIDI Macro — multi-byte MIDI message template, triggered by `Z` effect. Stored in the song's MMAC chunk. |
+| ARPG | Arpeggio — note-offset sequence triggered by `R` effect. Stored in the song's ARPG chunk. |
+| CC | Continuous Controller — MIDI control change. Sent via effect `Sxxyy` (xx = CC number, yy = value). |
+| F8 | MIDI clock pulse byte. `--midi-clock` chases this to derive tempo. |
+| Note Off | MIDI note-off message. Triggered by `§` (or remapped scancode). |
+| Keyjazz | Audition mode — PC keyboard plays MIDI notes through the current instrument. |
+
+## Code prefixes
+
+| Prefix | Meaning |
+|---|---|
+| `KS_` | Key state bits — `KS_SHIFT`, `KS_CTRL`, `KS_ALT`, `KS_META`. |
+| `KS_HAS_ALT(s)` | Macro: true when Alt or Cmd is held without Ctrl/Shift. |
+| `STATE_` | Page-state enum in `zt.h` — `STATE_PEDIT`, `STATE_IEDIT`, etc. Tracks which page is active. |
+| `CMD_` | Command enum (similar to STATE; some pages use it for action dispatch). |
+| `CUI_` | Page class — `CUI_Patterneditor`, `CUI_Sysconfig`. Subclass of `CUI_Page`. |
+| `UIP_` | Global page instance — `UIP_Patterneditor`, `UIP_Sysconfig`. Pointer to the singleton `CUI_*` page. |
+| `ZTM_` | Constants from `module.h` — `ZTM_MAX_PATTERNS = 256`, etc. |
+| `MAX_` | Limits — `MAX_TRACKS = 64`, `MAX_INSTS = 100`, `MAX_MIDI_INS = 64`. |
+| `BUTTON_` | Mouse button event constants — `BUTTON_DOWN_LEFT`, `BUTTON_UP_LEFT`. |
+| `MM_` | Main menu entry types — `MM_FUNC` (run a callback), `MM_PAGE` (jump to a page), etc. |
+| `SDLK_` / `SDL_SCANCODE_` | SDL3 key symbol / scancode. |
+
+## Layout macros (`zt.h`)
+
+| Macro | Value |
+|---|---|
+| `INITIAL_ROW` | 1 |
+| `PAGE_TITLE_ROW_Y` | `INITIAL_ROW + 8` = 9 |
+| `TRACKS_ROW_Y` | `PAGE_TITLE_ROW_Y + 2` = 11 |
+| `SPACE_AT_BOTTOM` | 8 (toolbar reserves bottom 8 char rows) |
+| `CHARS_X` / `CHARS_Y` | Total character grid for current resolution |
+| `FONT_SIZE_X` / `FONT_SIZE_Y` | 8 / 8 (pixels per character cell) |
+
+## Page F-keys
+
+| Key | Page |
+|---|---|
+| F1 | Help |
+| F2 | Pattern Editor (F2 again → Pattern Settings popup) |
+| F3 | Instrument Editor |
+| F4 | MIDI Macro Editor (toggle to Arpeggio Editor when already on it) |
+| Shift+F4 | Arpeggio Editor |
+| F5 | Song Play |
+| F6 | Pattern Play |
+| F7 | Start at current row / Shift+F7: from current order |
+| F8 | Stop playback |
+| F9 | Panic / Shift+F9: hard panic |
+| F10 | Song Message Editor |
+| F11 | Song Configuration / Order Editor |
+| F12 | System Configuration |
+| Shift+Ctrl+F12 | Palette Editor |
+| Alt+F12 | About |
+
+## File chunks (`.zt` song format)
+
+| Chunk | Contents |
+|---|---|
+| MMAC | MIDI Macros |
+| ARPG | Arpeggios |
+| (other chunks: see `module.cpp` save/load paths) | |

--- a/.claude/skills/ztrackerprime/recipes/add-page.md
+++ b/.claude/skills/ztrackerprime/recipes/add-page.md
@@ -1,0 +1,37 @@
+# Recipe: add a new page
+
+A "page" is a top-level screen reachable via an F-key (or via the ESC main menu). Examples: F2 Pattern Editor, F3 Instrument Editor, F12 Sysconfig, Shift+F4 Arpeggio Editor.
+
+## What to wire up
+
+1. **Add a `STATE_<NAME>` to the enum in `src/zt.h`** (around line 328). Order matters only insofar as `DEFAULT_STATE` and any code switching on the enum keep working — append to the end if unsure.
+
+2. **Declare the page class in `src/CUI_Page.h`** as a subclass of `CUI_Page`. Implement the four pure-virtuals:
+   - `enter()` — called when the page becomes active. Allocate widgets, set initial state.
+   - `leave()` — called when leaving. Free widgets if `enter()` allocated them.
+   - `update()` — per-frame logic.
+   - `draw(Drawable *S)` — per-frame rendering.
+
+3. **Create `src/CUI_<Pagename>.cpp`** alongside the existing `CUI_*.cpp` files. Implement the four methods. The page typically owns a `UserInterface *UI` (inherited) and adds widgets to it during `enter()`.
+
+4. **Add a global page instance** somewhere main.cpp can see (typically `extern CUI_<Pagename> *UIP_<Pagename>;` in a header, definition where the page list is constructed).
+
+5. **Wire the F-key in `keyhandler()` in `src/main.cpp`** — find the existing block of `case SDLK_F<n>:` handlers (around line 1670+) and add a `switch_page(UIP_<Pagename>);` call. Set the matching `STATE_<NAME>` if the page tracks it.
+
+6. **Add the source file to `CMakeLists.txt`.** Existing `CUI_*.cpp` files are listed near the build target's source list; insert there.
+
+7. **Add a help section to `doc/help.txt`.** Match the existing `|L|%==|H|<Title>|L|==%|U|` format. Document the F-key and any page-specific keybinds.
+
+8. **Add a CHANGELOG entry** to `doc/CHANGELOG.txt`.
+
+## Optional but recommended
+
+- **ESC main menu entry** in `src/CUI_MainMenu.cpp` — users who don't memorise F-keys reach the page through here. Add an entry of the form `{MM_FUNC, "Page Name", NULL, 0, mm_<page>_handler}` (or `MM_PAGE` if jumping directly).
+- **Unit tests** if the page has non-trivial decision logic. Extract pure functions into a header (see `references/test-harness.md`) and add a CTest suite.
+
+## Pitfalls
+
+- **Forgetting `leave()` cleanup** — widgets allocated in `enter()` and not freed leak across page switches.
+- **Skipping help.txt** — the in-app F1 help is the user's primary discovery path; out-of-date help is a real bug.
+- **Forgetting CMakeLists.txt** — the file builds locally only if it's in the source list; missing entries cause CI failures across the 5-platform matrix.
+- **Hard-coded layout coordinates** — use `INITIAL_ROW`, `PAGE_TITLE_ROW_Y`, `TRACKS_ROW_Y`, `SPACE_AT_BOTTOM` from `zt.h` instead of literals so the page survives resolution changes.

--- a/.claude/skills/ztrackerprime/recipes/add-test-suite.md
+++ b/.claude/skills/ztrackerprime/recipes/add-test-suite.md
@@ -1,0 +1,35 @@
+# Recipe: add a new CTest suite
+
+The harness is for pure-decision regression tests. If you've extracted a class of bug into a pure-function header (`*_decision.h`, `*_apply.h`), add a suite.
+
+## What to write
+
+1. **Pure header in `src/`** — no SDL, no globals, no I/O. A struct of inputs, a struct of outputs, one pure function. See `src/preset_selector.h`, `src/save_key_dispatch.h`, `src/page_sync.h` for examples.
+
+2. **Test file in `tests/test_<name>.cpp`** — `#include` the header, write a `main()` that runs assertion-style checks and prints a one-line summary. Existing suites use simple `if (!cond) { fprintf(stderr, "FAIL: ..."); return 1; }` patterns — no test framework.
+
+3. **CMakeLists registration** in `tests/CMakeLists.txt`:
+   - Add `add_executable(test_<name> test_<name>.cpp ...)` — list any extra source files (e.g., `module_stub.cpp`) the test needs.
+   - Add `add_test(NAME test_<name> COMMAND test_<name>)`.
+
+## Staying SDL-free
+
+If your code under test pulls in SDL transitively, two escape hatches exist:
+
+- **`tests/sdl_stub.h`** — defines the minimal `SDL_KMOD_*` and `SDLK_*` symbols used by `keybuffer.h`. Activate by defining `ZT_TEST_NO_SDL` before including the header. Used by `test_keybuffer` to pull in production `src/keybuffer.cpp` directly.
+
+- **`tests/module_stub.cpp`** — minimal `arpeggio` / `midimacro` constructors. Link this instead of `src/module.cpp` (which `#include`s `zt.h` and pulls the world).
+
+If your header needs more SDL surface than `sdl_stub.h` exposes, prefer extending the stub over linking SDL into the test binary — keep tests fast and CI-portable.
+
+## Run
+
+```sh
+cd build && ctest --output-on-failure
+```
+
+Or run a single suite directly: `./build/tests/test_<name>`.
+
+## When to extract
+
+Don't pre-emptively extract every helper into a tested header. The trigger is: **a class of bug has bitten more than once** (preset apply revert, save-key dispatch confusion, button-up event consumption, ring-buffer drain). At that point the cost of writing a test is amortised across the bugs it'll catch.

--- a/.claude/skills/ztrackerprime/recipes/add-widget.md
+++ b/.claude/skills/ztrackerprime/recipes/add-widget.md
@@ -1,0 +1,54 @@
+# Recipe: add a new widget
+
+Widgets are subclasses of `UserInterfaceElement` (declared in `src/UserInterface.h`). Pages add them to their `UserInterface *UI`, which then dispatches input + render calls.
+
+## The contract
+
+`UserInterfaceElement` declares two pure-virtuals every subclass must implement:
+
+```cpp
+virtual int update() = 0;
+virtual void draw(Drawable *S, int active) = 0;
+```
+
+Plus an optional override:
+
+```cpp
+virtual int mouseupdate(int cur_element);
+```
+
+Returns the new `cur_element` if the widget claims focus (typically `this->ID`), or the input value if not.
+
+## Where to put it
+
+- **Declare** in `src/UserInterface.h` alongside the existing widget classes.
+- **Implement** in `src/UserInterface.cpp`.
+
+Don't put widget code in a `CUI_*.cpp` file — pages are callers, widgets are reusable.
+
+## What goes in each method
+
+- **`update()`** — keyboard/state handling. Read `Keys` (the global `KeyBuffer`) for any keys you consume. Return non-zero if the widget changed state and the page should redraw.
+- **`draw(Drawable *S, int active)`** — render to `S`. The `active` flag tells you whether this widget has focus (highlight differently when true).
+- **`mouseupdate(int cur_element)`** — handle mouse hits. Test the click against your bounding rect (`x`, `y`, `xsize`, `ysize` are inherited). Return `this->ID` to claim focus; pass `cur_element` through otherwise.
+
+## ListBox subclasses: read first
+
+If you're subclassing `ListBox`, **read [`../references/foot-guns.md`](../references/foot-guns.md)** first. The `mousestate` invariant has caused hard-to-diagnose UI freezes more than once. Two rules:
+
+1. Don't reset `mousestate` at the top of `mouseupdate` — must run after the switch.
+2. Don't call `ListBox::OnSelect(selected)` from a subclass override during click handling — the base sets `mousestate=0`, which clobbers the BUTTON_UP path.
+
+## Defaults belong in the constructor
+
+If every caller will set the same value (`xsize`, color, padding), put it in the constructor — don't make every page configure the same thing. See [`../references/foot-guns.md`](../references/foot-guns.md) "widget-class fixes belong upstream."
+
+## ID and registration
+
+Widgets are added to a `UserInterface` and given an integer ID. Pages typically use a small enum of IDs at the top of the `.cpp` so navigation logic (`UI->cur_element`) can reference them by name.
+
+## Pitfalls
+
+- **Zero `xsize` / `ysize`** — mouse hit-tests fail silently. The widget appears on screen but can't be clicked or focused.
+- **Returning the wrong value from `mouseupdate`** — return `this->ID` only when claiming focus; otherwise pass `cur_element` through.
+- **Per-caller hacks for visual polish** — if multiple callers tweak the same property, fix the widget itself instead.

--- a/.claude/skills/ztrackerprime/references/cli-flags.md
+++ b/.claude/skills/ztrackerprime/references/cli-flags.md
@@ -1,0 +1,36 @@
+# CLI flags + Copy Relaunch Command
+
+zt accepts named CLI flags parsed by `zt_parse_cli` in `main.cpp`.
+
+## Flags
+
+| Flag | Effect |
+|---|---|
+| `-h`, `--help` | Print usage + exit. Works without SDL/MIDI/display. |
+| `--list-midi-in` | List MIDI input ports + exit. |
+| `--midi-in <name\|index>` | Open the named port at startup. Repeatable. |
+| `--midi-clock <name\|index>` | Open + enable `midi_in_sync` + `midi_in_sync_chase_tempo`. |
+
+First positional arg = .zt song to load.
+
+## Parser conventions
+
+- **Order-independent** — flags can appear before or after the song path.
+- **Two value forms** — `--flag value` and `--flag=value` both work.
+- **Dash-tolerant** — `-flag` and `--flag` both parse. (Bare words still need at least one `-`; `zt help` does *not* match `--help`.)
+- **Repeatable `--midi-in`** — internal cap is `midi_in_ports[16]`.
+
+## Helpers
+
+- `zt_print_cli_help` — prints usage, called for `-h`/`--help` and on parse error.
+- `zt_resolve_midi_in_port` — name-or-index lookup against MIDI in port table.
+- `zt_cli_match_flag` / `zt_cli_match_flag_with_value` — flag matchers tolerating `=` and dash count.
+- `zt_cli_strip_leading_dashes` — requires ≥1 dash, so bare positional args don't accidentally match flags.
+
+## Copy Relaunch Command (ESC menu)
+
+`mm_copy_relaunch_cmd()` in `src/CUI_MainMenu.cpp` reads current session state — open MIDI in ports, MIDI clock chase target, loaded song path — and emits a one-line `zt --midi-clock "X" --midi-in "Y" song.zt` invocation to the system clipboard via `SDL_SetClipboardText`.
+
+Pairs with the CLI flags for stage / live / chat-handoff workflows: copy the relaunch line on one machine, paste on another to bring up the same MIDI routing + song.
+
+The menu entry lives under File: `{MM_FUNC, "Copy Relaunch Command", NULL, 0, mm_copy_relaunch_cmd}`.

--- a/.claude/skills/ztrackerprime/references/conventions.md
+++ b/.claude/skills/ztrackerprime/references/conventions.md
@@ -1,0 +1,42 @@
+# Coding conventions
+
+The codebase predates modern C++ style. Follow the existing idioms rather than imposing new ones.
+
+## File layout
+
+- Headers in `src/*.h`, implementations in `src/*.cpp`. A handful of header-only modules use `.hpp` (`CUI_FileLists_Common.hpp`).
+- Pure-data / pure-decision modules added since PR #64 are header-only `.h` files (`preset_data.h`, `preset_selector.h`, `page_sync.h`, `save_key_dispatch.h`, `editor_layout.h`).
+- Pages live in `src/CUI_<Pagename>.{h,cpp}` and inherit from `CUI_Page`.
+
+## Header guards
+
+Style varies. New headers use `#ifndef _<NAME>_H_ / #define _<NAME>_H_ / #endif`. Don't switch existing files to `#pragma once`.
+
+## Include order
+
+Implementation files typically include local headers first, then SDL/system headers, then `<stdio.h>`/`<string.h>` etc. Don't reorder unless the change is the point of the patch.
+
+## Naming
+
+- Classes: `PascalCase` (`CheckBox`, `ValueSlider`, `CUI_Patterneditor`).
+- Functions: mixed — older code is `lower_snake`, newer code is sometimes `camelCase`. Match the surrounding file.
+- Constants / macros: `UPPER_SNAKE` (`KS_HAS_ALT`, `INITIAL_ROW`, `STATE_PEDIT`).
+- Page globals: `UIP_<Pagename>` for the `CUI_Page*` instance, `STATE_<NAME>` for the state enum.
+
+## Status-bar diagnostic idiom
+
+To trace which code path fired in a UI bug, set `status_change=1; statusmsg="...";` in the suspected branch. The status bar then displays the message until the next change. Useful when the user can't observe internal state otherwise.
+
+Don't ship leftover diagnostic messages — strip them once the bug is fixed.
+
+## SDL3, not SDL2
+
+`#include <SDL.h>` resolves to SDL3. Keys are `SDL_SCANCODE_*` and `SDLK_*`; events are `SDL_EVENT_*`. Use the SDL3 API; don't paste SDL2 patterns.
+
+## Lua
+
+Lua is statically linked from `extlibs/lua/`. The Lua console (F-key bound) lives in `src/CUI_LuaConsole.cpp`. Don't add new Lua bindings without checking the existing `lua_*` glue and CMake setup.
+
+## "Don't add what isn't asked for"
+
+zTracker is a 25-year-old codebase with a tight contract. Avoid speculative refactors, premature abstractions, or bringing modern-C++ features into legacy modules just because they're available. Match the surrounding style; touch one thing at a time.

--- a/.claude/skills/ztrackerprime/references/foot-guns.md
+++ b/.claude/skills/ztrackerprime/references/foot-guns.md
@@ -1,0 +1,55 @@
+# Recurring foot-guns
+
+Bug classes that have bitten more than once. Read before debugging UI freezes, click-handling weirdness, or "the same fix in five files."
+
+## ListBox subclass mousestate fragility
+
+`ListBox::mouseupdate` has a subtle invariant: `mousestate` must be non-zero when `BUTTON_UP_LEFT` arrives, because `act++` is gated on it. If `act` doesn't increment, `Keys.getkey()` is never called and the up event sits forever in the FIFO, blocking every subsequent input.
+
+Two ways `mousestate` gets clobbered prematurely:
+
+1. **Pre-switch reset.** `if (!bMouseIsDown) mousestate = 0;` AT THE TOP of `mouseupdate` clears it before the switch sees BUTTON_UP. The reset must run AFTER the switch so the BUTTON_UP_LEFT case can still observe `mousestate==1` for the listbox that owns the click.
+
+2. **Premature `ListBox::OnSelect(selected)` from a subclass.** The base `ListBox::OnSelect` sets `mousestate = 0`. If a subclass override calls it during click handling (between BUTTON_DOWN and BUTTON_UP), mousestate clears early — same freeze. Don't call `ListBox::OnSelect` from a subclass; the BUTTON_UP_LEFT case clears mousestate itself.
+
+**Symptom:** "click on widget freezes the UI; Cmd-Tab unfreezes it." The Cmd-Tab unfreeze is `SDL_EVENT_WINDOW_FOCUS_GAINED → Keys.flush()` in `src/main.cpp::zt_handle_platform_window_event`.
+
+## Widget-class fixes belong upstream
+
+When a rendering or behavior bug appears on **multiple pages with the same widget**, fix it in `src/UserInterface.cpp` (the widget class), not in each `CUI_*.cpp` caller.
+
+If you're editing the same property (`xsize`, `frame`, color, padding) across more than two callers to fix the *same visual problem*, **stop and refactor**. The call sites are symptomatic; the widget's `::draw()` or constructor is the real bug.
+
+Concrete patterns this catches:
+
+- **Default values in the constructor.** Every caller setting `cb->xsize = 5` → set it once in the constructor.
+- **Cap or ignore caller-supplied values inside `::draw()`** when callers historically passed bad values. Example: `CheckBox::draw` caps the wipe extent at 3 (the "Off" width) regardless of `xsize`, so legacy `xsize=5` callers don't bleed.
+- **Make a flag a no-op** if every caller's correct value is the same. Example: `CheckBox::frame` is a no-op — every audit ended with removing `frame=1`, so the frame block was deleted from `CheckBox::draw`.
+- **Sentinel cases stay in the caller.** A `MidiOutDeviceOpener` with custom `xsize`, a `BankSelectCheckBox` overriding click behavior — those *are* per-caller. Don't push genuinely-distinct logic into the base widget.
+
+Heuristic: if a series of caller-side edits keep fixing the same visual issue, the next fix should be upstream.
+
+## User-reported inputs are ground truth
+
+When the user reports a specific input ("I pressed Ctrl-S"), that IS what they pressed. Do not respond by substituting a different input ("you were probably pressing Cmd-S" / "you might have meant X"). That is gaslighting — overwriting their observation with a hypothesis convenient for the model.
+
+**Banned phrasings (any variant):**
+- "Most likely cause: you were pressing X (instead of what you said)"
+- "You probably / likely / actually pressed [something else]"
+- "Maybe you're hitting [different key]"
+- Any sentence whose effect is to substitute the user's reported input with model speculation.
+
+**When the trace doesn't explain the symptom**, the model is wrong, not the user. Allowed responses:
+
+1. Say so. "I traced Ctrl-S through the dispatch and can't see why it would freeze. I'm missing something."
+2. Ask for more detail. "Is the cursor still moving? Do toolbar clicks still respond? Does the status bar update?"
+3. Ask which binary they're running.
+4. Add diagnostic output. Insert `status_change=1; statusmsg=...` in the suspected branch to verify which path fired.
+
+## Pre-switch / pre-return cleanup that defeats observability
+
+Generalisation of the ListBox case. Resetting state at the *top* of an event handler — before the switch dispatches the current event — clobbers the very state the dispatch is supposed to see. If a state field gates downstream behavior (`act++`, `dirty=1`, an event-consumed flag), reset it AFTER the switch, not before. When in doubt: trace one event end-to-end, note which fields it depends on at each step, and only clear those fields *after* the last reader.
+
+## Saturated ring buffer with `head == tail`
+
+`KeyBuffer` originally checked `head != tail` to gate read/peek. Fails when the buffer is exactly full (head wraps back to tail). Fix: gate on `cursize > 0`. If you write a fixed-capacity ring with two pointers, also keep a count.

--- a/.claude/skills/ztrackerprime/references/keyboard.md
+++ b/.claude/skills/ztrackerprime/references/keyboard.md
@@ -1,0 +1,39 @@
+# Keyboard conventions
+
+## Modifier state
+
+`keybuffer.h` tracks four modifier bits in `kstate`:
+
+| Bit | Modifier |
+|---|---|
+| `KS_SHIFT` | Shift |
+| `KS_CTRL` | Control |
+| `KS_ALT` | Alt / Option |
+| `KS_META` | macOS Cmd / Windows Super |
+
+## macOS Cmd is a compound state
+
+`SDL_KMOD_GUI` on Apple maps to `KS_META | KS_ALT`. So every Alt+ shortcut also fires under Cmd+. **Don't write `kstate == KS_ALT`** — it fails on macOS. Use the macro:
+
+```c
+#define KS_HAS_ALT(s) (((s) & KS_ALT) && !((s) & (KS_CTRL | KS_SHIFT)))
+```
+
+`KS_HAS_ALT(s)` is true for plain Alt and for Cmd, false when Ctrl or Shift is also held.
+
+## § (section sign) on Finnish/EU ISO keyboards
+
+The § key sends `SDL_SCANCODE_NONUSBACKSLASH` (sometimes `INTERNATIONAL1`/`2`/`3`). In `keyhandler()` (`src/main.cpp`), those scancodes are remapped to `SDLK_GRAVE` so existing bindings work on non-US layouts:
+
+- Plain § → Note Off.
+- Shift+§ → drawmode toggle.
+
+If you bind a new key, **also test with Finnish layout** — § / `<` / `>` / `[` / `]` are positioned differently from US layouts.
+
+## macOS NSApp menu strips
+
+`Cmd-Q` is stripped from the auto-created NSApp menu so the Pattern Editor can use it (Transpose-Up). `Cmd-W` is stripped similarly so it doesn't dismiss the SDL window.
+
+## Updating help.txt
+
+When adding a shortcut, update `doc/help.txt` in the same PR. The in-app F1 help reads from this file; out-of-date help is an outright bug.

--- a/.claude/skills/ztrackerprime/references/keyjazz-slot.md
+++ b/.claude/skills/ztrackerprime/references/keyjazz-slot.md
@@ -1,0 +1,23 @@
+# Keyjazz slot pattern (Shift+F4)
+
+The Arpeggio editor uses a dedicated focusable UIE (`ArKeyjazzFocus`, id `KEYJAZZ_ID`) as the keyjazz target instead of always-on keyjazz handling.
+
+## Why a slot, not always-on
+
+Always-on keyjazz competes with letter-key handlers in TextInputs and listbox typeahead. A slot gives an explicit, visible mode toggle: focus the slot to keyjazz, focus anything else to type/scroll.
+
+## Anatomy
+
+- **Class:** subclass of `UserInterfaceElement` with id `KEYJAZZ_ID`.
+- **`xsize`/`ysize`:** non-trivial so click-to-focus works (the click hit-test runs against the bounding rect).
+- **`update()`:** no-op.
+- **`mouseupdate()`:** handles click-to-focus and returns `this->ID`.
+- **`draw()`:** empty — the page-level `draw()` paints the visible Keyjazz panel and switches its colors based on `UI->cur_element == KEYJAZZ_ID` (active = highlighted, inactive = dim).
+- **Page-level keypress handler:** gates on `focused == KEYJAZZ_ID` to fire `MidiOut->noteOn` + `jazz_set_state(sym, note, chan)`.
+- **Note-off:** main.cpp's existing key-up path detects `jazz_note_is_active(sym)` on release and fires `noteOff` automatically — no extra wiring needed in the slot.
+
+## Replicating the pattern elsewhere
+
+If another page wants keyjazz audition, mirror the same five pieces: stub UIE with non-trivial bounds, page-level highlight in `draw()`, page-level keydown gated on focus, rely on main.cpp's keyup path.
+
+Pitfall: if `xsize`/`ysize` are zero, click-to-focus silently fails — the user sees no response and assumes the panel is decorative.

--- a/.claude/skills/ztrackerprime/references/test-harness.md
+++ b/.claude/skills/ztrackerprime/references/test-harness.md
@@ -1,0 +1,35 @@
+# Test harness
+
+`tests/` has CTest-driven unit-test executables. Linux CI runs them after every push.
+
+## Run
+
+```sh
+cd build && ctest --output-on-failure
+```
+
+Each suite is a standalone executable: `build/tests/test_presets`, `test_selector`, `test_page_sync`, `test_save_key`, `test_keybuffer`.
+
+## Suites
+
+| Suite | What it covers |
+|---|---|
+| `test_presets` | Preset arrays + `*_apply_preset_to(struct*, idx)` functions in `preset_data.h` |
+| `test_selector` | Listbox decision logic (click / arrow / Space / P-cycle) in `preset_selector.h` |
+| `test_page_sync` | F4/Shift+F4 widget↔data sync per-frame cycle in `page_sync.h` |
+| `test_save_key` | Global Ctrl-S dispatch decisions in `save_key_dispatch.h` |
+| `test_keybuffer` | Real `src/keybuffer.cpp` compiled SDL-free |
+
+## Staying SDL-free
+
+Two stub strategies in `tests/`:
+
+1. **`tests/module_stub.cpp`** — minimal `arpeggio` / `midimacro` constructors. Linked instead of `src/module.cpp` (which `#include`s `zt.h` and pulls in the world).
+
+2. **`tests/sdl_stub.h`** — tiny header providing only the `SDL_KMOD_*` constants and a few `SDLK_*` codes used by keybuffer logic. Activated by defining `ZT_TEST_NO_SDL` before `#include "keybuffer.h"`. Lets the production `keybuffer.cpp` compile straight into a test binary.
+
+## Decision-extraction pattern
+
+When a class of UI bug has bitten more than once (preset apply, save-key dispatch, button-up consumption), don't write yet another targeted patch. Extract the decision logic into a header (`preset_selector.h`, `save_key_dispatch.h`, `page_sync.h`) — pure functions, no SDL — and add a CTest suite. Each header is one bug class with regression coverage.
+
+The pattern: callers in `CUI_*.cpp` collect inputs (mouse coords, key state, listbox row), pass them to a pure decision function, and act on the returned action enum. The pure function is what the test exercises; the caller is mechanical glue.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file is loaded automatically by Claude Code (and other AI agents that support `CLAUDE.md`) when working in this repo. It distills the conventions and gotchas that have been learned the hard way during zTracker Prime development. **Read this before making changes.**
 
+For deeper material — recipes, foot-gun details, effect reference, glossary, coding conventions — see [`.claude/skills/ztrackerprime/SKILL.md`](.claude/skills/ztrackerprime/SKILL.md) and the `references/` + `recipes/` directories alongside it.
+
 ---
 
 ## Repository overview

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,167 @@
+# CLAUDE.md — contributor notes for AI assistants
+
+This file is loaded automatically by Claude Code (and other AI agents that support `CLAUDE.md`) when working in this repo. It distills the conventions and gotchas that have been learned the hard way during zTracker Prime development. **Read this before making changes.**
+
+---
+
+## Repository overview
+
+**zTracker Prime** (m6502/ztrackerprime) is Manuel Montoto's maintained fork of zTracker — an Impulse-Tracker-inspired MIDI tracker originally by Christopher Micali (2000–2001) with contributions from Daniel Kahlin. Manuel brought it to SDL 3 and cross-platform (Windows XP through 11, macOS, Linux).
+
+- **Language / build:** C++17, CMake, SDL 3.
+- **No audio:** zTracker is **MIDI-only**. There is no sample playback, no audio mixing. Pattern data drives MIDI Out events.
+- **Cross-platform:** Linux (apt), macOS (Homebrew SDL3), Windows MSVC (SDL3 dev zip), Windows MinGW XP-compat. CI builds all five.
+
+---
+
+## Build
+
+```sh
+mkdir -p build && cd build
+cmake -G "Unix Makefiles" ..   # or Ninja, MSVC, MinGW
+make -j8                       # produces build/Program/zt(.exe) (or zt.app on macOS)
+ctest --output-on-failure      # runs the unit-test harness
+```
+
+`extlibs/libpng` and `extlibs/zlib` must be populated; CI fetches them from upstream tarballs (see `.github/workflows/build.yml`). Lua is statically linked from `extlibs/lua/`.
+
+CMake option `ZT_BUILD_TESTS` (default ON) controls whether the `tests/` subdirectory builds. Production builds are unaffected.
+
+---
+
+## Key files
+
+| File | Purpose |
+|---|---|
+| `src/main.cpp` | Entry, main loop, key dispatch, `switch_page`, CLI parser. |
+| `src/CUI_Patterneditor.cpp` | Pattern editor (F2). 10+ pattern operations. |
+| `src/CUI_Midimacroeditor.cpp` | MIDI Macro editor (F4). |
+| `src/CUI_Arpeggioeditor.cpp` | Arpeggio editor (Shift+F4). |
+| `src/CUI_*.cpp` | Other pages: Sysconfig, Songconfig, Help, About, InstEditor, MainMenu, etc. |
+| `src/UserInterface.{h,cpp}` | Widget classes — `CheckBox`, `ValueSlider`, `TextInput`, `Frame`, `Button`, `TextBox`, `ListBox`, `MidiOutDeviceOpener`, `SkinSelector`, `VUPlay`. **Fix rendering bugs in the widget class, not at every caller.** |
+| `src/keybuffer.{h,cpp}` | Key buffer + KS_ALT/KS_CTRL/KS_META/KS_SHIFT state. `KS_HAS_ALT(s)` macro accepts ALT or macOS Cmd. Header has a `ZT_TEST_NO_SDL` guard so it can be compiled into SDL-free unit tests via `tests/sdl_stub.h`. |
+| `src/font.cpp` | `print()` / `printtitle()` / `printBG()` drawing primitives. |
+| `src/zt.h` | Kitchen-sink: `STATE_*` enum, `CMD_*` enum, page globals, layout macros (`TRACKS_ROW_Y`, `CHARS_Y`, `SPACE_AT_BOTTOM`, etc.). |
+| `src/module.{h,cpp}` | Song data: patterns, tracks, events, instruments, arpeggios, midimacros. |
+| `src/playback.{h,cpp}` | MIDI output timing, playback state, R-effect arpeggio + Z-effect macro dispatch. |
+| `src/preset_data.h` | F4/Shift+F4 preset arrays + pure `*_apply_preset_to(struct*, idx)` apply functions. Header-only, SDL-free, exhaustively unit-tested. |
+| `src/preset_selector.h` | Pure decision logic for the preset listbox (click / arrow / Space / P-cycle). Unit-tested. |
+| `src/page_sync.h` | F4/Shift+F4 widget↔data sync helpers. Prevents the "preset reverts on next frame" class of bug. |
+| `src/save_key_dispatch.h` | Global Ctrl-S dispatch (open save dialog / pass through / let page handle). Unit-tested. |
+| `src/editor_layout.h` | Shared character-grid constants for F4/Shift+F4 editors. |
+| `tests/` | CTest unit-test executables. 5 suites, 285+ checks. Linux CI runs them. |
+| `doc/help.txt` | In-app F1 help. **Update this when adding keybinds or CLI flags.** |
+| `doc/CHANGELOG.txt` | Release notes, chronological. |
+| `.github/workflows/build.yml` | CI: 5-platform build matrix + Linux ctest run. |
+
+---
+
+## Coordinate system (read this; it has tripped us up multiple times)
+
+- `row(N)` returns `N * FONT_SIZE_Y` = `N * 8` pixels. Despite the name, it's a **Y-pixel offset**.
+- `col(M)` returns `M * FONT_SIZE_X` = `M * 8` pixels. Despite the name, it's an **X-pixel offset**.
+- `print(x, y, str, color, drawable)` takes x first, y second.
+- Some legacy code calls `print(row(2), col(13), ...)` — that's **x = row(2)** (16 px) and **y = col(13)** (104 px = character row 13). Confusing but works because `FONT_SIZE_X == FONT_SIZE_Y`.
+
+Layout macros:
+- `INITIAL_ROW = 1`
+- `PAGE_TITLE_ROW_Y = INITIAL_ROW + 8 = 9` (title separator row)
+- `TRACKS_ROW_Y = PAGE_TITLE_ROW_Y + 2 = 11`
+- `SPACE_AT_BOTTOM = 8` (toolbar reserves the bottom 8 character rows)
+- `CHARS_Y` = total visible character rows for current resolution
+
+---
+
+## Keyboard conventions
+
+- **macOS Cmd** maps to `KS_META | KS_ALT`. Use `KS_HAS_ALT(kstate)` for "Alt or Cmd, but not Ctrl/Shift." Plain `kstate == KS_ALT` fails on macOS because Cmd produces a compound state.
+- **§ key on Finnish/EU ISO keyboards** is remapped from `SDL_SCANCODE_NONUSBACKSLASH` (and `INTERNATIONAL1`/`2`/`3`) to `SDLK_GRAVE` in `keyhandler()`. Plain § = Note Off; Shift+§ = drawmode toggle.
+- macOS `Cmd-Q` is stripped from the auto-created NSApp menu so the Pattern Editor can use it as Transpose-Up. macOS `Cmd-W` is stripped similarly so it doesn't dismiss the SDL window.
+- When adding shortcuts, **also update `doc/help.txt`**.
+
+---
+
+## CLI flags (see PR #68 / #69)
+
+```
+zt [options] [song.zt]
+
+  -h, --help                  Show usage and exit.
+      --list-midi-in          List MIDI input ports and exit.
+      --midi-in <name|index>  Open the named MIDI input. Repeatable.
+      --midi-clock <name|index>
+                              Open + enable midi_in_sync +
+                              midi_in_sync_chase_tempo (chase incoming F8).
+```
+
+Order-independent, accepts both `--flag value` and `--flag=value`, dash-count tolerant. First positional = .zt song.
+
+The ESC menu has a "Copy Relaunch Command" entry that captures current state (open MIDI in ports, MIDI clock chase target, loaded song) and emits a one-line `zt ...` invocation to the system clipboard. Pairs with the CLI flags for stage / live / chat-handoff workflows.
+
+---
+
+## Test harness
+
+`tests/` builds five CTest executables:
+
+- `test_presets` — preset arrays + apply functions.
+- `test_selector` — listbox click / arrow / Space / P-cycle decision logic.
+- `test_page_sync` — apply→refresh→sync per-frame cycle.
+- `test_save_key` — global Ctrl-S dispatch.
+- `test_keybuffer` — real `KeyBuffer` from `src/keybuffer.cpp`, compiled under `ZT_TEST_NO_SDL` against `tests/sdl_stub.h`.
+
+Run all: `ctest --test-dir build --output-on-failure`. CI runs them on the Linux job after every push.
+
+When you fix a class of bug that has bitten more than once (preset apply, save-key dispatch, button-up consumption), extract the decision logic into a header (`preset_selector.h`, `save_key_dispatch.h`, `page_sync.h`, etc.) and add tests. Bug-class regression test scaffolding has paid off multiple times in the F4/Shift+F4 work.
+
+---
+
+## Recurring foot-guns
+
+### ListBox subclass mousestate gotcha
+
+`ListBox::mouseupdate` relies on `mousestate` being non-zero when `BUTTON_UP_LEFT` arrives, because `act++` is gated on it. Two ways this gets clobbered:
+
+1. **Pre-switch reset.** `if (!bMouseIsDown) mousestate = 0;` at the **top** of `mouseupdate` clears mousestate BEFORE the switch sees BUTTON_UP. Result: the up event never increments `act`, `Keys.getkey()` is never called, the up event sits forever in the FIFO blocking every subsequent input. **The reset must run AFTER the switch.**
+
+2. **Premature `ListBox::OnSelect(selected)` in a subclass override.** Base `ListBox::OnSelect` sets `mousestate = 0`. If a subclass override calls it during click handling (between BUTTON_DOWN and BUTTON_UP), mousestate gets cleared early — same freeze. **Don't call `ListBox::OnSelect` from a subclass; the BUTTON_UP_LEFT case clears mousestate itself.**
+
+Symptom for the user: "click on widget freezes the UI; Cmd-Tab unfreezes it." The Cmd-Tab unfreeze is `SDL_EVENT_WINDOW_FOCUS_GAINED → Keys.flush()` (see `main.cpp::zt_handle_platform_window_event`).
+
+### Widget-class fixes belong upstream
+
+When a rendering or behavior bug appears on multiple pages with the same widget, fix it in `src/UserInterface.cpp` (the widget class), not in each `CUI_*.cpp` caller. If you find yourself editing the same property (`xsize`, `frame`, color) across more than two callers to fix the same visual problem, **stop and refactor**. The call sites are symptomatic; the widget's `::draw()` or constructor is the real bug.
+
+Examples:
+- **Default values in the constructor.** If every caller sets `cb->xsize = 5`, set it once in the constructor.
+- **Cap or ignore caller-supplied values inside `::draw()`** when callers historically passed bad values.
+- **Make a flag a no-op** if every caller's correct value is the same.
+- **Sentinel cases stay in the caller.** A `MidiOutDeviceOpener` with custom `xsize`, a `BankSelectCheckBox` overriding click behaviour — those *are* per-caller.
+
+### User-reported inputs are ground truth
+
+When the user says "I pressed Ctrl-S", that IS what they pressed. Do not respond with "you were probably pressing Cmd-S" / "most likely cause is X" / "you might have meant Y". That's gaslighting — overwriting their observation with a hypothesis that's more convenient because the model can't account for the bug.
+
+If the trace doesn't show how the reported input produces the symptom, the model is wrong, not the user. Allowed responses: "I'm stuck" + ask for more detail; "are you running the latest binary?"; insert a status_change diagnostic in the suspected branch.
+
+---
+
+## PR discipline
+
+- **Keep PRs focused.** Manuel's preferred size: 1 feature, ~30–300 LOC. Large kitchen-sink PRs are tolerated when the body has a clear table of contents.
+- Tag commits with `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` (or current model).
+- Don't merge to master without Manuel's approval — open PRs and let him review/merge.
+- `doc/CHANGELOG.txt` gets a section per PR.
+- Don't duplicate content across PRs.
+- Push branches directly to `origin` (no fork needed; Esa has write access).
+
+---
+
+## Common user behaviour (learned)
+
+- **"Launch the app"** = visibly running on the desktop, not just a process ID. Use `open .../zt.app`.
+- **Don't ask the user to test.** Run the binary yourself first and verify basic rendering, ideally with `scripts/zt-screenshot.sh`. Only ask the user when something requires their interactive judgement.
+- They use **Finnish keyboard layout**. § is critical. Plain § = Note Off, Shift+§ = drawmode.
+- **PR quality over PR count.** Finish one well before starting another.
+- **Don't lecture.** Be specific, show diffs, explain *why*, then act.
+- When the user pushes back ("that's not right"), they mean it. Stop, re-read literally, ask a clarifying question.


### PR DESCRIPTION
## Summary
- Adds a repo-root `CLAUDE.md` so AI assistants (Claude Code and others that honor the convention) get the project's hard-won conventions auto-loaded.
- Distillation of the global ztrackerprime contributor skill — covers build, key files, coordinate system, keyboard conventions, CLI flags, unit-test harness, and recurring foot-guns.

## Why
A lot of context has been learned the hard way over PRs #61–#69 (ListBox mousestate fragility, widget-class fixes belong upstream, the `print(x,y,...)` argument order, the keyjazz slot pattern, the test-harness layout, etc.). Having it in-repo means contributors and AI agents both pick it up without having to re-derive it.

## Notes
- No code changes, docs only.
- Doesn't affect the build, CI, or any runtime behavior.

## Test plan
- [x] Verified file renders as plain markdown
- [x] No build artifacts touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)