### PR TITLE
CC drawmode + Learn + auto-name + F12 picker

### DIFF
--- a/src/CUI_CcConsole.cpp
+++ b/src/CUI_CcConsole.cpp
@@ -121,6 +121,7 @@ CUI_CcConsole::CUI_CcConsole() {
     slot_cur = slot_top = 0;
     channel = 1;
     loaded = 0;
+    learning = 0;
     status_line[0] = '\0';
     folder[0] = '\0';
     num_files = 0;
@@ -159,7 +160,7 @@ void CUI_CcConsole::enter(void) {
     rescan_folder();
     if (!loaded && num_files > 0) load_selected();
     snprintf(status_line, sizeof(status_line),
-             "Tab: focus  Up/Dn: pick  Enter: load  Left/Right: value  V: slider/knob  [/]: ch  Ctrl+S: save  ESC: exit");
+             "Tab focus | Lt/Rt value | V slider/knob | L learn | U unbind | [/] ch | Ctrl+S save | ESC exit");
     Keys.flush();
 }
 
@@ -168,12 +169,56 @@ void CUI_CcConsole::leave(void) {
 
 // --------- Update ---------
 void CUI_CcConsole::update(void) {
+    // ----- MIDI-in pump -----
+    // Drain any incoming MIDI messages while on this page. In Learn mode
+    // we capture (status, data1) into the focused slot. Always: a CC/PB
+    // message that matches a learnt slot updates that slot's value (and
+    // moves the cursor to it for visual feedback).
+    while (midiInQueue.size() > 0) {
+        int dw = midiInQueue.pop();
+        unsigned char status = (unsigned char)(dw & 0xFF);
+        unsigned char d1     = (unsigned char)((dw >> 8)  & 0x7F);
+        unsigned char d2     = (unsigned char)((dw >> 16) & 0x7F);
+        unsigned char hi     = status & 0xF0;
+
+        if (learning && (hi == 0xB0 || hi == 0xE0) && loaded &&
+            slot_cur >= 0 && slot_cur < g_loaded.num_slots) {
+            g_loaded.slots[slot_cur].learn_status = status;
+            g_loaded.slots[slot_cur].learn_data1  = (hi == 0xE0) ? 0 : d1;
+            learning = 0;
+            snprintf(status_line, sizeof(status_line),
+                     "Learnt %s%s slot %d <- status %02X data1 %02X  (Ctrl+S to save)",
+                     g_loaded.basename, "",
+                     slot_cur + 1, status, d1);
+            continue;
+        }
+
+        if (loaded && (hi == 0xB0 || hi == 0xE0)) {
+            int match = zt_ccizer_find_learn_match(
+                &g_loaded, status, (hi == 0xE0) ? 0 : d1);
+            if (match >= 0) {
+                ZtCcizerSlot *m = &g_loaded.slots[match];
+                if (hi == 0xE0) m->value = (unsigned short)(d1 | (d2 << 7));
+                else            m->value = d2;
+                slot_cur = match;
+                snprintf(status_line, sizeof(status_line),
+                         "%s = %d  (learnt slot %d)",
+                         m->name, (int)m->value, match + 1);
+            }
+        }
+    }
+
     if (!Keys.size()) return;
 
     KBMod  kstate = Keys.getstate();
     KBKey  key    = Keys.getkey();
 
     if (key == SDLK_ESCAPE) {
+        if (learning) {
+            learning = 0;
+            snprintf(status_line, sizeof(status_line), "Learn cancelled.");
+            return;
+        }
         switch_page(UIP_Patterneditor);
         return;
     }
@@ -196,13 +241,15 @@ void CUI_CcConsole::update(void) {
 
     if ((kstate & KS_CTRL) && !(kstate & KS_SHIFT) && key == SDLK_S) {
         if (loaded) {
-            int rc = zt_ccizer_save_view_sidecar(&g_loaded);
-            if (rc == 0) {
+            int rc1 = zt_ccizer_save_view_sidecar(&g_loaded);
+            int rc2 = zt_ccizer_save_learn_sidecar(&g_loaded);
+            if (rc1 == 0 && rc2 == 0) {
                 snprintf(status_line, sizeof(status_line),
-                         "Saved %s.cc-view.", g_loaded.basename);
+                         "Saved %s.cc-view + %s.cc-midi.",
+                         g_loaded.basename, g_loaded.basename);
             } else {
                 snprintf(status_line, sizeof(status_line),
-                         "Failed to save sidecar (%d).", rc);
+                         "Failed to save sidecar (view=%d learn=%d).", rc1, rc2);
             }
         }
         return;
@@ -267,6 +314,29 @@ void CUI_CcConsole::update(void) {
                  "%s view = %s  (Ctrl+S to save)",
                  s->name,
                  s->view == ZT_CCIZER_VIEW_KNOB ? "knob" : "slider");
+        return;
+    }
+    if (key == SDLK_L) {
+        // Toggle MIDI Learn for the focused slot. While learning, the
+        // next incoming CC/PB binds to slot_cur (handled in the MIDI-in
+        // pump above).
+        learning = !learning;
+        if (learning) {
+            midiInQueue.clear();
+            snprintf(status_line, sizeof(status_line),
+                     "LEARN: send a knob/CC/pitchbend for slot %d (%s)  ESC/L cancel",
+                     slot_cur + 1, s->name);
+        } else {
+            snprintf(status_line, sizeof(status_line), "Learn cancelled.");
+        }
+        return;
+    }
+    if (key == SDLK_U && loaded && slot_cur < g_loaded.num_slots) {
+        // Unbind learn for focused slot.
+        s->learn_status = 0;
+        s->learn_data1  = 0;
+        snprintf(status_line, sizeof(status_line),
+                 "Unbound learn for slot %d  (Ctrl+S to save)", slot_cur + 1);
         return;
     }
     // SPACE re-fires the current value (useful for testing wiring).
@@ -336,7 +406,7 @@ void CUI_CcConsole::draw(Drawable *S) {
 
     // ----- Slot grid pane -----
     print(col(CC_GRID_X), row(CC_GRID_Y - 1),
-          "Slot CC#  Name              View  Value",
+          "Slot CC#  Name              View          Value  Learn",
           focus == 1 ? COLORS.Brighttext : COLORS.Text, S);
 
     if (!loaded) {
@@ -372,11 +442,22 @@ void CUI_CcConsole::draw(Drawable *S) {
                 snprintf(view_str, sizeof(view_str), "%s", bar);
             }
 
-            char line[160];
+            char learn_str[16];
+            if (s->learn_status == 0) {
+                snprintf(learn_str, sizeof(learn_str), "----");
+            } else if ((s->learn_status & 0xF0) == 0xE0) {
+                snprintf(learn_str, sizeof(learn_str), "PB ch%d",
+                         (s->learn_status & 0x0F) + 1);
+            } else {
+                snprintf(learn_str, sizeof(learn_str), "%02X %02X",
+                         s->learn_status, s->learn_data1);
+            }
+            char line[200];
             snprintf(line, sizeof(line),
-                     "%c %3d  %-3s  %-16.16s %-15s %5d",
+                     "%c %3d  %-3s  %-16.16s %-13s %5d  %-6s",
                      (idx == slot_cur) ? '>' : ' ',
-                     idx + 1, cc_lbl, s->name, view_str, (int)s->value);
+                     idx + 1, cc_lbl, s->name, view_str, (int)s->value,
+                     learn_str);
 
             TColor fg = (idx == slot_cur)
                             ? (focus == 1 ? COLORS.Brighttext : COLORS.Text)

--- a/src/CUI_CcConsole.cpp
+++ b/src/CUI_CcConsole.cpp
@@ -146,10 +146,12 @@ void CUI_CcConsole::load_selected(void) {
     if (zt_ccizer_load(path, &g_loaded) == 0) {
         loaded = 1;
         slot_cur = slot_top = 0;
+        zt_ccizer_set_current_file(&g_loaded);
         snprintf(status_line, sizeof(status_line),
                  "Loaded %s — %d slot(s).", g_loaded.basename, g_loaded.num_slots);
     } else {
         loaded = 0;
+        zt_ccizer_set_current_file(NULL);
         snprintf(status_line, sizeof(status_line),
                  "Failed to load %s.", files[file_cur]);
     }

--- a/src/CUI_MainMenu.cpp
+++ b/src/CUI_MainMenu.cpp
@@ -77,6 +77,14 @@ static void mm_quit(void) {
     quit();
 }
 
+static void mm_toggle_cc_drawmode(void) {
+    g_cc_drawmode = !g_cc_drawmode;
+    snprintf(szStatmsg, sizeof(szStatmsg), "CC drawmode: %s",
+             g_cc_drawmode ? "ON  (incoming CC writes S/W effects)" : "OFF");
+    statusmsg = szStatmsg;
+    status_change = 1;
+}
+
 // Build a CLI invocation string that re-launches zt with the same
 // state the user has now (open MIDI in ports, MIDI clock chase target,
 // loaded song file) and copy it to the system clipboard. Pairs with
@@ -170,6 +178,7 @@ static const mm_entry MM_ENTRIES[] = {
 #endif
     {MM_CMD,        "Shortcuts & MIDI Mappings","Shift+F2",             CMD_SWITCH_KEYBINDINGS,     NULL},
     {MM_CMD,        "CC Console",               "Shift+F3",             CMD_SWITCH_CCCONSOLE,       NULL},
+    {MM_FUNC,       "Toggle CC Drawmode",       "Ctrl+Shift+\xA7",      0,                          mm_toggle_cc_drawmode},
     {MM_CMD,        "Lua Console",              "Ctrl+Alt+L",           CMD_SWITCH_LUA_CONSOLE,     NULL},
     {MM_FUNC,       "Toggle Fullscreen",        "Alt+Enter",            0,                          mm_toggle_fullscreen},
 

--- a/src/CUI_Page.h
+++ b/src/CUI_Page.h
@@ -513,6 +513,7 @@ class CUI_CcConsole : public CUI_Page {
         int slot_top;       // scroll offset for slot grid
         int channel;        // 1..16
         int loaded;         // is `loaded_file` populated?
+        int learning;       // 0 = browsing, 1 = waiting for incoming MIDI to learn-bind to slot_cur
         char status_line[160];
         char folder[1024];
         int  num_files;

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -1697,6 +1697,19 @@ void CUI_Patterneditor::update()
           key = 0;
         }
 
+        // CC drawmode toggle: Ctrl+Shift+§ (GRAVE). Plain Shift+§ is the
+        // existing PEM_MOUSEDRAW toggle (handled above); we use the
+        // Ctrl-extended combo so both gestures coexist. While CC drawmode
+        // is on, the MIDI-in handler below intercepts incoming CC (0xB0)
+        // and Pitchbend (0xE0) messages and writes Sxxyy / Wxxxx effects
+        // at the cursor row.
+        if ((kstate & KS_CTRL) && (kstate & KS_SHIFT) && key == SDLK_GRAVE) {
+          g_cc_drawmode = !g_cc_drawmode;
+          midiInQueue.clear();
+          sprintf(szStatmsg, "CC drawmode: %s", g_cc_drawmode ? "ON  (incoming CC writes S/W effects)" : "OFF");
+          statusmsg = szStatmsg; status_change = 1; need_refresh++; key = 0;
+        }
+
         // Double Pattern: Ctrl+Shift+G
         if ((kstate & KS_CTRL) && (kstate & KS_SHIFT) && key == SDLK_G) {
           UNDO_SAVE();
@@ -3089,21 +3102,64 @@ case SDLK_DELETE:
             if (midiInQueue.size()>0) {
               int dw;
               dw = midiInQueue.pop();
-              switch( dw&0xFF ) {
-              case 0x80: // Note off
-                key = (dw&0xFF00)>>8 ;
-                key+=0xFF;
-                if (jazz_note_is_active(key)) {
-                  const mbuf st = jazz_get_state(key);
-                  MidiOut->noteOff(song->instruments[cur_inst]->midi_device,st.note,st.chan,0x0,0);
-                  jazz_clear_state(key);
+              unsigned char status = (unsigned char)(dw & 0xFF);
+              unsigned char hi     = status & 0xF0;
+
+              // CC drawmode: capture CC (0xB0..0xBF) / PB (0xE0..0xEF) and
+              // write the matching effect (`Sxxyy` for CC, `Wxxxx` for PB)
+              // at the cursor row in the current edit track. Cursor advances
+              // by EditStep (step-follow). When drawmode is OFF the message
+              // falls through to the legacy 0x80/0x90 jazz-recording path.
+              if (g_cc_drawmode && (hi == 0xB0 || hi == 0xE0)) {
+                int data1 = (dw >> 8)  & 0x7F;
+                int data2 = (dw >> 16) & 0x7F;
+                if (hi == 0xB0) {
+                  // S<cc>:<val>  ->  effect 'S', effect_data = (cc<<8) | val
+                  unsigned short eff_data = (unsigned short)((data1 << 8) | data2);
+                  song->patterns[cur_edit_pattern]
+                       ->tracks[cur_edit_track]
+                       ->update_event(cur_edit_row, -1, -1, -1, -1, 'S', eff_data);
+                  sprintf(szStatmsg, "Drew S%02X%02X (CC %d = %d) at row %02X",
+                          data1, data2, data1, data2, cur_edit_row);
+                } else {
+                  // W<14bit pitchbend>  ->  effect 'W', effect_data = lsb|(msb<<7)
+                  unsigned short pb14 = (unsigned short)(data1 | (data2 << 7));
+                  song->patterns[cur_edit_pattern]
+                       ->tracks[cur_edit_track]
+                       ->update_event(cur_edit_row, -1, -1, -1, -1, 'W', pb14);
+                  sprintf(szStatmsg, "Drew W%04X (PB %d) at row %02X",
+                          pb14, pb14, cur_edit_row);
                 }
-                break;
-              case 0x90: // Note on
-                set_note = key = (dw&0xFF00)>>8 ;
-                key+=0xFF;
-                p1 = (dw&0xFF0000)>>16;
-                break;
+                statusmsg = szStatmsg; status_change = 1;
+                file_changed++;
+                // Step-follow: advance cursor by EditStep so the next CC
+                // message lands on the next row down.
+                int advance = cur_step;
+                if (advance < 1) advance = 1;
+                cur_edit_row += advance;
+                if (cur_edit_row >= song->patterns[cur_edit_pattern]->length)
+                  cur_edit_row = song->patterns[cur_edit_pattern]->length - 1;
+                need_refresh++;
+                // Don't fall through to note-jazz handling.
+                set_note = 0xFF;
+                p1 = -1;
+              } else {
+                switch( status ) {
+                case 0x80: // Note off (channel 0 — legacy)
+                  key = (dw&0xFF00)>>8 ;
+                  key+=0xFF;
+                  if (jazz_note_is_active(key)) {
+                    const mbuf st = jazz_get_state(key);
+                    MidiOut->noteOff(song->instruments[cur_inst]->midi_device,st.note,st.chan,0x0,0);
+                    jazz_clear_state(key);
+                  }
+                  break;
+                case 0x90: // Note on (channel 0 — legacy)
+                  set_note = key = (dw&0xFF00)>>8 ;
+                  key+=0xFF;
+                  p1 = (dw&0xFF0000)>>16;
+                  break;
+                }
               }
             }
             

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -1,5 +1,6 @@
 #include "zt.h"
 #include "platform/undo.h"
+#include "ccizer.h"
 
 // KS_META stub for Cmd key support (SDL3 maps macOS Cmd to SDL_KMOD_GUI).
 // Currently keybuffer does not translate GUI -> KS_META, so KS_META is a
@@ -3113,22 +3114,42 @@ case SDLK_DELETE:
               if (g_cc_drawmode && (hi == 0xB0 || hi == 0xE0)) {
                 int data1 = (dw >> 8)  & 0x7F;
                 int data2 = (dw >> 16) & 0x7F;
+                // Look up the friendly slot name from the currently-loaded
+                // CCizer file (if any) — matches by learn binding so we
+                // get "Cutoff" instead of "CC 74" in the status line.
+                const char *slot_name = NULL;
+                ZtCcizerFile *cf = zt_ccizer_current_file();
+                if (cf) {
+                  int m = zt_ccizer_find_learn_match(
+                      cf, status, (hi == 0xE0) ? 0 : (unsigned char)data1);
+                  if (m >= 0) slot_name = cf->slots[m].name;
+                }
                 if (hi == 0xB0) {
                   // S<cc>:<val>  ->  effect 'S', effect_data = (cc<<8) | val
                   unsigned short eff_data = (unsigned short)((data1 << 8) | data2);
                   song->patterns[cur_edit_pattern]
                        ->tracks[cur_edit_track]
                        ->update_event(cur_edit_row, -1, -1, -1, -1, 'S', eff_data);
-                  sprintf(szStatmsg, "Drew S%02X%02X (CC %d = %d) at row %02X",
-                          data1, data2, data1, data2, cur_edit_row);
+                  if (slot_name) {
+                    sprintf(szStatmsg, "Drew S%02X%02X [%s = %d] at row %02X",
+                            data1, data2, slot_name, data2, cur_edit_row);
+                  } else {
+                    sprintf(szStatmsg, "Drew S%02X%02X (CC %d = %d) at row %02X",
+                            data1, data2, data1, data2, cur_edit_row);
+                  }
                 } else {
                   // W<14bit pitchbend>  ->  effect 'W', effect_data = lsb|(msb<<7)
                   unsigned short pb14 = (unsigned short)(data1 | (data2 << 7));
                   song->patterns[cur_edit_pattern]
                        ->tracks[cur_edit_track]
                        ->update_event(cur_edit_row, -1, -1, -1, -1, 'W', pb14);
-                  sprintf(szStatmsg, "Drew W%04X (PB %d) at row %02X",
-                          pb14, pb14, cur_edit_row);
+                  if (slot_name) {
+                    sprintf(szStatmsg, "Drew W%04X [%s = %d] at row %02X",
+                            pb14, slot_name, pb14, cur_edit_row);
+                  } else {
+                    sprintf(szStatmsg, "Drew W%04X (PB %d) at row %02X",
+                            pb14, pb14, cur_edit_row);
+                  }
                 }
                 statusmsg = szStatmsg; status_change = 1;
                 file_changed++;

--- a/src/CUI_Sysconfig.cpp
+++ b/src/CUI_Sysconfig.cpp
@@ -448,6 +448,17 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         ml->bscb = cb; // link midi out list to bank select checkbox
         ml->al = ti;
 
+        // CCizer folder picker. Appended at the END of tabindex so the
+        // earlier UI->get_element(N) literal indices in update() (1=Prebuffer,
+        // 5=Full Screen, etc.) keep working. Label drawn in draw() below.
+        ti = new TextInput;
+        UI->add_element(ti, tabindex++);
+        ti->frame  = 1;
+        ti->x      = 4 + 16;                          // matches left-column controls
+        ti->y      = base_y + 7;                      // gap row 6 between Record Velocity (+5) and this
+        ti->xsize  = 56;                              // ends ~col 76, matches MIDI Out list right edge
+        ti->length = MAX_PATH;
+        ti->str    = (unsigned char*)zt_config_globals.ccizer_folder;
 }
 
 void CUI_Sysconfig::enter(void) {
@@ -508,6 +519,7 @@ void CUI_Sysconfig::draw(Drawable *S) {
 
         print(row(4),col(TRACKS_ROW_Y+7),"    Full Screen",COLORS.Text,S);
         print(row(4),col(TRACKS_ROW_Y+8),"Record Velocity",COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+10),"  CCizer Folder",COLORS.Text,S);
 #ifndef DISABLED_CONFIGURATION_VALUES
         print(row(4),col(TRACKS_ROW_Y+13),"     Key Repeat",COLORS.Text,S);
         print(row(4),col(TRACKS_ROW_Y+15),"       Key Wait",COLORS.Text,S);

--- a/src/ccizer.cpp
+++ b/src/ccizer.cpp
@@ -8,6 +8,8 @@
 
 #ifdef _WIN32
 #  include <windows.h>
+#  include <io.h>
+#  define unlink _unlink
 #else
 #  include <dirent.h>
 #  include <unistd.h>
@@ -94,7 +96,7 @@ int zt_ccizer_load(const char *path, ZtCcizerFile *out) {
     }
     fclose(fp);
 
-    // Read sidecar if present.
+    // Read .cc-view sidecar if present.
     char sidecar[1280];
     path_swap_extension(path, ".cc-view", sidecar, sizeof(sidecar));
     FILE *vfp = fopen(sidecar, "r");
@@ -115,7 +117,64 @@ int zt_ccizer_load(const char *path, ZtCcizerFile *out) {
         fclose(vfp);
     }
 
+    // Read .cc-midi sidecar if present. Format per line:
+    //   <slot> <status hex> <data1 hex>
+    // e.g. "2 B0 4A"
+    path_swap_extension(path, ".cc-midi", sidecar, sizeof(sidecar));
+    FILE *mfp = fopen(sidecar, "r");
+    if (mfp) {
+        while (fgets(line, sizeof(line), mfp)) {
+            rstrip(line);
+            if (line[0] == '#' || line[0] == '\0') continue;
+            int slot_idx = 0;
+            unsigned int st = 0, d1 = 0;
+            if (sscanf(line, "%d %x %x", &slot_idx, &st, &d1) == 3 &&
+                slot_idx >= 1 && slot_idx <= out->num_slots) {
+                ZtCcizerSlot *s = &out->slots[slot_idx - 1];
+                s->learn_status = (unsigned char)(st & 0xFF);
+                s->learn_data1  = (unsigned char)(d1 & 0x7F);
+            }
+        }
+        fclose(mfp);
+    }
+
     return 0;
+}
+
+int zt_ccizer_save_learn_sidecar(const ZtCcizerFile *f) {
+    if (!f || !f->path[0]) return -1;
+    char sidecar[1280];
+    path_swap_extension(f->path, ".cc-midi", sidecar, sizeof(sidecar));
+    FILE *fp = fopen(sidecar, "w");
+    if (!fp) return -2;
+    fprintf(fp, "# zTracker CC Console MIDI Learn -- slot, status (hex), data1 (hex)\n");
+    int wrote = 0;
+    for (int i = 0; i < f->num_slots; i++) {
+        if (f->slots[i].learn_status == 0) continue;
+        fprintf(fp, "%d %02X %02X\n", i + 1,
+                f->slots[i].learn_status, f->slots[i].learn_data1);
+        wrote++;
+    }
+    fclose(fp);
+    if (wrote == 0) {
+        // No mappings -> remove the file entirely so the next load doesn't
+        // resurrect a stale sidecar.
+        unlink(sidecar);
+    }
+    return 0;
+}
+
+int zt_ccizer_find_learn_match(const ZtCcizerFile *f,
+                               unsigned char status,
+                               unsigned char data1) {
+    if (!f) return -1;
+    for (int i = 0; i < f->num_slots; i++) {
+        if (f->slots[i].learn_status == status &&
+            f->slots[i].learn_data1  == data1) {
+            return i;
+        }
+    }
+    return -1;
 }
 
 int zt_ccizer_save_view_sidecar(const ZtCcizerFile *f) {

--- a/src/ccizer.cpp
+++ b/src/ccizer.cpp
@@ -177,6 +177,11 @@ int zt_ccizer_find_learn_match(const ZtCcizerFile *f,
     return -1;
 }
 
+static ZtCcizerFile *g_ccizer_current = NULL;
+
+ZtCcizerFile *zt_ccizer_current_file() { return g_ccizer_current; }
+void zt_ccizer_set_current_file(ZtCcizerFile *f) { g_ccizer_current = f; }
+
 int zt_ccizer_save_view_sidecar(const ZtCcizerFile *f) {
     if (!f || !f->path[0]) return -1;
     char sidecar[1280];

--- a/src/ccizer.h
+++ b/src/ccizer.h
@@ -66,6 +66,13 @@ int  zt_ccizer_find_learn_match(const ZtCcizerFile *f,
                                 unsigned char status,
                                 unsigned char data1);
 
+// Process-wide currently-loaded CC Console file pointer. The CC Console
+// writes to it when a file is loaded; the Pattern Editor reads it to
+// pretty-print learnt slot names in status messages while CC drawmode
+// is on. May be NULL if nothing has been loaded this session.
+extern ZtCcizerFile *zt_ccizer_current_file();
+void zt_ccizer_set_current_file(ZtCcizerFile *f);
+
 // Scan `dir` for files ending in ".txt". Returns sorted basenames in `out`,
 // up to `max_results`. Returns count.
 int  zt_ccizer_list_dir(const char *dir, char (*out)[256], int max_results);

--- a/src/ccizer.h
+++ b/src/ccizer.h
@@ -31,6 +31,11 @@ struct ZtCcizerSlot {
     char name[64];
     unsigned char view;        // ZT_CCIZER_VIEW_SLIDER | _KNOB
     unsigned short value;      // 0..127 normally, 0..16383 when cc==PB_MARKER
+
+    // MIDI Learn: incoming (status, data1) that maps to this slot.
+    // learn_status == 0 => unmapped. Persisted in the `.cc-midi` sidecar.
+    unsigned char learn_status;
+    unsigned char learn_data1;
 };
 
 struct ZtCcizerFile {
@@ -49,6 +54,17 @@ int  zt_ccizer_load(const char *path, ZtCcizerFile *out);
 // Path is `<f->path>` with the trailing ".txt" replaced by ".cc-view".
 // Returns 0 on success.
 int  zt_ccizer_save_view_sidecar(const ZtCcizerFile *f);
+
+// Write the .cc-midi sidecar for `f` based on each slot's learn_status
+// / learn_data1 fields. Slots with learn_status==0 are skipped. Path is
+// `<f->path>` with `.txt` replaced by `.cc-midi`.
+int  zt_ccizer_save_learn_sidecar(const ZtCcizerFile *f);
+
+// Match an incoming (status, data1) pair against any learnt slot. Returns
+// the matching slot index (0-based) or -1 on no match.
+int  zt_ccizer_find_learn_match(const ZtCcizerFile *f,
+                                unsigned char status,
+                                unsigned char data1);
 
 // Scan `dir` for files ending in ".txt". Returns sorted basenames in `out`,
 // up to `max_results`. Returns count.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -342,6 +342,7 @@ CUI_Midimacroeditor *UIP_Midimacroeditor = NULL;
 CUI_LuaConsole *UIP_LuaConsole = NULL;
 CUI_KeyBindings *UIP_KeyBindings = NULL;
 CUI_CcConsole *UIP_CcConsole = NULL;
+int g_cc_drawmode = 0;
 
 
 

--- a/src/zt.h
+++ b/src/zt.h
@@ -703,6 +703,13 @@ extern int cur_edit_column;
 extern int base_octave ;
 extern int cur_step;
 
+// CC drawmode -- when non-zero, the Pattern Editor's MIDI-in handler
+// captures incoming CC (0xB0) and Pitchbend (0xE0) messages and writes
+// them as `Sxxyy` (CC) / `Wxxxx` (PB) effects at the cursor row in the
+// current edit track, advancing the cursor by EditStep. Toggle with
+// Ctrl+Shift+§ from the Pattern Editor or from the ESC main menu.
+extern int g_cc_drawmode;
+
 extern int keypress;
 extern int keywait;
 extern zt_timer_handle keytimer;


### PR DESCRIPTION
## Stacked on PR #78

This PR builds on `esa/ccizer-console` (PR #78). Merge #78 first, then rebase / merge this. Diff against `master` reduces to just this PR's commits once #78 lands.

## What this PR does — four follow-ups from CC Console v1 TODO list

### 1. F12 Sysconfig: CCizer Folder text input
TextInput on the System Configuration page bound directly to `zt_config_globals.ccizer_folder`. Users pick / change the CCizer folder without editing `zt.conf` by hand. (TODO 0.)

### 2. Pattern Editor: Ctrl+Shift+§ CC drawmode
New global `g_cc_drawmode`. While ON, incoming MIDI CC and Pitchbend get written into the pattern as `Sxxyy` / `Wxxxx` effects at cursor row, advancing by EditStep. No .zt format change — both effect letters already exist in `playback.cpp`.

- Toggle: Ctrl+Shift+§ (plain Shift+§ keeps its existing PEM_MOUSEDRAW toggle — both drawmodes coexist).
- ESC menu also gets a "Toggle CC Drawmode" entry.
- All 16 channels match for CC/PB capture (legacy 0x80/0x90 jazz path still channel-0-only, intact).

(TODO 2 — the headline "Shift+§ CC drawing" feature, on Ctrl+Shift+§ since plain Shift+§ is taken.)

### 3. CC Console: MIDI Learn per slot + .cc-midi sidecar
Press L on a focused slot to enter Learn; next incoming CC/PB binds `(status, data1)` to that slot. Press U to unbind. Bindings persist in `.cc-midi` sidecar next to the `.txt` (Ctrl+S writes both `.cc-view` and `.cc-midi`).

`ZtCcizerSlot` grows `learn_status` / `learn_data1`. CC Console pumps `midiInQueue` every frame: in Learn mode the next CC/PB binds; otherwise a CC/PB matching a learnt slot updates the slot value and moves cursor. New "Learn" column shows per-slot binding (`B0 4A`, `PB ch3`, or `----`).

(TODO 3.)

### 4. CC drawmode: pretty-print learnt CCizer slot names
When CC drawmode is on AND a CCizer file is loaded with the incoming CC learnt to a slot, the Pattern Editor status shows the friendly slot name (`Cutoff`) instead of the raw CC number.

Process-wide `zt_ccizer_current_file()` set by CC Console on load, read by Pattern Editor on capture.

(TODO 4.)

## Deferred

**TODO 1 — Per-instrument CCizer bank assignment.** Changes the .zt save format (new optional chunk + new instrument field). Skipped here intentionally — deserves its own focused review. Will follow as a separate PR.

## Test plan

- [x] Builds clean on macOS arm64
- [x] `ctest --output-on-failure` — all 6 suites pass
- [ ] Manual: F12 → CCizer Folder field accepts paste, persists across restart
- [ ] Manual: Ctrl+Shift+§ → "CC drawmode: ON"; tweak knob → `Sxxyy` lands in pattern; cursor advances by EditStep
- [ ] Manual: L on focused slot, twist knob → binds; restart → loads from .cc-midi
- [ ] Manual: with CCizer loaded + drawmode ON, learnt knob shows friendly name (`Drew SB04A [Cutoff = 74]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
