### PR TITLE
.zt format: per-instrument CCizer bank (optional CCBN chunk)

### DIFF
--- a/src/CUI_CcConsole.cpp
+++ b/src/CUI_CcConsole.cpp
@@ -162,7 +162,7 @@ void CUI_CcConsole::enter(void) {
     rescan_folder();
     if (!loaded && num_files > 0) load_selected();
     snprintf(status_line, sizeof(status_line),
-             "Tab focus | Lt/Rt value | V slider/knob | L learn | U unbind | [/] ch | Ctrl+S save | ESC exit");
+             "Tab | Lt/Rt val | V slider/knob | L learn | U unbind | B bank-to-inst | Shift+B clear | [/] ch | Ctrl+S | ESC");
     Keys.flush();
 }
 
@@ -330,6 +330,37 @@ void CUI_CcConsole::update(void) {
                      slot_cur + 1, s->name);
         } else {
             snprintf(status_line, sizeof(status_line), "Learn cancelled.");
+        }
+        return;
+    }
+    if (key == SDLK_B) {
+        // Assign the currently-loaded file as the bank for the current
+        // instrument (Shift+B clears it). Persisted in the .zt file via
+        // the CCBN chunk on next save.
+        if (cur_inst < 0 || cur_inst >= MAX_INSTS || !song->instruments[cur_inst]) {
+            snprintf(status_line, sizeof(status_line), "No current instrument.");
+            return;
+        }
+        if (kstate & KS_SHIFT) {
+            song->instruments[cur_inst]->ccizer_bank[0] = '\0';
+            file_changed++;
+            snprintf(status_line, sizeof(status_line),
+                     "Cleared CCizer bank for inst %d.", cur_inst);
+            return;
+        }
+        if (loaded) {
+            strncpy(song->instruments[cur_inst]->ccizer_bank,
+                    g_loaded.basename,
+                    sizeof(song->instruments[cur_inst]->ccizer_bank) - 1);
+            song->instruments[cur_inst]->ccizer_bank[
+                sizeof(song->instruments[cur_inst]->ccizer_bank) - 1] = '\0';
+            file_changed++;
+            snprintf(status_line, sizeof(status_line),
+                     "Assigned %s as bank for inst %d.",
+                     g_loaded.basename, cur_inst);
+        } else {
+            snprintf(status_line, sizeof(status_line),
+                     "Load a file first (Enter on Files pane).");
         }
         return;
     }

--- a/src/CUI_InstEditor.cpp
+++ b/src/CUI_InstEditor.cpp
@@ -554,6 +554,20 @@ void CUI_InstEditor::draw(Drawable *S)
         draw_status(S);
         status(S);
         printtitle(PAGE_TITLE_ROW_Y,"Instrument Editor (F3)",COLORS.Text,COLORS.Background,S);
+        // CCizer bank attached to the focused instrument. Show the
+        // basename (or "(none)") so the user can see which CC layout
+        // was assigned via Shift+F3 -> B. Per-instrument data persists
+        // in the .zt CCBN chunk.
+        {
+            const char *bank = (cur_inst >= 0 && cur_inst < MAX_INSTS &&
+                                song->instruments[cur_inst] &&
+                                song->instruments[cur_inst]->ccizer_bank[0])
+                                   ? song->instruments[cur_inst]->ccizer_bank
+                                   : "(none)";
+            char ccline[72];
+            snprintf(ccline, sizeof(ccline), "CCizer Bank: %-50.50s", bank);
+            printBG(col(36), row(11), ccline, COLORS.Text, COLORS.Background, S);
+        }
         printBG(col(36),row(13),"Bank",COLORS.Text,COLORS.Background,S);
         printBG(col(58),row(13),"Patch",COLORS.Text,COLORS.Background,S);
         printBG(col(36),row(18),"Default Volume",COLORS.Text,COLORS.Background,S);

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -82,6 +82,8 @@ instrument::instrument(int p)
   memset(title,' ',ZTM_INSTTITLE_MAXLEN);
   title[ZTM_INSTTITLE_MAXLEN-1]=0;
 
+  ccizer_bank[0] = '\0';
+
   // <Manu>
   MarkAsUnused() ;
 }

--- a/src/module.h
+++ b/src/module.h
@@ -145,6 +145,13 @@ public:
 
   unsigned short int default_length;
 
+  // CCizer bank attached to this instrument. Filename only (basename of a
+  // `.txt` in the configured ccizer_folder), e.g. "microfreak.txt". Empty
+  // string = no bank attached. Persisted in the .zt file via the optional
+  // CCBN chunk; the chunk is skipped by older zTracker versions, which
+  // load such files cleanly with this field empty (forward-compat).
+  char ccizer_bank[256];
+
 } ;
 
 

--- a/src/ztfile-io.cpp
+++ b/src/ztfile-io.cpp
@@ -700,7 +700,38 @@ int zt_module::save(char *fn, int compressed)
             writeblock("ZTin",&buffer,compressed,f,lpDS);
         }
     }
-    
+
+    // CCBN: optional chunk listing per-instrument CCizer bank filenames.
+    // Skipped by older zTracker versions (unrecognized chunk -> harmless).
+    // Format:
+    //   uint32 count
+    //   repeat count times:
+    //     uint8  inst_idx (0..ZTM_MAX_INSTS-1)
+    //     uint16 length    (path bytes, no null terminator)
+    //     bytes  path      (length bytes)
+    {
+        short int count = 0;
+        for (i = 0; i < ZTM_MAX_INSTS; i++) {
+            if (this->instruments[i] && this->instruments[i]->ccizer_bank[0])
+                count++;
+        }
+        if (count > 0) {
+            buffer.write((const char *)&count, sizeof(short int));
+            for (i = 0; i < ZTM_MAX_INSTS; i++) {
+                if (!this->instruments[i] || !this->instruments[i]->ccizer_bank[0])
+                    continue;
+                unsigned char inst_idx = (unsigned char)i;
+                const char *path = this->instruments[i]->ccizer_bank;
+                short int len = (short int)strlen(path);
+                buffer.write((const char *)&inst_idx, sizeof(unsigned char));
+                buffer.write((const char *)&len, sizeof(short int));
+                buffer.write(path, len);
+            }
+            writeblock("CCBN", &buffer, compressed, f, lpDS);
+        }
+    }
+
+
     for(i=0;i<ZTM_MAX_ARPEGGIOS;i++) {
         if (this->arpeggios[i] && !this->arpeggios[i]->isempty()) {
             build_arpeggio(&buffer,i);
@@ -1220,6 +1251,37 @@ int zt_module::load(char *fn)
             if (cmp_hd(&header[0], "ZTpp")) { load_ZT_pattern_properties(&buffer); recognized_chunks++; }
             if (cmp_hd(&header[0], "ZTin")) { load_ZT_instrument(&buffer); recognized_chunks++; }
             if (cmp_hd(&header[0], "ZTev")) { load_ZT_event_list(&buffer); recognized_chunks++; saw_event_list = 1; }
+            if (cmp_hd(&header[0], "CCBN")) {
+                // Optional per-instrument CCizer bank chunk. Format:
+                //   uint32 count
+                //   repeat: uint8 inst_idx, uint16 length, bytes path
+                // Bounds-checked at every step so a corrupt or malicious
+                // chunk can't read past the buffer or scribble out of
+                // range. Failure stops processing this chunk; the rest of
+                // the song still loads.
+                short int count = buffer.getsi();
+                if (count >= 0 && count <= ZTM_MAX_INSTS) {
+                    for (short int k = 0; k < count; k++) {
+                        unsigned char inst_idx = buffer.getuch();
+                        short int len          = buffer.getsi();
+                        if (len < 0) len = 0;
+                        if ((size_t)len >= sizeof(this->instruments[0]->ccizer_bank))
+                            len = (short int)(sizeof(this->instruments[0]->ccizer_bank) - 1);
+                        char tmp[sizeof(this->instruments[0]->ccizer_bank)];
+                        for (short int b = 0; b < len; b++)
+                            tmp[b] = buffer.getch();
+                        tmp[len] = '\0';
+                        if (inst_idx < ZTM_MAX_INSTS && this->instruments[inst_idx]) {
+                            strncpy(this->instruments[inst_idx]->ccizer_bank,
+                                    tmp,
+                                    sizeof(this->instruments[inst_idx]->ccizer_bank) - 1);
+                            this->instruments[inst_idx]->ccizer_bank[
+                                sizeof(this->instruments[inst_idx]->ccizer_bank) - 1] = '\0';
+                        }
+                    }
+                }
+                recognized_chunks++;
+            }
         }
         SDL_Delay(1);
     }


### PR DESCRIPTION
## Stacked on PR #79 (which is stacked on #78)

Merge order: **#78 → #79 → #80**. This PR's diff against `master` reduces to just this commit once #78/#79 land.

## What this PR does

Adds a **per-instrument CCizer bank** field. Each instrument carries a CCizer filename ("microfreak.txt", "sc88st.txt", etc.) that's persisted in the `.zt` save format via a new optional **`CCBN` chunk**.

## .zt format change — fully backward AND forward compatible

* **Old `.zt` files in new zTracker**: no `CCBN` chunk → bank string empty → fine.
* **New `.zt` files in old zTracker**: `CCBN` is unrecognized → falls through the chunk switch → `readblock()` already advanced past it → no crash, no error, file loads cleanly with bank field absent (just unused on the old binary).

The skip-on-unknown property is inherent to the existing chunk loader (every `cmp_hd(...) { ... recognized_chunks++; }` block has no `else`; unrecognized chunks are silently dropped after `readblock` consumed their bytes). I only had to confirm it; no compatibility shim added.

## Chunk format

```
short int  count           -- number of entries
repeat count times:
  unsigned char  inst_idx  -- 0..ZTM_MAX_INSTS-1
  short int      length    -- path bytes (no null terminator)
  bytes          path      -- length bytes
```

The chunk is **only written when count > 0** — songs without per-instrument banks save byte-identical to pre-`CCBN` `.zt` files, so you can verify backward compatibility with existing saves trivially.

## Bounds checking

The loader is paranoid about hostile / corrupted chunks:
- `count <= ZTM_MAX_INSTS` else skip the whole chunk.
- `length` clamped to `sizeof(ccizer_bank) - 1` so a malicious giant length can't overrun.
- `inst_idx < ZTM_MAX_INSTS` else discard that entry.
- Failure of any check stops processing **this chunk only** — the rest of the song still loads.

## UI

- **F3 Instrument Editor** draws `CCizer Bank: <basename>` (or `(none)`) at row 11.
- **Shift+F3 CC Console**: press `B` on a loaded file to assign its basename as the focused instrument's bank; `Shift+B` clears it. `file_changed` bumps so Ctrl+S persists.

## Test plan

- [x] Builds clean on macOS arm64 (the other 4 platforms run via CI)
- [x] `ctest --output-on-failure` — 6/6 suites pass
- [ ] Manual: assign a bank in CC Console (B), Ctrl+S the song, reload — bank persists.
- [ ] Manual: open a song saved with this PR in a pre-`CCBN` build of zTracker — file loads, no error, banks are absent (expected).
- [ ] Manual: open a pre-`CCBN` `.zt` file in this build — loads, all banks empty (expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
