### PR TITLE
Pattern Editor: configurable 4/8 audition step (0 / 1 / EditStep, default 1)

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,19 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_04_29 (Hotfix: Pattern Editor 4/8 note audition + step)
+---------------------------------------------------------------
+
+        * Pattern Editor: 4 (play current note + step) and 8 (play
+          current row + step) work again on the note column. The
+          2026-04-19 layout-independent-keys refactor switched the
+          T_NOTE dispatch from switch(key) to switch(scancode) and
+          converted the note-row letters to SDL_SCANCODE_*, but left
+          the editing-key cases (4, 8, 1, ., §) as SDLK_* — making
+          them dead code in a scancode switch. Restored: 1 (note
+          off), § (note cut), . (clear), 4 (audition note), 8
+          (audition row).
+
 zt 2026_04_25 (Minor tweaks: status messages, help nav, F4 binding)
 -------------------------------------------------------------------
 

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,25 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_04_29 (Note audition step is configurable)
+--------------------------------------------------
+
+        + Song Configuration (F11): new "4/8 Audition Step" slider
+          controls how far the cursor advances after the 4 (audition
+          note) and 8 (audition row) keys fire on the note column.
+          0 = stay on the current row, 1 = advance one row (default),
+          2 = advance by EditStep (the legacy behaviour).
+        + zt.conf: new key `note_audition_step_mode` with the same
+          0 / 1 / 2 values, persisted across sessions. Out-of-range
+          values are clamped to the default at load.
+        ! Default change: 4 / 8 now advance by 1 row. Users who
+          relied on EditStep-driven auditioning (set EditStep to 4
+          to step a quarter at a time, audition four notes per row
+          jump) can restore the prior behaviour by setting the
+          slider to 2 once.
+        ! Status line confirms each switch
+          ("Note audition (4/8): cursor advances 1 row" etc.).
+
 zt 2026_04_29 (Hotfix: Pattern Editor 4/8 note audition + step)
 ---------------------------------------------------------------
 

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -2957,15 +2957,20 @@ case SDLK_DELETE:
                       case SDL_SCANCODE_J: set_note = (12*(base_octave-1))+10;break;
                       case SDL_SCANCODE_M: set_note = (12*(base_octave-1))+11;break;
                         /* EDITING KEYS */
-                      case SDLK_1: set_note = 0x81; break;      
-                      case SDLK_GRAVE: set_note = 0x82; break;  
-                      case SDLK_PERIOD: 
+                        // Switch is on scancode (see line 2920); use
+                        // SDL_SCANCODE_* here too. Mixing SDLK_* into a
+                        // scancode switch silently makes the cases
+                        // dead — that broke 4/8 audition + step in the
+                        // 2026-04-19 layout-independent-keys refactor.
+                      case SDL_SCANCODE_1: set_note = 0x81; break;
+                      case SDL_SCANCODE_GRAVE: set_note = 0x82; break;
+                      case SDL_SCANCODE_PERIOD:
                         if (kstate != KS_SHIFT) {
-                          set_note = 0x80; 
+                          set_note = 0x80;
                         }
                         break;
                         /* ROW/NOTE PEEK PLAY */
-                      case SDLK_8:
+                      case SDL_SCANCODE_8:
                         
                         ztPlayer->play_current_row();
                         
@@ -2991,8 +2996,8 @@ case SDLK_DELETE:
                       
                         break;
                       
-                      case SDLK_4:
-                        
+                      case SDL_SCANCODE_4:
+
                         ztPlayer->play_current_note();
 
                         // <Manu> Hacemos avanzar el cursor

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -2970,57 +2970,58 @@ case SDLK_DELETE:
                         }
                         break;
                         /* ROW/NOTE PEEK PLAY */
+                        // 4 / 8 advance distance is configurable via
+                        // zt_config_globals.note_audition_step_mode:
+                        //   ZT_NAS_NONE     -> stay on the same row
+                        //   ZT_NAS_ONE      -> always advance by 1 row (default)
+                        //   ZT_NAS_EDITSTEP -> advance by cur_step (legacy)
                       case SDL_SCANCODE_8:
-                        
+
                         ztPlayer->play_current_row();
-                        
-                        // <Manu> Hacemos avanzar el cursor [EN: advance the cursor]
-                        
-                        cur_edit_row+=cur_step;
-            
+
+                        {
+                          int advance =
+                              (zt_config_globals.note_audition_step_mode == ZT_NAS_NONE)     ? 0 :
+                              (zt_config_globals.note_audition_step_mode == ZT_NAS_EDITSTEP) ? cur_step :
+                              1;
+                          cur_edit_row += advance;
+
                 // <MANU> 2 Feb 2005 - Arreglado el bug que impedia avanzar el scroll
                 //        mientras se tocaba la nota actual o la linea actual y llegabamos abajo
+                          if (advance > 0 &&
+                              (cur_edit_row-1 - cur_edit_row_disp) >= (PATTERN_EDIT_ROWS-1)) {
+                            if (cur_edit_row_disp <
+                                (song->patterns[cur_edit_pattern]->length - PATTERN_EDIT_ROWS)) {
+                              cur_edit_row_disp += advance;
+                            }
+                          }
+                        }
 
-                  if ((cur_edit_row-1 - cur_edit_row_disp) >= (PATTERN_EDIT_ROWS-1)) {
-                    
-                    if (cur_edit_row_disp<(song->patterns[cur_edit_pattern]->length - PATTERN_EDIT_ROWS)) {
-                      
-                      cur_edit_row_disp+=cur_step;
-                    }
-                  }
+                        need_refresh++;
 
-                        
-                        need_refresh++; 
-                        
-                        // ------------------
-                      
                         break;
-                      
+
                       case SDL_SCANCODE_4:
 
                         ztPlayer->play_current_note();
 
-                        // <Manu> Hacemos avanzar el cursor
-/*                        
-                        cur_edit_row++;
-                        cur_edit_row_disp++;
-*/
-                        cur_edit_row+=cur_step;
+                        {
+                          int advance =
+                              (zt_config_globals.note_audition_step_mode == ZT_NAS_NONE)     ? 0 :
+                              (zt_config_globals.note_audition_step_mode == ZT_NAS_EDITSTEP) ? cur_step :
+                              1;
+                          cur_edit_row += advance;
 
-                // <MANU> 2 Feb 2005 - Arreglado el bug que impedia avanzar el scroll
-                //        mientras se tocaba la nota actual o la linea actual y llegabamos abajo
+                          if (advance > 0 &&
+                              (cur_edit_row-1 - cur_edit_row_disp) >= (PATTERN_EDIT_ROWS-1)) {
+                            if (cur_edit_row_disp <
+                                (song->patterns[cur_edit_pattern]->length - PATTERN_EDIT_ROWS)) {
+                              cur_edit_row_disp += advance;
+                            }
+                          }
+                        }
 
-                  if ((cur_edit_row-1 - cur_edit_row_disp) >= (PATTERN_EDIT_ROWS-1)) {
-                    
-                    if (cur_edit_row_disp<(song->patterns[cur_edit_pattern]->length - PATTERN_EDIT_ROWS)) {
-                      
-                      cur_edit_row_disp+=cur_step;
-                    }
-                  }
-
-                  need_refresh++; 
-                        
-                        // ------------------
+                        need_refresh++;
 
                         break;
                         /* EVERYTHING ELSE */

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -144,6 +144,21 @@ CUI_Songconfig::CUI_Songconfig(void) {
         cb->xsize = 3;
         cb->value = &zt_config_globals.midi_in_sync_chase_tempo;
 
+        // 4 / 8 audition advance: 0 = stay, 1 = one row, 2 = use EditStep.
+        // Default 1 — the historical value-of-cur_step behaviour was
+        // surprising for users who set EditStep > 1 to lay coarse grids
+        // but still wanted single-row auditioning. Stored as a plain int
+        // so zt.conf round-trips it cleanly.
+        vs = new ValueSlider;
+        UI->add_element(vs, 10);
+        vs->frame = 0;
+        vs->x = 20;
+        vs->y = base_y + 13;
+        vs->xsize = 3;
+        vs->min = ZT_NAS_NONE;
+        vs->max = ZT_NAS_EDITSTEP;
+        vs->value = zt_config_globals.note_audition_step_mode;
+
         oe = new OrderEditor;
         UI->add_element(oe,9);
         oe->x = 59;
@@ -167,7 +182,13 @@ void CUI_Songconfig::enter(void) {
         zt_config_globals.highlight_increment = song->tpb;
     if(!zt_config_globals.lowlight_increment)
         zt_config_globals.lowlight_increment = song->tpb >> 1 / song->tpb / 2;
-    
+
+    // Reflect the live config value in the slider whenever this page
+    // is entered (config could have been changed elsewhere — e.g. by
+    // hand-editing zt.conf and reloading).
+    vs = (ValueSlider *)UI->get_element(10);
+    if (vs) vs->value = zt_config_globals.note_audition_step_mode;
+
     // F11 toggle: pressing F11 while already on Songconfig flips focus
     // between OrderEditor (id 9) and Title (id 0) on every press, so the
     // user can keep tapping F11 to alternate. Fresh entry from another
@@ -283,6 +304,27 @@ void CUI_Songconfig::update()
         if (cb && cb->changed)
             zt_config_globals.midi_in_sync_chase_tempo = *(cb->value);
     }
+    vs = (ValueSlider *)UI->get_element(10);
+    if (vs) {
+        if (vs->from_input) vs->from_input = 0;
+        if (vs->value < ZT_NAS_NONE)     vs->value = ZT_NAS_NONE;
+        if (vs->value > ZT_NAS_EDITSTEP) vs->value = ZT_NAS_EDITSTEP;
+        if (vs->value != zt_config_globals.note_audition_step_mode) {
+            zt_config_globals.note_audition_step_mode = vs->value;
+            switch (vs->value) {
+                case ZT_NAS_NONE:
+                    statusmsg = (char*)"Note audition (4/8): cursor stays on row";
+                    break;
+                case ZT_NAS_ONE:
+                    statusmsg = (char*)"Note audition (4/8): cursor advances 1 row";
+                    break;
+                case ZT_NAS_EDITSTEP:
+                    statusmsg = (char*)"Note audition (4/8): cursor advances by EditStep";
+                    break;
+            }
+            status_change = 1;
+        }
+    }
     if (Keys.size()) {
         Keys.getkey();
     }
@@ -308,6 +350,10 @@ void CUI_Songconfig::draw(Drawable *S) {
         printchar(row(20 + 27) + 1,col(base_y+9),0x84,COLORS.Highlight,S);
         print(row(4),col(base_y+11),"   MIDI In Sync",COLORS.Text,S);
         print(row(3),col(base_y+12),"Chase MIDI Tempo",COLORS.Text,S);
+        // 4 / 8 audition step mode label + inline legend explaining
+        // the three slider values (slider only renders the integer).
+        print(row(2),col(base_y+13),"4/8 Audition Step",COLORS.Text,S);
+        print(row(25),col(base_y+13)," (0=stay  1=row  2=editstep)",COLORS.Text,S);
         // Order List label aligned to the OE x-origin (col 59) — NOT shifted.
         print(row(59),col(11),"Order List",COLORS.Text,S);
         printchar(row(20 + 27) + 1,col(base_y+2),0x84,COLORS.Highlight,S);

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -350,10 +350,11 @@ void CUI_Songconfig::draw(Drawable *S) {
         printchar(row(20 + 27) + 1,col(base_y+9),0x84,COLORS.Highlight,S);
         print(row(4),col(base_y+11),"   MIDI In Sync",COLORS.Text,S);
         print(row(3),col(base_y+12),"Chase MIDI Tempo",COLORS.Text,S);
-        // 4 / 8 audition step mode label + inline legend explaining
-        // the three slider values (slider only renders the integer).
+        // 4 / 8 audition step mode label. The slider value is rendered
+        // wider than xsize so the legend goes on the row below to avoid
+        // colliding with the on-slider digits.
         print(row(2),col(base_y+13),"4/8 Audition Step",COLORS.Text,S);
-        print(row(25),col(base_y+13)," (0=stay  1=row  2=editstep)",COLORS.Text,S);
+        print(row(20),col(base_y+14),"0=stay  1=row  2=editstep",COLORS.Text,S);
         // Order List label aligned to the OE x-origin (col 59) — NOT shifted.
         print(row(59),col(11),"Order List",COLORS.Text,S);
         printchar(row(20 + 27) + 1,col(base_y+2),0x84,COLORS.Highlight,S);

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -253,6 +253,7 @@ ZTConf::ZTConf() {
     default_directory[0] = '\0';
     record_velocity = 1;
     post_load_page = POST_LOAD_PATTERN_EDIT;
+    note_audition_step_mode = ZT_NAS_ONE;
 }
 
 ZTConf::~ZTConf() {
@@ -303,6 +304,13 @@ int ZTConf::load()
       post_load_page = atoi(Config->get("post_load_page"));
       if (post_load_page < 0 || post_load_page >= POST_LOAD_PAGE_COUNT)
           post_load_page = POST_LOAD_PATTERN_EDIT;
+  }
+  if(Config->get("note_audition_step_mode")) {
+      note_audition_step_mode = atoi(Config->get("note_audition_step_mode"));
+      if (note_audition_step_mode < ZT_NAS_NONE ||
+          note_audition_step_mode > ZT_NAS_EDITSTEP) {
+          note_audition_step_mode = ZT_NAS_ONE;
+      }
   }
   
   ////////////////////////////////////////////////
@@ -397,6 +405,9 @@ int ZTConf::save() {
 
     sprintf(s, "%d", post_load_page);
     Config->set("post_load_page", s);
+
+    sprintf(s, "%d", note_audition_step_mode);
+    Config->set("note_audition_step_mode", s);
 
     Config->set("skin", skin);
 

--- a/src/conf.h
+++ b/src/conf.h
@@ -95,6 +95,19 @@ class ZTConf {
         int record_velocity;
         int post_load_page;        // E_post_load_page — page to switch to after a successful load
         char window_icon[MAX_PATH + 1];
+        // How far the cursor advances after the 4 / 8 audition keys
+        // fire on the note column. 0 = stay put, 1 = always step by
+        // one row, 2 = use the current EditStep value (legacy behaviour).
+        // Default is 1 -- the historical behaviour drove the cursor by
+        // EditStep, which surprised users who set EditStep > 1 to
+        // sequence at coarse intervals but still wanted single-row
+        // auditioning.
+        int note_audition_step_mode;
 };
+
+// Allowed values for zt_config_globals.note_audition_step_mode.
+#define ZT_NAS_NONE     0
+#define ZT_NAS_ONE      1
+#define ZT_NAS_EDITSTEP 2
 
 #endif


### PR DESCRIPTION
Esa: *"make it a setting in song settings, that '4' or '8' would advance either by 1, or by 0, or by editstep. i think users need to set it to '1' by default."*

## What this adds

- New `zt_config_globals.note_audition_step_mode` (int, persisted in `zt.conf` as `note_audition_step_mode`):
  - `0` = stay on the current row
  - `1` = advance by 1 row (**new default**)
  - `2` = advance by EditStep (legacy behaviour)
- Wired into the `SDL_SCANCODE_4` and `SDL_SCANCODE_8` cases on the note column in `src/CUI_Patterneditor.cpp`. Mode 0 also short-circuits the viewport-scroll guard so no stale scroll happens when the cursor isn't moving.
- Surfaced in **F11 Song Configuration** as a new "4/8 Audition Step" slider directly below Chase MIDI Tempo. Slider syncs with the live config on `enter()`. Each change posts a plain-language status message:
  - *"Note audition (4/8): cursor stays on row"*
  - *"Note audition (4/8): cursor advances 1 row"*
  - *"Note audition (4/8): cursor advances by EditStep"*

## Default change

The historical behaviour (EditStep-driven) is preserved as mode 2 but is no longer the default. Users who set EditStep > 1 specifically to drive 4/8 by larger jumps can flip the slider to 2 once and it sticks across sessions via zt.conf.

## Dependency

Depends on **PR #71** (the `SDL_SCANCODE_4` / `SDL_SCANCODE_8` fix). Without that the cases are dead code in a `switch(scancode)` and this setting cannot fire. This PR is branched off `esa/hotfix-4-8-note-audition`, so merging #71 first means this rebases cleanly onto master.

## Test plan

- [x] Builds clean on macOS
- [x] All 5 ctest suites pass
- [ ] F11 → "4/8 Audition Step" slider snaps between 0/1/2; status message appears
- [ ] Mode 0: 4/8 audition without moving the cursor
- [ ] Mode 1 (default): 4/8 advance one row regardless of EditStep
- [ ] Mode 2: 4/8 advance by EditStep (legacy)
- [ ] zt.conf: setting persists across restart; manually editing to a junk value (e.g. `note_audition_step_mode: 99`) clamps to default 1 on next load

🤖 Generated with [Claude Code](https://claude.com/claude-code)
