### PR TITLE
SysEx I/O foundation: send (3 platforms) + receive queue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ set(ZT_SOURCES
   src/midi_mappings.cpp
   src/ccizer.cpp
   src/CUI_CcConsole.cpp
+  src/sysex_inq.cpp
 )
 
 if(WIN32)

--- a/src/OutputDevices.cpp
+++ b/src/OutputDevices.cpp
@@ -178,6 +178,16 @@ void MidiOutputDevice::sendCC(unsigned char cc, unsigned char value,unsigned cha
 	midiOutMsg( 0xB0 + chan, cc, value);
 }
 
+int MidiOutputDevice::sendSysEx(const unsigned char *bytes, int len) {
+    if (!this->opened || !bytes || len <= 0) return 0;
+    // Caller passes the full SysEx including 0xF0..0xF7 framing. Defensive
+    // check: at minimum we want F0 ... F7. If the caller forgot to frame
+    // we refuse rather than spit out a malformed byte stream that some
+    // synths interpret as random short messages.
+    if (bytes[0] != 0xF0 || bytes[len - 1] != 0xF7) return 0;
+    return zt_midi_out_sysex(handle, bytes, len) == MMSYSERR_NOERROR ? 1 : 0;
+}
+
 
 
 #ifdef _ENABLE_AUDIO    

--- a/src/OutputDevices.h
+++ b/src/OutputDevices.h
@@ -23,6 +23,7 @@ class MidiOutputDevice : public OutputDevice {
         virtual void pitchWheel(unsigned char chan, unsigned short int value);
         virtual void progChange(int program, int bank, unsigned char chan);
         virtual void sendCC(unsigned char cc, unsigned char value,unsigned char chan);
+        virtual int  sendSysEx(const unsigned char *bytes, int len);
 
 
 	private:

--- a/src/midi-io.h
+++ b/src/midi-io.h
@@ -94,6 +94,12 @@ class OutputDevice {
         virtual void progChange(int program, int bank, unsigned char chan)=0;
         virtual void sendCC(unsigned char cc, unsigned char value,unsigned char chan)=0;
 
+        // SysEx send. `bytes` must include the leading 0xF0 status and
+        // trailing 0xF7 EOX; `len` includes both. Default impl is a no-op
+        // so AudioOutputDevice subclasses (TestTone, Noise) don't have to
+        // implement it. Returns 1 on success, 0 on error/unsupported.
+        virtual int sendSysEx(const unsigned char * /*bytes*/, int /*len*/) { return 0; }
+
 };
 
 class AudioOutputDevice : public OutputDevice {
@@ -207,6 +213,10 @@ class midiOut {
         inline void sendCC(unsigned int dev,unsigned char cc, unsigned char value,unsigned char chan) {
             if (dev>=numOuputDevices) return;
             outputDevices[dev]->sendCC(cc,value,chan);
+        }
+        inline int sendSysEx(unsigned int dev, const unsigned char *bytes, int len) {
+            if (dev >= numOuputDevices) return 0;
+            return outputDevices[dev]->sendSysEx(bytes, len);
         }
         inline void clock(void) {
             sendGlobal(0xF8);

--- a/src/sysex_inq.cpp
+++ b/src/sysex_inq.cpp
@@ -1,0 +1,58 @@
+#include "sysex_inq.h"
+
+#include <mutex>
+#include <string.h>
+
+namespace {
+
+struct Slot {
+    int len;
+    unsigned char data[ZT_SYSEX_MAX_LEN];
+};
+
+Slot       g_slots[ZT_SYSEX_QUEUE_SLOTS];
+int        g_head  = 0;    // next read slot
+int        g_tail  = 0;    // next write slot
+int        g_count = 0;
+std::mutex g_mu;
+
+} // namespace
+
+extern "C" void zt_sysex_inq_clear(void) {
+    std::lock_guard<std::mutex> lk(g_mu);
+    g_head = g_tail = g_count = 0;
+}
+
+extern "C" int zt_sysex_inq_push(const unsigned char *bytes, int len) {
+    if (!bytes || len <= 0 || len > ZT_SYSEX_MAX_LEN) return 0;
+    std::lock_guard<std::mutex> lk(g_mu);
+    if (g_count == ZT_SYSEX_QUEUE_SLOTS) {
+        // Overflow: drop oldest.
+        g_head = (g_head + 1) % ZT_SYSEX_QUEUE_SLOTS;
+        g_count--;
+    }
+    Slot *s = &g_slots[g_tail];
+    s->len = len;
+    memcpy(s->data, bytes, (size_t)len);
+    g_tail = (g_tail + 1) % ZT_SYSEX_QUEUE_SLOTS;
+    g_count++;
+    return 1;
+}
+
+extern "C" int zt_sysex_inq_pop(unsigned char *out, int out_cap) {
+    if (!out || out_cap <= 0) return 0;
+    std::lock_guard<std::mutex> lk(g_mu);
+    if (g_count == 0) return 0;
+    Slot *s = &g_slots[g_head];
+    if (s->len > out_cap) return 0;     // caller's buffer too small; leave in place
+    int n = s->len;
+    memcpy(out, s->data, (size_t)n);
+    g_head = (g_head + 1) % ZT_SYSEX_QUEUE_SLOTS;
+    g_count--;
+    return n;
+}
+
+extern "C" int zt_sysex_inq_size(void) {
+    std::lock_guard<std::mutex> lk(g_mu);
+    return g_count;
+}

--- a/src/sysex_inq.h
+++ b/src/sysex_inq.h
@@ -1,0 +1,53 @@
+#ifndef _ZT_SYSEX_INQ_H_
+#define _ZT_SYSEX_INQ_H_
+
+// Process-wide queue of incoming SysEx messages.
+//
+// MIDI input callbacks on each platform parse F0..F7 frames out of the
+// raw byte stream and push complete messages here. Consumers (e.g. the
+// upcoming Send/Recv SysEx page) call zt_sysex_inq_pop() to drain the
+// queue.
+//
+// Storage is bounded -- both the per-message length cap and the total
+// queued-frames cap. Overflow drops the oldest message rather than
+// growing without bound; this matches the behaviour of midiInQueue,
+// which silently overwrites on overflow.
+//
+// Lock-free single-producer / single-consumer is sufficient today
+// (one MIDI-in thread, one consumer per frame on the UI thread) but
+// the access functions still take a mutex internally to keep the API
+// simple and correct under future producer changes (e.g. multiple
+// open MIDI-in devices).
+
+#include <stddef.h>
+
+#define ZT_SYSEX_MAX_LEN     8192   // single message cap (sysex >8KB are rare)
+#define ZT_SYSEX_QUEUE_SLOTS 16     // up to 16 messages buffered before overwrite
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Reset the queue (drop everything). Safe to call from any thread; cheap.
+void zt_sysex_inq_clear(void);
+
+// Push a complete SysEx message (must include 0xF0..0xF7 framing). If
+// the queue is full, the oldest message is dropped. Returns 1 on push,
+// 0 if `len` is invalid or `bytes` is NULL.
+int  zt_sysex_inq_push(const unsigned char *bytes, int len);
+
+// Pop the next queued message into `out`, capacity `out_cap`. Returns
+// the number of bytes copied (0 if the queue is empty or `out_cap` was
+// too small to hold the next message). On overflow-too-small, the
+// message is left in place; the caller should retry with a larger
+// buffer or call zt_sysex_inq_clear() to discard it.
+int  zt_sysex_inq_pop(unsigned char *out, int out_cap);
+
+// Number of queued messages.
+int  zt_sysex_inq_size(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _ZT_SYSEX_INQ_H_

--- a/src/winmm_compat.h
+++ b/src/winmm_compat.h
@@ -11,6 +11,25 @@
 #endif
 #include <windows.h>
 #include <mmsystem.h>
+
+// SysEx send (Windows / WinMM). bytes must include 0xF0 prefix and 0xF7
+// terminator. Wraps midiOutLongMsg with the required MIDIHDR prepare /
+// unprepare dance. Synchronous: blocks until WinMM accepts the buffer
+// (typical OS-level call; not "blocks until receiver consumed it").
+static inline MMRESULT zt_midi_out_sysex(HMIDIOUT h, const unsigned char *bytes, int len) {
+    if (!h || !bytes || len <= 0) return MMSYSERR_ERROR;
+    MIDIHDR hdr;
+    memset(&hdr, 0, sizeof(hdr));
+    hdr.lpData = (LPSTR)bytes;
+    hdr.dwBufferLength = (DWORD)len;
+    hdr.dwBytesRecorded = (DWORD)len;
+    if (midiOutPrepareHeader(h, &hdr, sizeof(hdr)) != MMSYSERR_NOERROR) {
+        return MMSYSERR_ERROR;
+    }
+    MMRESULT r = midiOutLongMsg(h, &hdr, sizeof(hdr));
+    midiOutUnprepareHeader(h, &hdr, sizeof(hdr));
+    return r;
+}
 #else
 
 #include <stdint.h>
@@ -323,6 +342,22 @@ static inline MMRESULT midiOutShortMsg(HMIDIOUT h, DWORD msg) {
 }
 
 static inline MMRESULT midiOutReset(HMIDIOUT) { return MMSYSERR_NOERROR; }
+
+// SysEx send (Linux / ALSA). bytes must include 0xF0 prefix and 0xF7
+// terminator — the caller is responsible for framing. Length includes
+// both bytes. Returns MMSYSERR_NOERROR on success.
+static inline MMRESULT zt_midi_out_sysex(HMIDIOUT h, const unsigned char *bytes, int len) {
+    zt_alsa_midi_out_handle *ctx = (zt_alsa_midi_out_handle *)h;
+    if (!ctx || !ctx->seq || !bytes || len <= 0) return MMSYSERR_ERROR;
+    snd_seq_event_t ev;
+    snd_seq_ev_clear(&ev);
+    snd_seq_ev_set_source(&ev, ctx->src_port);
+    snd_seq_ev_set_subs(&ev);
+    snd_seq_ev_set_direct(&ev);
+    snd_seq_ev_set_sysex(&ev, (unsigned int)len, (void *)bytes);
+    if (snd_seq_event_output_direct(ctx->seq, &ev) < 0) return MMSYSERR_ERROR;
+    return MMSYSERR_NOERROR;
+}
 #elif defined(__APPLE__)
 typedef void (CALLBACK *zt_midi_in_callback_fn)(HMIDIIN, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR);
 
@@ -348,6 +383,15 @@ typedef struct zt_coremidi_in_handle {
     DWORD_PTR instance;
     int started;
     unsigned char running_status;
+    // SysEx assembly. When sysex_active != 0, every incoming byte is
+    // appended to sysex_buf until 0xF7 closes the frame; then the whole
+    // buffer (including the 0xF0 / 0xF7 framing) is pushed via
+    // zt_sysex_inq_push. Cleared on overflow or when a new status byte
+    // (other than realtime 0xF8..0xFF) interrupts the dump -- a
+    // protocol violation we treat as "drop and resume."
+    int sysex_active;
+    int sysex_len;
+    unsigned char sysex_buf[8192];   // matches ZT_SYSEX_MAX_LEN
 } zt_coremidi_in_handle;
 
 static inline int zt_coremidi_endpoint_name(MIDIEndpointRef endpoint, char *name, size_t name_len) {
@@ -524,12 +568,68 @@ static inline MMRESULT midiOutShortMsg(HMIDIOUT h, DWORD msg) {
 
 static inline MMRESULT midiOutReset(HMIDIOUT) { return MMSYSERR_NOERROR; }
 
+// SysEx send (macOS / CoreMIDI). bytes must include 0xF0 prefix and
+// 0xF7 terminator. Length includes both bytes. CoreMIDI packets are
+// limited to 256 bytes per packet, but a single packet list can hold
+// multiple packets — for SysEx longer than 256 bytes we segment into
+// multiple packets within one packet list (timestamp 0 = "now"). The
+// receiver reassembles by spec since 0xF0..0xF7 framing is preserved.
+static inline MMRESULT zt_midi_out_sysex(HMIDIOUT h, const unsigned char *bytes, int len) {
+    zt_coremidi_out_handle *ctx = (zt_coremidi_out_handle *)h;
+    if (!ctx || !ctx->out_port || !bytes || len <= 0) return MMSYSERR_ERROR;
+
+    // Build the packet list with per-packet chunks of up to 256 bytes.
+    // sizeof storage: header + N * (packet hdr + 256 bytes) — pick a
+    // generous static buffer that handles patches up to ~16 KB; for
+    // larger dumps the caller can split.
+    enum { MAX_SYSEX = 16384, CHUNK = 256 };
+    if (len > MAX_SYSEX) return MMSYSERR_ERROR;
+    Byte buf[MAX_SYSEX + 1024];
+    MIDIPacketList *pl = (MIDIPacketList *)buf;
+    MIDIPacket *pkt = MIDIPacketListInit(pl);
+
+    int offset = 0;
+    while (offset < len) {
+        int chunk = len - offset;
+        if (chunk > CHUNK) chunk = CHUNK;
+        pkt = MIDIPacketListAdd(pl, sizeof(buf), pkt, 0,
+                                (UInt16)chunk, bytes + offset);
+        if (!pkt) return MMSYSERR_ERROR;
+        offset += chunk;
+    }
+
+    // First attempt with the cached endpoint.
+    if (ctx->endpoint != 0) {
+        if (MIDISend(ctx->out_port, ctx->endpoint, pl) == noErr) {
+            return MMSYSERR_NOERROR;
+        }
+    }
+    // Recovery: re-resolve endpoint by name (same pattern as the short
+    // message path) and retry once before giving up.
+    if (ctx->endpoint_name[0] != '\0') {
+        MIDIEndpointRef fresh = zt_coremidi_find_destination_by_name(ctx->endpoint_name);
+        if (fresh != 0 && fresh != ctx->endpoint) {
+            ctx->endpoint = fresh;
+            if (MIDISend(ctx->out_port, ctx->endpoint, pl) == noErr) {
+                return MMSYSERR_NOERROR;
+            }
+        }
+    }
+    return MMSYSERR_ERROR;
+}
+
 static inline void zt_coremidi_emit_data(zt_coremidi_in_handle *ctx, unsigned int packed_msg) {
     if (!ctx || !ctx->callback) {
         return;
     }
     ctx->callback((HMIDIIN)ctx, MIM_DATA, ctx->instance, (DWORD_PTR)packed_msg, 0);
 }
+
+// Forward declaration of the SysEx queue producer; defined in
+// src/sysex_inq.cpp. Declared inline here so the CoreMIDI callback
+// (which lives in this header) can push without dragging the queue
+// header into every translation unit that includes winmm_compat.h.
+extern "C" int zt_sysex_inq_push(const unsigned char *bytes, int len);
 
 static inline void zt_coremidi_read_proc(const MIDIPacketList *packet_list, void *read_proc_ref_con, void *) {
     zt_coremidi_in_handle *ctx = (zt_coremidi_in_handle *)read_proc_ref_con;
@@ -543,6 +643,46 @@ static inline void zt_coremidi_read_proc(const MIDIPacketList *packet_list, void
         UInt16 i = 0;
         while (i < packet->length) {
             unsigned char b = data[i];
+
+            // SysEx accumulator. F0 starts a frame; every byte (including
+            // realtime bytes 0xF8..0xFF, which the spec allows mid-SysEx
+            // -- we leave them in the buffer rather than splitting) is
+            // appended until F7 closes it. On overflow we drop the frame
+            // and reset; on a non-F7 status byte interrupting the dump
+            // we drop too (protocol violation).
+            if (ctx->sysex_active) {
+                if ((int)ctx->sysex_len < (int)sizeof(ctx->sysex_buf)) {
+                    ctx->sysex_buf[ctx->sysex_len++] = b;
+                }
+                if (b == 0xF7) {
+                    if ((int)ctx->sysex_len <= (int)sizeof(ctx->sysex_buf)) {
+                        zt_sysex_inq_push(ctx->sysex_buf, ctx->sysex_len);
+                    }
+                    ctx->sysex_active = 0;
+                    ctx->sysex_len = 0;
+                    i++;
+                    continue;
+                }
+                if ((b & 0x80U) != 0U && b < 0xF8) {
+                    // Non-realtime status byte mid-SysEx -- abort.
+                    ctx->sysex_active = 0;
+                    ctx->sysex_len = 0;
+                    // Fall through so this byte gets handled normally below.
+                } else {
+                    i++;
+                    continue;
+                }
+            }
+
+            if (b == 0xF0) {
+                ctx->sysex_active = 1;
+                ctx->sysex_len = 0;
+                ctx->sysex_buf[ctx->sysex_len++] = b;
+                ctx->running_status = 0;
+                i++;
+                continue;
+            }
+
             if ((b & 0x80U) != 0U) {
                 if (b < 0xF0) {
                     ctx->running_status = b;
@@ -738,6 +878,10 @@ static inline MMRESULT midiOutOpen(HMIDIOUT *h, UINT, DWORD_PTR, DWORD_PTR, DWOR
 static inline MMRESULT midiOutClose(HMIDIOUT) { return MMSYSERR_ERROR; }
 static inline MMRESULT midiOutShortMsg(HMIDIOUT, DWORD) { return MMSYSERR_ERROR; }
 static inline MMRESULT midiOutReset(HMIDIOUT) { return MMSYSERR_ERROR; }
+// SysEx send fallback (no-op on platforms without a real backend).
+static inline MMRESULT zt_midi_out_sysex(HMIDIOUT, const unsigned char *, int) {
+    return MMSYSERR_ERROR;
+}
 #endif
 
 #if !defined(__APPLE__)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,3 +76,11 @@ add_executable(test_ccizer
 target_include_directories(test_ccizer PRIVATE "${CMAKE_SOURCE_DIR}/src")
 target_compile_features(test_ccizer PRIVATE cxx_std_17)
 add_test(NAME ccizer COMMAND test_ccizer)
+
+# SysEx receive queue. Pure C++ (std::mutex), no platform MIDI deps.
+add_executable(test_sysex_inq
+    test_sysex_inq.cpp
+)
+target_include_directories(test_sysex_inq PRIVATE "${CMAKE_SOURCE_DIR}/src")
+target_compile_features(test_sysex_inq PRIVATE cxx_std_17)
+add_test(NAME sysex_inq COMMAND test_sysex_inq)

--- a/tests/test_sysex_inq.cpp
+++ b/tests/test_sysex_inq.cpp
@@ -1,0 +1,103 @@
+// Unit tests for src/sysex_inq.{h,cpp} -- the process-wide SysEx
+// receive queue. Pure code, no SDL / MIDI dependency.
+
+#include "sysex_inq.h"
+#include "sysex_inq.cpp"
+
+#include <stdio.h>
+#include <string.h>
+
+static int failures = 0;
+static int checks   = 0;
+
+#define CHECK(expr) do {                                                \
+    checks++;                                                           \
+    if (!(expr)) { failures++;                                          \
+        fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #expr); \
+    }                                                                   \
+} while(0)
+
+static void test_empty_queue() {
+    zt_sysex_inq_clear();
+    CHECK(zt_sysex_inq_size() == 0);
+    unsigned char buf[16];
+    CHECK(zt_sysex_inq_pop(buf, sizeof(buf)) == 0);
+}
+
+static void test_push_pop_roundtrip() {
+    zt_sysex_inq_clear();
+    unsigned char msg[] = {0xF0, 0x7E, 0x7F, 0x06, 0x01, 0xF7};
+    CHECK(zt_sysex_inq_push(msg, sizeof(msg)) == 1);
+    CHECK(zt_sysex_inq_size() == 1);
+    unsigned char out[64];
+    int n = zt_sysex_inq_pop(out, sizeof(out));
+    CHECK(n == (int)sizeof(msg));
+    CHECK(memcmp(out, msg, sizeof(msg)) == 0);
+    CHECK(zt_sysex_inq_size() == 0);
+}
+
+static void test_fifo_order() {
+    zt_sysex_inq_clear();
+    unsigned char a[] = {0xF0, 0x01, 0xF7};
+    unsigned char b[] = {0xF0, 0x02, 0x02, 0xF7};
+    unsigned char c[] = {0xF0, 0x03, 0x03, 0x03, 0xF7};
+    zt_sysex_inq_push(a, sizeof(a));
+    zt_sysex_inq_push(b, sizeof(b));
+    zt_sysex_inq_push(c, sizeof(c));
+    CHECK(zt_sysex_inq_size() == 3);
+    unsigned char out[16];
+    int n = zt_sysex_inq_pop(out, sizeof(out));
+    CHECK(n == 3 && out[1] == 0x01);
+    n = zt_sysex_inq_pop(out, sizeof(out));
+    CHECK(n == 4 && out[1] == 0x02);
+    n = zt_sysex_inq_pop(out, sizeof(out));
+    CHECK(n == 5 && out[1] == 0x03);
+}
+
+static void test_overflow_drops_oldest() {
+    zt_sysex_inq_clear();
+    unsigned char msg[] = {0xF0, 0x00, 0xF7};
+    for (int i = 0; i < ZT_SYSEX_QUEUE_SLOTS + 4; i++) {
+        msg[1] = (unsigned char)i;
+        zt_sysex_inq_push(msg, sizeof(msg));
+    }
+    CHECK(zt_sysex_inq_size() == ZT_SYSEX_QUEUE_SLOTS);
+    // Oldest 4 dropped; first one we pop should be index 4.
+    unsigned char out[16];
+    int n = zt_sysex_inq_pop(out, sizeof(out));
+    CHECK(n == 3);
+    CHECK(out[1] == 4);
+}
+
+static void test_pop_buffer_too_small() {
+    zt_sysex_inq_clear();
+    unsigned char msg[] = {0xF0, 0xAA, 0xBB, 0xCC, 0xDD, 0xF7};
+    zt_sysex_inq_push(msg, sizeof(msg));
+    unsigned char tiny[3];
+    CHECK(zt_sysex_inq_pop(tiny, sizeof(tiny)) == 0);   // too small
+    CHECK(zt_sysex_inq_size() == 1);                    // message still queued
+    unsigned char big[16];
+    CHECK(zt_sysex_inq_pop(big, sizeof(big)) == 6);
+}
+
+static void test_invalid_inputs() {
+    zt_sysex_inq_clear();
+    CHECK(zt_sysex_inq_push(NULL, 4) == 0);
+    unsigned char buf[4] = {0,0,0,0};
+    CHECK(zt_sysex_inq_push(buf, 0) == 0);
+    CHECK(zt_sysex_inq_push(buf, -1) == 0);
+    CHECK(zt_sysex_inq_push(buf, ZT_SYSEX_MAX_LEN + 1) == 0);
+    CHECK(zt_sysex_inq_pop(NULL, 4) == 0);
+    CHECK(zt_sysex_inq_pop(buf, 0) == 0);
+}
+
+int main(void) {
+    test_empty_queue();
+    test_push_pop_roundtrip();
+    test_fifo_order();
+    test_overflow_drops_oldest();
+    test_pop_buffer_too_small();
+    test_invalid_inputs();
+    printf("sysex_inq: %d checks, %d failures\n", checks, failures);
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Stacked on PR #81 (chain: #78 → #79 → #80 → #81 → #82)

Merge order: #78 → #79 → #80 → #81 → #82.

## What this PR does

Adds the platform plumbing for **MIDI System Exclusive** I/O. No UI, no .zt-format integration — those land in follow-up PRs. This is the foundation everything else stacks on.

## Send out — all three platforms

- New `MidiOut->sendSysEx(dev, bytes, len)` virtual on `OutputDevice`. Default = no-op so AudioOutputDevice subclasses don't have to implement it. Concrete impl on `MidiOutputDevice` calls a new `zt_midi_out_sysex(handle, bytes, len)` helper in `winmm_compat.h`.
- **macOS / CoreMIDI**: `MIDIPacketListAdd` in 256-byte chunks, single `MIDISend`, with the endpoint-recovery-by-name fallback the short-message path already uses.
- **Windows / WinMM**: native `midiOutPrepareHeader` → `midiOutLongMsg` → `Unprepare`.
- **Linux / ALSA**: `snd_seq_ev_set_sysex` + `snd_seq_event_output_direct`.

Caller passes the full SysEx including `0xF0..0xF7` framing; `MidiOutputDevice::sendSysEx` asserts the framing and refuses malformed payloads rather than emitting random short messages.

## Receive — queue + macOS parse

- New `src/sysex_inq.{h,cpp}`: lock-protected SPSC-friendly ring of up to 16 messages × 8 KB each. Push from any thread (MIDI-in callback); pop on the UI thread. Overflow drops the oldest, matching `midiInQueue`'s overwrite semantics.
- macOS callback (`zt_coremidi_read_proc`) now accumulates `F0..F7` frames into a per-handle buffer and pushes complete messages to the queue. Realtime bytes `0xF8..0xFF` mid-SysEx are buffered (spec-allowed); any non-realtime status byte mid-SysEx aborts the frame.
- Linux ALSA-in and Windows WinMM-in receive paths still drop SysEx — those land in PR #83. Current zTracker MIDI-in on Linux is itself stubbed in `winmm_compat`, so there's no regression.

## Tests

`tests/test_sysex_inq.cpp` — 6 tests, ~25 checks: empty queue, push/pop round-trip, FIFO ordering, overflow-drops-oldest, undersized pop (message stays queued), invalid-input rejection. Wired into CTest. Total now 7 suites.

## What is intentionally NOT in this PR

- UI (Send SysEx / Recv SysEx page) → PR #83
- Linux + Windows receive parsing → PR #83
- Pattern integration via midimacros (Z-effect dispatch of stored SysEx blobs) → PR #84

## Test plan

- [x] Builds clean on macOS arm64
- [x] `ctest --output-on-failure` — 7/7 suites pass
- [ ] Manual (after #83 ships UI): macOS — send a Universal Device Inquiry to a connected synth, observe response in the Recv log
- [ ] Manual: Windows — same, with WinMM
- [ ] Manual: Linux — same, with ALSA

🤖 Generated with [Claude Code](https://claude.com/claude-code)
