### PR TITLE
Hotfix: Pattern Editor 4 / 8 note audition + step (and 1 / § / .)

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,19 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_04_29 (Hotfix: Pattern Editor 4/8 note audition + step)
+---------------------------------------------------------------
+
+        * Pattern Editor: 4 (play current note + step) and 8 (play
+          current row + step) work again on the note column. The
+          2026-04-19 layout-independent-keys refactor switched the
+          T_NOTE dispatch from switch(key) to switch(scancode) and
+          converted the note-row letters to SDL_SCANCODE_*, but left
+          the editing-key cases (4, 8, 1, ., §) as SDLK_* — making
+          them dead code in a scancode switch. Restored: 1 (note
+          off), § (note cut), . (clear), 4 (audition note), 8
+          (audition row).
+
 zt 2026_04_25 (Minor tweaks: status messages, help nav, F4 binding)
 -------------------------------------------------------------------
 

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -2957,15 +2957,20 @@ case SDLK_DELETE:
                       case SDL_SCANCODE_J: set_note = (12*(base_octave-1))+10;break;
                       case SDL_SCANCODE_M: set_note = (12*(base_octave-1))+11;break;
                         /* EDITING KEYS */
-                      case SDLK_1: set_note = 0x81; break;      
-                      case SDLK_GRAVE: set_note = 0x82; break;  
-                      case SDLK_PERIOD: 
+                        // Switch is on scancode (see line 2920); use
+                        // SDL_SCANCODE_* here too. Mixing SDLK_* into a
+                        // scancode switch silently makes the cases
+                        // dead — that broke 4/8 audition + step in the
+                        // 2026-04-19 layout-independent-keys refactor.
+                      case SDL_SCANCODE_1: set_note = 0x81; break;
+                      case SDL_SCANCODE_GRAVE: set_note = 0x82; break;
+                      case SDL_SCANCODE_PERIOD:
                         if (kstate != KS_SHIFT) {
-                          set_note = 0x80; 
+                          set_note = 0x80;
                         }
                         break;
                         /* ROW/NOTE PEEK PLAY */
-                      case SDLK_8:
+                      case SDL_SCANCODE_8:
                         
                         ztPlayer->play_current_row();
                         
@@ -2991,8 +2996,8 @@ case SDLK_DELETE:
                       
                         break;
                       
-                      case SDLK_4:
-                        
+                      case SDL_SCANCODE_4:
+
                         ztPlayer->play_current_note();
 
                         // <Manu> Hacemos avanzar el cursor


### PR DESCRIPTION
## What broke

In the note column, **4** (play current note + step) and **8** (play current row + step) stopped working. Manuel reported: *"4 and 8 don't step anymore... I absolutely depend on 4 and 8 to hear what I do."* Same dead-code class also disabled **1** (note off), **§** (note cut), and **.** (clear) on the note column.

## When + who

Commit 797e88e on 2026-04-19, *"use layout-independent scan codes for note keys"* (Grump megagrump@pm.me).

That refactor switched the T_NOTE column dispatch in src/CUI_Patterneditor.cpp from switch(key) to switch(scancode) and converted the note-row letters (Q W E R T Y U I O P + 2 3 5 6 7 9 0 + Z S X D C V G B H N J M) to SDL_SCANCODE_* — the right call for layout independence. But it left the five "editing key" cases at the bottom of the same switch as SDLK_*:

- case SDLK_1       // note off
- case SDLK_GRAVE   // note cut
- case SDLK_PERIOD  // clear
- case SDLK_8       // play_current_row() + cur_edit_row += cur_step
- case SDLK_4       // play_current_note() + cur_edit_row += cur_step

SDLK_* are keycodes (SDLK_4 = 0x34); SDL_SCANCODE_* are USB HID scancodes (SDL_SCANCODE_4 = 33). In a switch(scancode) they never match a real keypress — pure dead code since 2026-04-19.

## Fix

Convert all five to SDL_SCANCODE_* and add an inline comment so a future reader does not repeat the trap. Also adds a CHANGELOG.txt entry.

CUI_InstEditor.cpp was inspected — its scancode switch only contains note keys (no editing-key tail), so it is unaffected.

## Test plan

- [x] Builds clean on macOS
- [ ] Manual: in Pattern Editor on the note column, press **4** plays current note and advances by cur_step; press **8** plays current row and advances; press **1** enters note-off; press **§** enters note-cut; press **.** clears note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
