### PR TITLE
Hotfix: F10 robustness + Load/Save list clamps at edges

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,34 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_04_29 (Hotfix: F10 robustness + file dialog focus clamp)
+----------------------------------------------------------------
+
+        * F10 Song Message: backspacing past empty no longer crashes.
+          CDataBuf::popc had two unsigned-arithmetic bugs that
+          (a) decremented buffsize past zero on an empty buffer and
+          (b) wrapped the shrink-realloc check so a single backspace
+          on a 1024-allocated, single-byte buffer drove allocsize
+          negative and called realloc with a near-4 GB size. Both
+          paths now hard-guard against the underflow and only shrink
+          when the buffer is genuinely under-occupied.
+        * F10 Song Message: surviving a song reload while the page
+          is open. CUI_SongMessage::enter cached
+          song->songmessage->songmessage in the editor's target field;
+          loading a different song deleted the underlying CDataBuf and
+          left target dangling. The page now re-binds target every
+          frame from the live song chain and null-guards each step
+          (song / songmsg / CDataBuf) so a partial chain prints empty
+          rather than crashing.
+        * UserInterface: CommentEditor::refresh_display handles a
+          failed realloc instead of dereferencing NULL.
+        * File Load / Save lists: pressing Up at the first row or
+          Down at the last row now clamps at the edge instead of
+          jumping focus into a sibling list. The base ListBox
+          behaviour (added for Sysconfig in #18) is preserved
+          everywhere else; FileList opts out via a new
+          wrap_focus_at_edges flag. Tab still moves between lists.
+
 zt 2026_04_29 (Note audition step is configurable)
 --------------------------------------------------
 

--- a/src/CDataBuf.cpp
+++ b/src/CDataBuf.cpp
@@ -95,13 +95,30 @@ void CDataBuf::pushc(const char c) {
 }
 
 void CDataBuf::popc(void) {
-    if (this->buffsize-sizeof(char) < this->allocsize-DATABUF_CHUNK_SIZE-1) {
-        while(this->buffsize-sizeof(char) < this->allocsize-DATABUF_CHUNK_SIZE-1)
-            this->allocsize -= DATABUF_CHUNK_SIZE;
-        this->buffer = (char *)realloc(this->buffer, this->allocsize);
-    }
-    if (this->buffsize>0) {
-        --this->buffsize;
+    // Pop nothing on an empty buffer (otherwise --buffsize would
+    // underflow the unsigned counter, then a subsequent push would
+    // realloc to a near-4GB allocation and crash).
+    if (this->buffsize == 0)
+        return;
+    --this->buffsize;
+    // Shrink the allocation when the buffer is more than one full
+    // chunk smaller than the current allocation. The previous formula
+    // mixed unsigned arithmetic ((0u - 1) wraps to UINT_MAX) and
+    // could either skip the shrink entirely or, via the while loop,
+    // wrap allocsize negative and call realloc(buffer, ~4GB) — the
+    // F10 Song Message editor's Backspace path was crashing here.
+    if (this->allocsize >= 2 * DATABUF_CHUNK_SIZE &&
+        this->buffsize + DATABUF_CHUNK_SIZE < this->allocsize) {
+        unsigned int newalloc = this->allocsize;
+        while (newalloc >= 2 * DATABUF_CHUNK_SIZE &&
+               this->buffsize + DATABUF_CHUNK_SIZE < newalloc) {
+            newalloc -= DATABUF_CHUNK_SIZE;
+        }
+        char *nb = (char *)realloc(this->buffer, newalloc);
+        if (nb) {
+            this->buffer = nb;
+            this->allocsize = newalloc;
+        }
     }
 }
 

--- a/src/CUI_SongMessage.cpp
+++ b/src/CUI_SongMessage.cpp
@@ -70,9 +70,18 @@ void CUI_SongMessage::enter(void) {
     need_refresh++;
     cur_state = STATE_SONG_MESSAGE;
     CommentEditor *cb = (CommentEditor*)UI->get_element(0);
-    buffer = song->songmessage->songmessage;
-    cb->target = buffer;
-    cb->refresh_display();
+    // Defensive: a corrupt or partially loaded song could leave the
+    // songmessage chain incomplete. Bind target to NULL in that case
+    // rather than dereferencing through a missing link.
+    if (song && song->songmessage && song->songmessage->songmessage) {
+        buffer = song->songmessage->songmessage;
+    } else {
+        buffer = NULL;
+    }
+    if (cb) {
+        cb->target = buffer;
+        cb->refresh_display();
+    }
     zt_text_input_start();
 }
 
@@ -118,8 +127,20 @@ void CUI_SongMessage::draw(Drawable *S) {
     // Re-run the bottom-anchored sizing in case the window has been
     // resized since the page was constructed.
     CommentEditor *cb = (CommentEditor*)UI->get_element(0);
+    if (!cb) return;
     cb->xsize = TextBox::full_width_xsize();
     cb->ysize = (INTERNAL_RESOLUTION_Y/8) - cb->y - 8;
+    // Re-bind target every frame: a song load (Ctrl-L) deletes and
+    // re-creates song->songmessage, so any pointer cached in enter()
+    // would be left dangling. Re-fetching here keeps cb->target valid
+    // through page-resident song reloads.
+    CDataBuf *current = (song && song->songmessage)
+                        ? song->songmessage->songmessage
+                        : NULL;
+    if (cb->target != current) {
+        cb->target = current;
+        buffer = current;
+    }
     // Refresh the null-terminated display mirror so TextBox::draw has
     // a clean string to walk (CDataBuf is not null-terminated; reading
     // past the live byte count walks heap garbage).

--- a/src/FileList.cpp
+++ b/src/FileList.cpp
@@ -249,6 +249,11 @@ FileList::FileList()
     empty_message = (char *)"";
     is_sorted = true;
     use_checks = false;
+    // File Load/Save users navigate by arrow + Enter; the base
+    // ListBox behavior of jumping focus to a sibling list when Up/Down
+    // hits an edge sent them into the wrong list and lost their place.
+    // Clamp at edges instead — Tab still moves between lists.
+    wrap_focus_at_edges = false;
     updated = 1;
     OnChange();
     onEnter = NULL;

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -2042,6 +2042,7 @@ ListBox::ListBox()
   clear();
   is_sorted = false;
   use_key_select = true;
+  wrap_focus_at_edges = true;
   empty_message = NULL;
   use_checks = false;
   check_on = 251;
@@ -2564,7 +2565,7 @@ int ListBox::update() {
                 else
                 if (y_start>0)
                     y_start--;
-                else
+                else if (wrap_focus_at_edges)
                     ret = -1;  // At top of list, pass focus to previous element (#18)
                 act++;
                 break;
@@ -2574,7 +2575,7 @@ int ListBox::update() {
                         cur_sel++;
                     else
                         y_start++;
-                } else {
+                } else if (wrap_focus_at_edges) {
                     ret = 1;  // At bottom of list, pass focus to next element (#18)
                 }
                 act++;
@@ -3326,16 +3327,25 @@ void CommentEditor::refresh_display() {
         return;
     }
     int n = target->getsize();
+    if (n < 0) n = 0;
     int need = n + 1;
     if (need > _display_alloc) {
         int newalloc = _display_alloc ? _display_alloc : 64;
         while (newalloc < need) newalloc *= 2;
-        _display = (char*)realloc(_display, (size_t)newalloc);
+        char *nb = (char*)realloc(_display, (size_t)newalloc);
+        if (!nb) {
+            // realloc failed: keep the old buffer (may be too small),
+            // but never let TextBox::draw walk into garbage.
+            text = NULL;
+            return;
+        }
+        _display = nb;
         _display_alloc = newalloc;
     }
     if (n > 0) {
         const char *src = target->getbuffer();
         if (src) memcpy(_display, src, (size_t)n);
+        else n = 0;
     }
     _display[n] = '\0';
     text = _display;

--- a/src/UserInterface.h
+++ b/src/UserInterface.h
@@ -300,6 +300,15 @@ class ListBox : public UserInterfaceElement {
         int num_elements;
 //        int sorted;
         bool use_checks, use_key_select, is_sorted;
+        // When true (default), pressing Up at the first row or Down at
+        // the last row passes focus to the previous / next UI element
+        // (Sysconfig depends on this so the user can walk Skin Selector
+        // -> Key Wait -> MIDI Out without Tabbing). Set to false in
+        // contexts where the listbox should clamp at its edges and
+        // stay focused (file Load/Save dialogs — pressing past the end
+        // jumping into a different list confused users who navigate by
+        // arrow + Enter).
+        bool wrap_focus_at_edges;
         unsigned char check_on, check_off;
         const char *empty_message;
         LBNode *items;


### PR DESCRIPTION
Three independent fixes from Manuel's bug report. None of them touch the same area, but they all happen to come out of the same review pass and ship cleaner together.

## 1. F10 Song Message: backspace-on-empty crash (CDataBuf::popc)

`src/CDataBuf.cpp::popc()` had two unsigned-arithmetic bugs:

- On an empty buffer, `--this->buffsize` wrapped `unsigned int` to UINT_MAX. The next pushc would realloc to ~4 GB.
- The shrink-realloc check used `buffsize-1 < allocsize-CHUNK-1` as raw unsigned arithmetic. With buffsize=1 and allocsize=1024 (one chunk), the RHS underflowed to UINT_MAX, the while loop entered, and `allocsize -= CHUNK` wrapped negative before `realloc(buffer, ~4 GB)`.

Fixed both: empty popc is a no-op; the shrink only runs when the buffer is actually under-occupied (>= 2 chunks allocated AND at least a chunk's worth free); a failed realloc keeps the existing buffer rather than nulling out the editor display.

This is the most likely culprit for Manuel's "F10 crash after typing letters" — type a letter, hit Backspace, repeat past zero.

## 2. F10 Song Message: survive a song reload while the page is open

`zt_module::load_song_message` does `delete this->songmessage` and allocates a new `songmsg`. The Song Message editor cached the inner CDataBuf pointer in `CommentEditor::target` during `enter()`, which becomes dangling after a song load. If the user was on F10 when they Ctrl-L loaded a song, the next refresh_display walked freed memory.

`CUI_SongMessage::draw` now re-binds `cb->target` every frame from `song -> songmessage -> songmessage` with null-guards on each link. A partially-loaded song renders an empty editor instead of crashing.

`CommentEditor::refresh_display` also now handles a realloc failure cleanly.

## 3. File Load / Save lists: clamp arrows at edges

Manuel:

> do we really want to go to another list when pushing down or up after reaching the end? I'm 100% used to the key pushed and pushing enter and I'm getting lost and going to unexpected places all the time because the focus jumps to another list when I try to go to first or last elements.

The auto focus-jump in `ListBox::update` was added in #18 so Sysconfig users could walk Skin Selector -> Key Wait -> MIDI Out without Tabbing. File Load / Save dialogs inherited the same behaviour and it sent arrow-key navigators into the wrong list.

Added a `wrap_focus_at_edges` flag on `ListBox`, default `true` (preserves Sysconfig + every other ListBox subclass behaviour), and set it `false` in the `FileList` constructor. Tab still moves between lists explicitly.

## What's NOT in this PR

- **MIDI Out drop / half-speed playback**: still investigating. Manuel's update — *"loses connection after stopping the song, or after a few seconds"* + *"time is seemingly at half speed too"* — points at either the MIDI Clock chase path (`ztPlayer->chase_external_tempo` in src/midi-io.cpp around line 395) overwriting the live BPM, or stop()'s panic flow. I don't have a deterministic repro yet. Will follow up in a separate PR — please share the GBA synth's port name and the exact platform/build so I can reproduce.
- **The 4/8 note-audition regression** ships separately as #71 (already open).

## Test plan

- [x] Builds clean on macOS (warning-free for the touched files)
- [x] `ctest` passes all 5 suites (331 checks)
- [ ] F10: type letters, repeatedly Backspace past empty — no crash
- [ ] F10 -> Ctrl-L load a different song -> editor shows the new message (or empty), no crash
- [ ] Sysconfig (F12): arrow Up at top of Skin Selector still walks to Key Wait (regression check on the kept default)
- [ ] File Load (Ctrl-L): arrow Down at last entry stays put; Tab still moves to filename input

🤖 Generated with [Claude Code](https://claude.com/claude-code)
