### PR TITLE
MIDI Mappings page (Shift+F3): bind 4/8 audition to MIDI input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,8 @@ set(ZT_SOURCES
   src/CUI_LuaConsole.cpp
   src/CUI_KeyBindings.cpp
   src/CUI_MainMenu.cpp
+  src/midi_mappings.cpp
+  src/CUI_MidiMappings.cpp
 )
 
 if(WIN32)

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,65 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_04_29 (MIDI Mappings: bind 4 / 8 audition to MIDI input)
+----------------------------------------------------------------
+
+        + New MIDI Mappings page (Shift+F3). Bind incoming MIDI
+          messages to internal actions; first two actions wired up
+          are Note Audition (= keyboard "4") and Row Audition (=
+          keyboard "8"). Each action has 3 independent slots so a
+          foot switch AND a launchpad pad can fire the same audition.
+        + UI: Up/Down picks the action, Left/Right picks the slot.
+          Enter puts the focused slot into Learn mode -- the next
+          incoming MIDI message is captured into that slot. Backspace
+          / Delete clears a slot. ESC returns to Pattern Editor;
+          inside Learn mode ESC cancels the capture.
+        + Persistence: bindings round-trip through zt.conf as
+          midi_map_<action>: SS,DD SS,DD SS,DD with "-" for empty
+          slots. Out-of-range values clamp to a fresh empty binding.
+        + Threading: MIDI input thread captures the matched action
+          into a small mutex-guarded ring; the main loop drains the
+          ring once per frame and runs the handler on the main
+          thread, so song / cursor globals are never touched from a
+          callback context. A consumed mapping is suppressed from
+          the regular MIDI-In queue (so a bound C3 audition does not
+          also enter a note into the pattern).
+        ! Audition handlers honour zt_config_globals.note_audition_
+          step_mode (0 = stay, 1 = one row [default], 2 = EditStep)
+          and only fire while the Pattern Editor's note column is
+          the active context, matching the keyboard 4 / 8 path.
+
+zt 2026_04_29 (Note audition step is configurable)
+--------------------------------------------------
+
+        + Song Configuration (F11): new "4/8 Audition Step" slider
+          controls how far the cursor advances after the 4 (audition
+          note) and 8 (audition row) keys fire on the note column.
+          0 = stay on the current row, 1 = advance one row (default),
+          2 = advance by EditStep (the legacy behaviour).
+        + zt.conf: new key `note_audition_step_mode` with the same
+          0 / 1 / 2 values, persisted across sessions. Out-of-range
+          values are clamped to the default at load.
+        ! Default change: 4 / 8 now advance by 1 row. Users who
+          relied on EditStep-driven auditioning (set EditStep to 4
+          to step a quarter at a time, audition four notes per row
+          jump) can restore the prior behaviour by setting the
+          slider to 2 once.
+        ! Status line confirms each switch
+          ("Note audition (4/8): cursor advances 1 row" etc.).
+
+zt 2026_04_29 (Hotfix: Pattern Editor 4/8 note audition + step)
+---------------------------------------------------------------
+
+        * Pattern Editor: 4 (play current note + step) and 8 (play
+          current row + step) work again on the note column. The
+          2026-04-19 layout-independent-keys refactor switched the
+          T_NOTE dispatch from switch(key) to switch(scancode) and
+          converted the note-row letters to SDL_SCANCODE_*, but left
+          the editing-key cases (4, 8, 1, ., §) as SDLK_* — making
+          them dead code in a scancode switch. Restored: 1 (note
+          off), § (note cut), . (clear), 4 (audition note), 8
+          (audition row).
 zt 2026_04_29 (F10 Song Message: caret + cursor nav + crash logger)
 -------------------------------------------------------------------
 

--- a/src/CUI_MidiMappings.cpp
+++ b/src/CUI_MidiMappings.cpp
@@ -1,0 +1,183 @@
+#include "zt.h"
+#include "midi_mappings.h"
+
+#include <stdio.h>
+#include <string.h>
+
+CUI_MidiMappings::CUI_MidiMappings() {
+    UI = new UserInterface;
+    cursor_y = 0;
+    cursor_x = 0;
+    status_line[0] = '\0';
+}
+
+void CUI_MidiMappings::enter(void) {
+    cur_state = STATE_MIDI_MAPPINGS;
+    need_refresh = 1;
+    Keys.flush();
+    // Cancel any stale Learn target so the page opens in browse mode.
+    zt_mm_set_learn_target(-1, -1);
+    snprintf(status_line, sizeof(status_line),
+             "Enter = Learn this slot   Backspace/Delete = Clear   ESC = Back");
+    statusmsg = status_line;
+    status_change = 1;
+}
+
+void CUI_MidiMappings::leave(void) {
+    // Drop Learn so a stray MIDI message after exiting does not get
+    // consumed into a stale slot.
+    zt_mm_set_learn_target(-1, -1);
+}
+
+void CUI_MidiMappings::update(void) {
+    int learn_a = zt_mm_get_learn_action();
+    int learn_s = zt_mm_get_learn_slot();
+    if (learn_a >= 0) {
+        // Re-render the status line every frame while in Learn mode
+        // so the user sees the current target. The MIDI thread will
+        // capture the next short channel message and clear the
+        // target via zt_mm_dispatch.
+        snprintf(status_line, sizeof(status_line),
+                 "LEARN: send a MIDI key/CC for %s slot %d   (ESC to cancel)",
+                 zt_mm_action_display_name(learn_a),
+                 learn_s + 1);
+        statusmsg = status_line;
+        status_change = 1;
+    }
+
+    if (!Keys.size()) return;
+    int key = Keys.checkkey();
+    int kstate = Keys.getstate();
+    (void)kstate;
+
+    switch (key) {
+        case SDLK_ESCAPE:
+            Keys.getkey();
+            if (learn_a >= 0) {
+                zt_mm_set_learn_target(-1, -1);
+                snprintf(status_line, sizeof(status_line),
+                         "Learn cancelled");
+                statusmsg = status_line;
+                status_change = 1;
+                need_refresh++;
+            } else {
+                switch_page(UIP_Patterneditor);
+            }
+            return;
+
+        case SDLK_UP:
+            Keys.getkey();
+            if (cursor_y > 0) cursor_y--;
+            need_refresh++;
+            return;
+        case SDLK_DOWN:
+            Keys.getkey();
+            if (cursor_y < ZT_MM_NUM_ACTIONS - 1) cursor_y++;
+            need_refresh++;
+            return;
+        case SDLK_LEFT:
+            Keys.getkey();
+            if (cursor_x > 0) cursor_x--;
+            need_refresh++;
+            return;
+        case SDLK_RIGHT:
+            Keys.getkey();
+            if (cursor_x < ZT_MM_SLOTS_PER_ACTION - 1) cursor_x++;
+            need_refresh++;
+            return;
+
+        case SDLK_RETURN:
+        case SDLK_KP_ENTER:
+            Keys.getkey();
+            zt_mm_set_learn_target(cursor_y, cursor_x);
+            snprintf(status_line, sizeof(status_line),
+                     "LEARN: send a MIDI key/CC for %s slot %d   (ESC to cancel)",
+                     zt_mm_action_display_name(cursor_y),
+                     cursor_x + 1);
+            statusmsg = status_line;
+            status_change = 1;
+            need_refresh++;
+            return;
+
+        case SDLK_BACKSPACE:
+        case SDLK_DELETE:
+            Keys.getkey();
+            zt_mm_clear_slot(cursor_y, cursor_x);
+            snprintf(status_line, sizeof(status_line),
+                     "Cleared %s slot %d",
+                     zt_mm_action_display_name(cursor_y),
+                     cursor_x + 1);
+            statusmsg = status_line;
+            status_change = 1;
+            need_refresh++;
+            return;
+
+        default:
+            // Drop unrecognised keys so they do not leak into the
+            // page below.
+            Keys.getkey();
+            return;
+    }
+}
+
+void CUI_MidiMappings::draw(Drawable *S) {
+    if (S->lock() != 0) return;
+
+    UI->draw(S);
+    draw_status(S);
+    printtitle(PAGE_TITLE_ROW_Y, "MIDI Mappings (Shift+F3)",
+               COLORS.Text, COLORS.Background, S);
+
+    const int header_y = TRACKS_ROW_Y;
+    const int x_action = 2;
+    const int x_slots[ZT_MM_SLOTS_PER_ACTION] = { 28, 38, 48 };
+
+    // Column headers.
+    print(col(x_action), row(header_y), "Action", COLORS.Highlight, S);
+    for (int s = 0; s < ZT_MM_SLOTS_PER_ACTION; s++) {
+        char header[16];
+        snprintf(header, sizeof(header), "Slot %d", s + 1);
+        print(col(x_slots[s]), row(header_y), header,
+              COLORS.Highlight, S);
+    }
+
+    // One row per action.
+    ZtMmMappings *mm = zt_mm_get_mappings();
+    int learn_a = zt_mm_get_learn_action();
+    int learn_s = zt_mm_get_learn_slot();
+    for (int a = 0; a < ZT_MM_NUM_ACTIONS; a++) {
+        const int row_y = header_y + 2 + a;
+        TColor name_col = (a == cursor_y) ? COLORS.Highlight : COLORS.Text;
+        print(col(x_action), row(row_y),
+              zt_mm_action_display_name(a), name_col, S);
+
+        for (int s = 0; s < ZT_MM_SLOTS_PER_ACTION; s++) {
+            char buf[8];
+            zt_mm_format_binding(&mm->bindings[a][s], buf, sizeof(buf));
+            TColor slot_col;
+            if (a == learn_a && s == learn_s) {
+                slot_col = COLORS.Highlight;   // capturing
+            } else if (a == cursor_y && s == cursor_x) {
+                slot_col = COLORS.Highlight;   // focused
+            } else if (mm->bindings[a][s].valid) {
+                slot_col = COLORS.Text;
+            } else {
+                slot_col = COLORS.Lowlight;
+            }
+            print(col(x_slots[s]), row(row_y), buf, slot_col, S);
+        }
+    }
+
+    // Helpful legend below the grid.
+    const int legend_y = header_y + 4 + ZT_MM_NUM_ACTIONS;
+    print(col(x_action), row(legend_y),
+          "Up/Down = action   Left/Right = slot",
+          COLORS.Text, S);
+    print(col(x_action), row(legend_y + 1),
+          "Bindings save to zt.conf as midi_map_<action>: SS,DD SS,DD SS,DD",
+          COLORS.Lowlight, S);
+
+    need_refresh = 0;
+    updated = 2;
+    S->unlock();
+}

--- a/src/CUI_Page.h
+++ b/src/CUI_Page.h
@@ -518,4 +518,23 @@ class CUI_KeyBindings : public CUI_Page {
 
         int visible_rows(void) const;
 };
+
+// MIDI Mappings page -- bind incoming MIDI messages to internal
+// actions (Note Audition / Row Audition for now). Cursor walks a
+// 2-D grid: rows = actions, columns = the 3 mapping slots. Enter
+// puts the focused slot into Learn mode (next incoming MIDI
+// message captured); Backspace / Delete clears the focused slot.
+class CUI_MidiMappings : public CUI_Page {
+    public:
+        int cursor_y;     // 0..ZT_MM_NUM_ACTIONS-1
+        int cursor_x;     // 0..ZT_MM_SLOTS_PER_ACTION-1
+        char status_line[160];
+
+        CUI_MidiMappings();
+
+        void enter(void);
+        void leave(void);
+        void update(void);
+        void draw(Drawable *S);
+};
 #endif

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -47,6 +47,7 @@
 
 #include "conf.h"
 #include "keybindings.h"
+#include "midi_mappings.h"
 
 #include "zt.h"
 
@@ -341,6 +342,42 @@ int ZTConf::load()
   window_icon[0] = '\0';
   if(Config->get("window_icon"))                      strncpy(window_icon, Config->get("window_icon"), MAX_PATH);
 
+  // MIDI mappings: keys named "midi_map_<action>" each hold up to
+  // ZT_MM_SLOTS_PER_ACTION space-separated tokens. Each token is
+  // "SS,DD" (status hex, data1 hex) or "-" for an empty slot.
+  {
+      char keybuf[64];
+      ZtMmMappings *mm = zt_mm_get_mappings();
+      for (int a = 0; a < ZT_MM_NUM_ACTIONS; a++) {
+          snprintf(keybuf, sizeof(keybuf), "midi_map_%s", zt_mm_action_conf_key(a));
+          char *raw = Config->get(keybuf);
+          if (!raw) continue;
+          // Reset to empty before parsing so a partial line doesn't
+          // leave stale slots from a previous load.
+          for (int s = 0; s < ZT_MM_SLOTS_PER_ACTION; s++) {
+              mm->bindings[a][s] = ZtMmBinding{0, 0, 0};
+          }
+          int slot = 0;
+          char *tok = raw;
+          while (*tok && slot < ZT_MM_SLOTS_PER_ACTION) {
+              while (*tok == ' ') tok++;
+              if (!*tok) break;
+              char *end = tok;
+              while (*end && *end != ' ') end++;
+              if (!(tok[0] == '-' && (end - tok) == 1)) {
+                  unsigned int s_byte = 0, d_byte = 0;
+                  if (sscanf(tok, "%2X,%2X", &s_byte, &d_byte) == 2) {
+                      mm->bindings[a][slot].valid  = 1;
+                      mm->bindings[a][slot].status = (unsigned char)s_byte;
+                      mm->bindings[a][slot].data1  = (unsigned char)d_byte;
+                  }
+              }
+              slot++;
+              tok = end;
+          }
+      }
+  }
+
   return(0) ;
 }
 
@@ -464,6 +501,29 @@ int ZTConf::save() {
 
     g_keybindings.save(Config);
 
+    // Save MIDI mappings (mirror of the load parser).
+    {
+        char keybuf[64];
+        char valbuf[64];
+        ZtMmMappings *mm = zt_mm_get_mappings();
+        for (int a = 0; a < ZT_MM_NUM_ACTIONS; a++) {
+            valbuf[0] = '\0';
+            for (int sl = 0; sl < ZT_MM_SLOTS_PER_ACTION; sl++) {
+                char tok[16];
+                const ZtMmBinding *b = &mm->bindings[a][sl];
+                if (b->valid) {
+                    snprintf(tok, sizeof(tok), "%02X,%02X",
+                             (unsigned)b->status, (unsigned)b->data1);
+                } else {
+                    snprintf(tok, sizeof(tok), "-");
+                }
+                if (sl > 0) strncat(valbuf, " ", sizeof(valbuf) - strlen(valbuf) - 1);
+                strncat(valbuf, tok, sizeof(valbuf) - strlen(valbuf) - 1);
+            }
+            snprintf(keybuf, sizeof(keybuf), "midi_map_%s", zt_mm_action_conf_key(a));
+            Config->set(keybuf, valbuf);
+        }
+    }
 
     return Config->save(conf_filename) ? 0 : -1;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,6 +76,7 @@
 #include "keybindings.h"
 #include "save_key_dispatch.h"
 #include "zt_crash.h"
+#include "midi_mappings.h"
 
 #ifdef __APPLE__
 extern "C" void zt_macos_disable_cmd_q(void);
@@ -340,6 +341,7 @@ CUI_Arpeggioeditor *UIP_Arpeggioeditor = NULL;
 CUI_Midimacroeditor *UIP_Midimacroeditor = NULL;
 CUI_LuaConsole *UIP_LuaConsole = NULL;
 CUI_KeyBindings *UIP_KeyBindings = NULL;
+CUI_MidiMappings *UIP_MidiMappings = NULL;
 
 
 
@@ -1130,6 +1132,7 @@ int initConsole(int& Width, int& Height, int& FullScreen, int& Flags, Screen* S)
     UIP_PaletteEditor = new CUI_PaletteEditor;
     UIP_Config = new CUI_Config;
     UIP_KeyBindings = new CUI_KeyBindings;
+    UIP_MidiMappings = new CUI_MidiMappings;
     UIP_Patterneditor = new CUI_Patterneditor;
     UIP_PEParms = new CUI_PEParms;
     UIP_PEVol = new CUI_PEVol;
@@ -1446,6 +1449,17 @@ void global_keys(Drawable *S)
                 }
                 break;
 
+            case SDLK_F3: // Shift+F3 = MIDI Mappings page
+                // Plain F3 (handled in the no-modifier block below)
+                // opens the Instrument editor. Shift+F3 sidesteps the
+                // F3 dispatch and lands on the MIDI Mappings page so
+                // the user can bind incoming MIDI to internal actions.
+                if (kstate & KS_SHIFT) {
+                    command = CMD_SWITCH_MIDI_MAPPINGS;
+                    key = Keys.getkey();
+                }
+                break;
+
 
             case SDLK_F4:
                 // Shift+F4 opens the Arpeggio editor. Plain F4 (handled
@@ -1479,12 +1493,14 @@ void global_keys(Drawable *S)
                 }
                 break;
 
+#ifndef DISABLE_UNFINISHED_F10_SONG_MESSAGE_EDITOR
             case SDLK_F10:
 
                 if (kstate == KS_NO_SHIFT_KEYS) {
 
                     command = CMD_SWITCH_SONGMSG;
                 }
+#endif
 
               break ;
 
@@ -1755,6 +1771,11 @@ void global_keys(Drawable *S)
         // ------------------------------------------------------------------------
         case CMD_SWITCH_KEYBINDINGS:
             switch_page(UIP_KeyBindings);
+            doredraw++; clear++;
+            break;
+        // ------------------------------------------------------------------------
+        case CMD_SWITCH_MIDI_MAPPINGS:
+            switch_page(UIP_MidiMappings);
             doredraw++; clear++;
             break;
         // ------------------------------------------------------------------------
@@ -2376,6 +2397,7 @@ int postAction ()
     delete UIP_Midimacroeditor;
     delete UIP_LuaConsole;
     delete UIP_KeyBindings;
+    delete UIP_MidiMappings;
     g_lua.shutdown();
     delete ztPlayer;
     delete MidiIn;
@@ -3448,6 +3470,7 @@ int initSDL(void)
     UIP_SongDuration = new CUI_SongDuration;
     UIP_LuaConsole = new CUI_LuaConsole;
     UIP_KeyBindings = new CUI_KeyBindings;
+    UIP_MidiMappings = new CUI_MidiMappings;
     g_lua.init();
     UIP_PaletteEditor = new CUI_PaletteEditor;
     UIP_MainMenu = new CUI_MainMenu;
@@ -3918,6 +3941,12 @@ int main(int argc, char *argv[])
       }
 
       zt_apply_pending_window_title();
+
+      // Drain any MIDI mapping action posts captured by the MIDI
+      // input thread since the last frame. Action handlers run here,
+      // on the main thread, so they can safely touch song / cursor
+      // globals.
+      zt_mm_drain_actions();
 
       static int next_frame_redraw_all = 0;
       if(next_frame_redraw_all) {

--- a/src/midi-io.cpp
+++ b/src/midi-io.cpp
@@ -38,6 +38,7 @@
  *
  ******/
 #include "zt.h"
+#include "midi_mappings.h"
 
 
 /*
@@ -363,7 +364,21 @@ void CALLBACK midiInCallback(HMIDIIN handle, UINT uMsg, DWORD_PTR dwInstance, DW
         case MIM_DATA:
           msg = (unsigned char)(dwParam1 & 0x000000FF);
 
-          switch(msg) {
+          {
+              // MIDI mappings have first dibs on short channel
+              // messages. If the incoming message matches a binding
+              // (or learn mode is capturing), the dispatcher
+              // consumes it and we skip the regular MIDI-In queue
+              // insertion -- otherwise an audition-bound C3 would
+              // also write a note into the pattern.
+              unsigned char mm_status = (unsigned char)(dwParam1 & 0xFF);
+              unsigned char mm_data1  = (unsigned char)((dwParam1 >> 8) & 0xFF);
+              unsigned char mm_data2  = (unsigned char)((dwParam1 >> 16) & 0xFF);
+              if (mm_status >= 0x80 && mm_status < 0xF0 &&
+                  zt_mm_dispatch(mm_status, mm_data1, mm_data2)) {
+                  // Consumed by mapping/learn -- do not enqueue.
+              } else
+              switch(msg) {
               case 0x80: // Note off
                   midiInQueue.insert(dwParam1);
                   break;
@@ -379,6 +394,7 @@ void CALLBACK midiInCallback(HMIDIIN handle, UINT uMsg, DWORD_PTR dwInstance, DW
                       midiInQueue.insert(dwParam1);
                   }
                   break;
+              }
           }
 
           if (zt_config_globals.midi_in_sync)

--- a/src/midi_mappings.cpp
+++ b/src/midi_mappings.cpp
@@ -1,0 +1,254 @@
+#include "midi_mappings.h"
+
+#include "zt.h"
+
+#include <SDL.h>
+#include <stdio.h>
+#include <string.h>
+
+// File-private state -----------------------------------------------------------
+
+namespace {
+
+ZtMmMappings g_mappings = {};
+
+// Pending-action ring. MIDI thread writes via zt_mm_post_action_locked;
+// main thread drains via zt_mm_drain_actions. SDL_Mutex protects head/tail.
+struct ActionRing {
+    int actions[16];
+    int head;          // write index
+    int tail;          // read index
+    SDL_Mutex *mtx;    // lazily created in zt_mm_init_ring
+};
+ActionRing g_ring = { {0}, 0, 0, NULL };
+
+// Learn target. -1 means inactive. Reads/writes are protected by the
+// same mutex as the ring (the dispatcher locks for both checks).
+int g_learn_action = -1;
+int g_learn_slot   = -1;
+
+void zt_mm_init_ring() {
+    if (!g_ring.mtx) {
+        g_ring.mtx = SDL_CreateMutex();
+    }
+}
+
+void zt_mm_post_action_locked(int action) {
+    int next = (g_ring.head + 1) % (int)(sizeof(g_ring.actions) / sizeof(g_ring.actions[0]));
+    if (next == g_ring.tail) {
+        // Ring full -- drop the oldest to keep the latest. A burst of
+        // mapped MIDI events past the ring depth is rare; preferring
+        // recent over stale is the right tradeoff for an audition key.
+        g_ring.tail = (g_ring.tail + 1) % (int)(sizeof(g_ring.actions) / sizeof(g_ring.actions[0]));
+    }
+    g_ring.actions[g_ring.head] = action;
+    g_ring.head = next;
+}
+
+const char *kConfKeys[ZT_MM_NUM_ACTIONS] = {
+    "note_audition",   // ZT_MM_NOTE_AUDITION
+    "row_audition",    // ZT_MM_ROW_AUDITION
+};
+
+const char *kDisplayNames[ZT_MM_NUM_ACTIONS] = {
+    "Note Audition (4)",
+    "Row Audition (8)",
+};
+
+// Status-byte normalisation: a binding stores the upper nibble + ch.
+// For matching purposes we treat note-on with velocity 0 as note-off
+// equivalent BUT ALSO match note-on bindings against incoming
+// note-on-velocity-0 messages (some controllers emit those). The
+// midi-io.cpp callback already rewrites NoteOn-velocity-0 to NoteOff
+// before this dispatcher sees it, so a binding stored as 0x90 will
+// not fire on the rewrite -- users should bind on the actual press.
+bool match_binding(const ZtMmBinding *b, unsigned char status, unsigned char data1) {
+    if (!b->valid) return false;
+    return b->status == status && b->data1 == data1;
+}
+
+} // namespace
+
+// Public API -------------------------------------------------------------------
+
+const char *zt_mm_action_conf_key(int action) {
+    if (action < 0 || action >= ZT_MM_NUM_ACTIONS) return "";
+    return kConfKeys[action];
+}
+
+const char *zt_mm_action_display_name(int action) {
+    if (action < 0 || action >= ZT_MM_NUM_ACTIONS) return "";
+    return kDisplayNames[action];
+}
+
+ZtMmMappings *zt_mm_get_mappings(void) {
+    return &g_mappings;
+}
+
+void zt_mm_clear_slot(int action, int slot) {
+    if (action < 0 || action >= ZT_MM_NUM_ACTIONS) return;
+    if (slot < 0 || slot >= ZT_MM_SLOTS_PER_ACTION) return;
+    g_mappings.bindings[action][slot] = ZtMmBinding{0, 0, 0};
+}
+
+void zt_mm_set_learn_target(int action, int slot) {
+    zt_mm_init_ring();
+    SDL_LockMutex(g_ring.mtx);
+    if (action < 0 || slot < 0 ||
+        action >= ZT_MM_NUM_ACTIONS ||
+        slot >= ZT_MM_SLOTS_PER_ACTION) {
+        g_learn_action = -1;
+        g_learn_slot   = -1;
+    } else {
+        g_learn_action = action;
+        g_learn_slot   = slot;
+    }
+    SDL_UnlockMutex(g_ring.mtx);
+}
+
+int zt_mm_get_learn_action(void) {
+    zt_mm_init_ring();
+    SDL_LockMutex(g_ring.mtx);
+    int a = g_learn_action;
+    SDL_UnlockMutex(g_ring.mtx);
+    return a;
+}
+
+int zt_mm_get_learn_slot(void) {
+    zt_mm_init_ring();
+    SDL_LockMutex(g_ring.mtx);
+    int s = g_learn_slot;
+    SDL_UnlockMutex(g_ring.mtx);
+    return s;
+}
+
+int zt_mm_dispatch(unsigned char status, unsigned char data1, unsigned char /*data2*/) {
+    // Real-time messages (clock, start, stop, ...) are noise here.
+    // Only short channel messages can be bound.
+    if (status < 0x80 || status >= 0xF0) return 0;
+
+    zt_mm_init_ring();
+    SDL_LockMutex(g_ring.mtx);
+
+    // Learn mode: capture into the requested slot and consume.
+    if (g_learn_action >= 0 && g_learn_slot >= 0) {
+        ZtMmBinding *b = &g_mappings.bindings[g_learn_action][g_learn_slot];
+        b->valid  = 1;
+        b->status = status;
+        b->data1  = data1;
+        g_learn_action = -1;
+        g_learn_slot   = -1;
+        SDL_UnlockMutex(g_ring.mtx);
+        return 1;
+    }
+
+    // Otherwise look for a matching binding. First match wins.
+    int matched_action = -1;
+    for (int a = 0; a < ZT_MM_NUM_ACTIONS && matched_action < 0; a++) {
+        for (int s = 0; s < ZT_MM_SLOTS_PER_ACTION; s++) {
+            if (match_binding(&g_mappings.bindings[a][s], status, data1)) {
+                matched_action = a;
+                break;
+            }
+        }
+    }
+    if (matched_action >= 0) {
+        zt_mm_post_action_locked(matched_action);
+    }
+    SDL_UnlockMutex(g_ring.mtx);
+    return matched_action >= 0 ? 1 : 0;
+}
+
+// Action handlers --------------------------------------------------------------
+//
+// Both handlers mirror the keyboard SDL_SCANCODE_4 / _8 path in
+// CUI_Patterneditor.cpp: play_current_note() / play_current_row()
+// followed by an advance amount governed by
+// zt_config_globals.note_audition_step_mode. Only fire when the
+// pattern editor is the active page AND the cursor is on the note
+// column (T_NOTE) -- on other columns 4 / 8 are digit-input keys
+// and the user wouldn't expect the audition to fire there either.
+
+extern int cur_edit_pattern;
+extern int cur_edit_track;
+extern int cur_edit_row;
+extern int cur_edit_row_disp;
+extern int cur_edit_col;
+extern int cur_step;
+extern int PATTERN_EDIT_ROWS;
+extern int need_refresh;
+
+namespace {
+
+bool in_pattern_editor_note_col() {
+    if (!UIP_Patterneditor || ActivePage != UIP_Patterneditor) return false;
+    if (cur_edit_col < 0 || cur_edit_col >= 41) return false;  // edit_cols[41]
+    return edit_cols[cur_edit_col].type == T_NOTE;
+}
+
+int audition_advance_amount() {
+    switch (zt_config_globals.note_audition_step_mode) {
+        case ZT_NAS_NONE:     return 0;
+        case ZT_NAS_EDITSTEP: return cur_step;
+        case ZT_NAS_ONE:
+        default:              return 1;
+    }
+}
+
+void audition_advance_after() {
+    int advance = audition_advance_amount();
+    if (advance <= 0) return;
+    cur_edit_row += advance;
+    if ((cur_edit_row - 1 - cur_edit_row_disp) >= (PATTERN_EDIT_ROWS - 1)) {
+        if (cur_edit_row_disp <
+            (song->patterns[cur_edit_pattern]->length - PATTERN_EDIT_ROWS)) {
+            cur_edit_row_disp += advance;
+        }
+    }
+    need_refresh++;
+}
+
+void run_action(int action) {
+    if (!ztPlayer) return;
+    if (!in_pattern_editor_note_col()) return;
+    switch (action) {
+        case ZT_MM_NOTE_AUDITION:
+            ztPlayer->play_current_note();
+            audition_advance_after();
+            break;
+        case ZT_MM_ROW_AUDITION:
+            ztPlayer->play_current_row();
+            audition_advance_after();
+            break;
+        default:
+            break;
+    }
+}
+
+} // namespace
+
+void zt_mm_drain_actions(void) {
+    zt_mm_init_ring();
+    while (true) {
+        int action = -1;
+        SDL_LockMutex(g_ring.mtx);
+        if (g_ring.tail != g_ring.head) {
+            action = g_ring.actions[g_ring.tail];
+            g_ring.tail = (g_ring.tail + 1) %
+                (int)(sizeof(g_ring.actions) / sizeof(g_ring.actions[0]));
+        }
+        SDL_UnlockMutex(g_ring.mtx);
+        if (action < 0) break;
+        run_action(action);
+    }
+}
+
+void zt_mm_format_binding(const ZtMmBinding *b, char *out, int out_len) {
+    if (!out || out_len <= 0) return;
+    if (!b || !b->valid) {
+        snprintf(out, out_len, "----");
+        return;
+    }
+    snprintf(out, out_len, "%02X %02X",
+             (unsigned)b->status, (unsigned)b->data1);
+}

--- a/src/midi_mappings.h
+++ b/src/midi_mappings.h
@@ -1,0 +1,102 @@
+// MIDI Mappings — bind incoming MIDI messages to internal actions.
+//
+// First two actions wired up: Note Audition (== keyboard "4" on the
+// Pattern Editor note column) and Row Audition (== "8"). Each action
+// has up to ZT_MM_SLOTS_PER_ACTION independent bindings so a user can
+// trigger the same action from multiple controllers (a foot switch
+// AND a launchpad pad, for example).
+//
+// Architecture
+// ------------
+//   * ZtMmAction   -- enum of bindable actions. Add to the end; the
+//                     names array in midi_mappings.cpp must stay in
+//                     sync.
+//   * ZtMmBinding  -- one captured MIDI message-shape (status byte +
+//                     data1). data2 (note velocity / CC value) is
+//                     intentionally not matched so a single binding
+//                     fires regardless of how hard the user hits the
+//                     pad.
+//   * Three slots per action, persisted to zt.conf as
+//         midi_map_<action_name>: <s1,d1> <s2,d2> <s3,d3>
+//     Empty slots write as "-".
+//
+// Threading
+// ---------
+//   The MIDI input dispatcher runs on the MIDI callback thread
+//   (CoreMIDI read proc / WinMM callback / ALSA seq thread). Action
+//   handlers touch shared editor state (cur_edit_row, song->patterns,
+//   ...) so they MUST run on the main thread. The dispatcher posts
+//   the matching action enum into a small mutex-guarded ring; the
+//   main loop drains the ring once per frame and fires the handlers.
+//
+//   Learn mode is also driven through the same dispatcher: when
+//   g_mm_learn_target is set, the next incoming message is captured
+//   into that slot instead of dispatched.
+
+#ifndef ZT_MIDI_MAPPINGS_H
+#define ZT_MIDI_MAPPINGS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum ZtMmAction {
+    ZT_MM_NOTE_AUDITION = 0,   // == keyboard "4" — play current note + advance
+    ZT_MM_ROW_AUDITION,        // == keyboard "8" — play current row  + advance
+    ZT_MM_NUM_ACTIONS
+};
+
+#define ZT_MM_SLOTS_PER_ACTION 3
+
+struct ZtMmBinding {
+    int  valid;          // 0 = empty slot
+    unsigned char status; // top nibble matters: 0x90 note-on, 0xB0 CC, etc.
+    unsigned char data1;  // note number / CC number
+};
+
+struct ZtMmMappings {
+    ZtMmBinding bindings[ZT_MM_NUM_ACTIONS][ZT_MM_SLOTS_PER_ACTION];
+};
+
+// File-private state lives in midi_mappings.cpp; access through the
+// helpers below.
+
+// Action name keys used by zt.conf (e.g. "note_audition") and
+// rendered as table headers in the UI ("Note Audition"). The two
+// arrays are guaranteed to have ZT_MM_NUM_ACTIONS entries.
+const char *zt_mm_action_conf_key(int action);
+const char *zt_mm_action_display_name(int action);
+
+// Direct accessor for the mapping table. Used by the UI page and
+// the conf load/save path. Mutating from outside is allowed.
+ZtMmMappings *zt_mm_get_mappings(void);
+
+// Try to dispatch an incoming MIDI message. Called from the MIDI
+// input callback thread. Returns 1 if the message was consumed
+// (matched a binding OR captured by learn mode), 0 if it should
+// flow on to normal MIDI-In processing.
+int zt_mm_dispatch(unsigned char status, unsigned char data1, unsigned char data2);
+
+// Drain pending action posts. Called from the main loop once per
+// frame. Runs handlers on the main thread.
+void zt_mm_drain_actions(void);
+
+// Learn mode -- set with a (action, slot) pair to redirect the next
+// incoming MIDI message into that slot instead of dispatching it.
+// Pass action == -1 to cancel.
+void zt_mm_set_learn_target(int action, int slot);
+int  zt_mm_get_learn_action(void);  // -1 if not active
+int  zt_mm_get_learn_slot(void);    // -1 if not active
+
+// Slot mutation -- used by the UI page's "Clear" affordance.
+void zt_mm_clear_slot(int action, int slot);
+
+// Pretty-print a binding into a small fixed buffer ("90 3C", "B0 7F",
+// or "----"). Buffer must be at least 6 bytes.
+void zt_mm_format_binding(const ZtMmBinding *b, char *out, int out_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ZT_MIDI_MAPPINGS_H

--- a/src/zt.h
+++ b/src/zt.h
@@ -338,7 +338,8 @@ enum state {
   STATE_MIDIMACEDIT,
   STATE_LUA_CONSOLE,
   STATE_PALETTE_EDITOR,
-  STATE_KEYBINDINGS
+  STATE_KEYBINDINGS,
+  STATE_MIDI_MAPPINGS
 } ;
 
 
@@ -609,7 +610,9 @@ enum E_col_type { T_NOTE, T_OCTAVE, T_INST, T_VOL, T_CHAN, T_LEN,
 
         CMD_SWITCH_LUA_CONSOLE,
 
-        CMD_SWITCH_KEYBINDINGS
+        CMD_SWITCH_KEYBINDINGS,
+
+        CMD_SWITCH_MIDI_MAPPINGS
 
     };
 
@@ -764,6 +767,7 @@ extern CUI_Arpeggioeditor *UIP_Arpeggioeditor;
 extern CUI_Midimacroeditor *UIP_Midimacroeditor;
 extern CUI_LuaConsole *UIP_LuaConsole;
 extern CUI_KeyBindings *UIP_KeyBindings;
+extern CUI_MidiMappings *UIP_MidiMappings;
 extern CUI_Help *UIP_Help;
 extern CUI_MainMenu *UIP_MainMenu;
 


### PR DESCRIPTION
Manuel asked: bind "4" and "8" (note / row audition) to MIDI input, with 1st / 2nd / 3rd slots per action so multiple physical surfaces can fire the same internal trigger. This PR builds the framework and the first two actions.

## What's new

- **New page on Shift+F3 — MIDI Mappings.** Up/Down picks the action, Left/Right picks the slot. **Enter** puts the focused slot into Learn mode (next incoming MIDI message captured); **Backspace/Delete** clears a slot; **ESC** returns to Pattern Editor (or cancels Learn).
- **Two actions wired up**: Note Audition (= keyboard "4") and Row Audition (= keyboard "8"). Each gets 3 slots.
- **Persistence in zt.conf**:
  ```
  midi_map_note_audition: 90,3C - -
  midi_map_row_audition:  B0,7F - -
  ```
  (status hex, data1 hex per slot; "-" = empty). Out-of-range / malformed tokens clamp to empty on next load.
- **Threading-safe**: the MIDI input callback thread captures the matched action into a small mutex-guarded ring; the main loop drains the ring once per frame and runs handlers on the main thread, so song / cursor globals are never touched from a callback context.
- **Mapping consumes the message**: a bound C3 audition does NOT also enter a note into the pattern (the dispatch returns 1 to skip the regular `midiInQueue` insertion).
- Audition handlers honour `note_audition_step_mode` (PR #74) and only fire while the Pattern Editor's note column is the active context, matching the keyboard 4 / 8 path.

## Why Shift+F3 (not Cmd-Alt-M)

Originally bound to Ctrl+Alt+M; switched to Shift+F3 because Cmd+M is the macOS minimize shortcut. Shift+F3 is used here for the **MIDI Mappings** page (per Manuel's earlier proposal) — the upcoming **MIDI Controller** window will get its own key (TBD).

## Adding more actions later

Append to `ZtMmAction` in `midi_mappings.h` and to the `kConfKeys` / `kDisplayNames` tables in `midi_mappings.cpp`. Dispatcher + UI + persistence pick them up automatically.

## Architecture

- `src/midi_mappings.{h,cpp}` — enum, table, dispatcher, learn-mode state, drain ring, action handlers
- `src/CUI_MidiMappings.cpp` + `CUI_Page.h` — the page UI
- `src/conf.{cpp}` — load/save round-trip
- `src/midi-io.cpp` — dispatcher hook in `MIM_DATA`
- `src/main.cpp` — instantiate page, drain ring per frame, Shift+F3 dispatcher

## Dependencies

- **PR #71** — restores the SCANCODE 4/8 keyboard path (this PR's MIDI handlers mirror it)
- **PR #74** — configurable `note_audition_step_mode` (this PR's handlers honour it)

Branched off PR #74; merging #71 → #74 → this PR keeps history clean.

## Test plan

- [x] Builds clean on macOS
- [x] Page renders cleanly via Shift+F3 (verified by screenshot)
- [ ] Manual: enable a MIDI In device → Shift+F3 → Enter on Note Audition slot 1 → press a MIDI key → slot fills with `90,XX`
- [ ] Manual: ESC back to Pattern Editor, place cursor on note column, press the bound MIDI key → `play_current_note()` fires + cursor advances per `note_audition_step_mode`
- [ ] Manual: quit + restart → bindings persist (visible again on Shift+F3)
- [ ] Manual: same key bound across two slots — only one fires (first match wins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
