### PR TITLE
CCizer: auto-route on instrument switch + drawmode badge + undo

### DIFF
--- a/src/CUI_CcConsole.cpp
+++ b/src/CUI_CcConsole.cpp
@@ -139,6 +139,25 @@ void CUI_CcConsole::rescan_folder(void) {
     if (file_top > file_cur) file_top = file_cur;
 }
 
+void CUI_CcConsole::load_by_basename(const char *bn) {
+    if (!bn || !*bn) return;
+    if (folder[0] == '\0') rescan_folder();
+    if (folder[0] == '\0') return;
+    // Skip if it's already loaded — avoids re-reading on every
+    // cur_inst-change tick when the user stays on one instrument.
+    if (loaded && strcmp(g_loaded.basename, bn) == 0) return;
+    // Find it in the current folder list.
+    for (int i = 0; i < num_files; i++) {
+        if (strcmp(files[i], bn) == 0) {
+            file_cur = i;
+            load_selected();
+            return;
+        }
+    }
+    // Not in the configured folder — don't try to follow an absolute path.
+    // Just leave whatever is currently loaded; the user can switch folders.
+}
+
 void CUI_CcConsole::load_selected(void) {
     if (file_cur < 0 || file_cur >= num_files || folder[0] == '\0') return;
     char path[1280];

--- a/src/CUI_Page.h
+++ b/src/CUI_Page.h
@@ -528,6 +528,11 @@ class CUI_CcConsole : public CUI_Page {
 
         void rescan_folder(void);
         void load_selected(void);
+        // Look up `bn` (basename, e.g. "microfreak.txt") in the current
+        // ccizer folder and load it. Used by the Pattern Editor to
+        // auto-route the CC Console to the focused instrument's bank
+        // when cur_inst changes. No-op if `bn` is empty or not found.
+        void load_by_basename(const char *bn);
 };
 
 // Unified Shortcuts & MIDI Mappings page. cursor_y picks an action;

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -15,6 +15,12 @@ static PatternUndo g_undo;
 // Save undo snapshot before destructive pattern operations
 #define UNDO_SAVE() g_undo.save(song, cur_edit_pattern)
 
+// Reset by the Ctrl+Shift+§ toggle each time CC drawmode flips state,
+// then set on the first drawmode write so each ON->...->OFF session
+// produces exactly one UNDO_SAVE() snapshot. See the MIDI-in handler
+// further down.
+static int g_cc_draw_session_snapped = 0;
+
 #define LEFT_MARGIN                     40
 #define RIGHT_MARGIN                    2
 
@@ -999,6 +1005,23 @@ void CUI_Patterneditor::update()
     need_refresh++;
     clear++;
   }
+
+  // Auto-route the CC Console to the focused instrument's CCizer bank
+  // whenever cur_inst changes. The user picks an instrument here and the
+  // Shift+F3 page silently follows so "1st CC for instrument N" maps to
+  // slot 1 of *that* instrument's bank without having to flip pages.
+  // Tracked across frames via a static; on the first frame after a
+  // bank-bearing instrument becomes focused, load_by_basename() pulls
+  // the file in (no-op if it's already loaded).
+  static int s_last_cur_inst = -1;
+  if (cur_inst != s_last_cur_inst) {
+    s_last_cur_inst = cur_inst;
+    if (UIP_CcConsole && cur_inst >= 0 && cur_inst < MAX_INSTS &&
+        song->instruments[cur_inst] &&
+        song->instruments[cur_inst]->ccizer_bank[0]) {
+      UIP_CcConsole->load_by_basename(song->instruments[cur_inst]->ccizer_bank);
+    }
+  }
   //memset(note,0,4);
 
 //  int pattern_visible ;
@@ -1706,6 +1729,7 @@ void CUI_Patterneditor::update()
         // at the cursor row.
         if ((kstate & KS_CTRL) && (kstate & KS_SHIFT) && key == SDLK_GRAVE) {
           g_cc_drawmode = !g_cc_drawmode;
+          g_cc_draw_session_snapped = 0;  // start a fresh undo session each toggle
           midiInQueue.clear();
           sprintf(szStatmsg, "CC drawmode: %s", g_cc_drawmode ? "ON  (incoming CC writes S/W effects)" : "OFF");
           statusmsg = szStatmsg; status_change = 1; need_refresh++; key = 0;
@@ -3114,6 +3138,16 @@ case SDLK_DELETE:
               if (g_cc_drawmode && (hi == 0xB0 || hi == 0xE0)) {
                 int data1 = (dw >> 8)  & 0x7F;
                 int data2 = (dw >> 16) & 0x7F;
+                // Snapshot the pattern before the first write of this
+                // drawmode session so the user can undo a knob run with
+                // a single Ctrl+Z. The session marker is reset by the
+                // Ctrl+Shift+§ toggler itself (above) whenever drawmode
+                // flips on/off, so each ON->...->OFF span generates one
+                // undo step.
+                if (!g_cc_draw_session_snapped) {
+                    UNDO_SAVE();
+                    g_cc_draw_session_snapped = 1;
+                }
                 // Look up the friendly slot name from the currently-loaded
                 // CCizer file (if any) — matches by learn binding so we
                 // get "Cutoff" instead of "CC 74" in the status line.
@@ -3662,7 +3696,19 @@ void CUI_Patterneditor::draw(Drawable *S)
     draw_status_vars(S);
 
     printtitle(PAGE_TITLE_ROW_Y,"Pattern Editor (F2)",COLORS.Text,COLORS.Background,S);
-    
+
+    // Persistent CC drawmode badge — easy to forget the toggle is on
+    // since the toggle's status message scrolls past. Right-aligned on
+    // the title row so it doesn't fight with the pattern data area.
+    if (g_cc_drawmode) {
+      const char *badge = "[CC DRAW] (Ctrl+Shift+\xA7 toggles)";
+      int badge_len = (int)strlen(badge);
+      int x_col = CHARS_X - badge_len - 2;
+      if (x_col < 2) x_col = 2;
+      print(col(x_col), row(PAGE_TITLE_ROW_Y), badge,
+            COLORS.Brighttext, S);
+    }
+
     switch(mode) {
       
     case PEM_MOUSEDRAW: 


### PR DESCRIPTION
## Stacked on PR #80 (chain: #78 → #79 → #80 → #81)

Merge order: #78 → #79 → #80 → #81. This PR's diff against `master` reduces to just this commit once the upstream PRs land.

## Three behavioural fixes that finish the per-instrument CCizer workflow

After PR #80 attached a CCizer file to each instrument, three gaps remained between what the user described and what shipped:
- the assigned bank didn't auto-route on instrument switch
- there was no persistent on-screen indicator that drawmode was on
- a knob run had no undo

This PR closes all three.

### 1. Auto-load CC Console bank on `cur_inst` change
- New `CUI_CcConsole::load_by_basename(bn)` looks the filename up in the current ccizer folder and loads it.
- Pattern Editor `update()` tracks `cur_inst` across frames; when it changes to an instrument with a non-empty `ccizer_bank`, it calls into the CC Console.
- No-op when the bank is already loaded (avoids re-reading every frame).
- "1st CC for instrument N" now actually maps to slot 1 of *that* instrument's bank without flipping pages — the Shift+F3 page silently follows the F2 cursor's instrument.

### 2. Visible `[CC DRAW]` badge in Pattern Editor
Right-aligned on the title row whenever `g_cc_drawmode` is on. The Ctrl+Shift+§ toggle prints a status message but it scrolls past; this badge stays put so an unintentional knob tweak doesn't surprise-write effects into the pattern.

### 3. Single `UNDO_SAVE` per drawmode session
- New file-static `g_cc_draw_session_snapped`. Reset every time Ctrl+Shift+§ flips drawmode (on or off).
- The first drawmode write per session does `UNDO_SAVE()`; subsequent writes don't.
- One Ctrl+Z reverts the entire knob run, and the undo history doesn't blow up when the user wiggles a knob 200 times.

## Test plan

- [x] Builds clean on macOS arm64
- [x] `ctest --output-on-failure` — 6/6 suites pass
- [ ] Manual: assign a bank to inst 1 (Shift+F3 → B), assign a different bank to inst 2; F2 instrument switch flips Shift+F3's loaded file
- [ ] Manual: Ctrl+Shift+§ → `[CC DRAW]` badge appears top-right; toggle off → badge disappears
- [ ] Manual: drawmode ON → tweak a knob 50 times → Ctrl+Z reverts the whole session as one step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
