### PR TITLE
Pattern row -> SysEx: midimacros named *.syx dispatch as files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ set(ZT_SOURCES
   src/CUI_CcConsole.cpp
   src/sysex_inq.cpp
   src/CUI_SysExLibrarian.cpp
+  src/sysex_macro.cpp
 )
 
 if(WIN32)

--- a/src/CUI_Midimacroeditor.cpp
+++ b/src/CUI_Midimacroeditor.cpp
@@ -30,6 +30,7 @@
  *
  ******/
 #include "zt.h"
+#include "sysex_macro.h"
 
 #include "editor_layout.h"
 
@@ -593,6 +594,14 @@ void CUI_Midimacroeditor::draw(Drawable *S) {
     print(row(6),  col(BASE_Y),     "Slot",   COLORS.Text, S);
     print(row(6),  col(BASE_Y + 2), "Name",   COLORS.Text, S);
     print(row(4),  col(BASE_Y + 4), "Length", COLORS.Text, S);
+
+    // Hint: a macro whose name ends in `.syx` is dispatched as a SysEx
+    // file send by the playback engine — the data grid below is ignored.
+    if (m && zt_sysex_macro_is_file(m->name)) {
+        print(row(36), col(BASE_Y + 2),
+              "(SysEx file mode: data grid is ignored)",
+              COLORS.Brighttext, S);
+    }
 
     // Label above the inline Preset listbox (Tab to focus, Enter to apply).
     print(row(47), col(BASE_Y), "Presets (Tab/Arrows/Enter/Space; P=cycle)", COLORS.Text, S);

--- a/src/playback.cpp
+++ b/src/playback.cpp
@@ -38,6 +38,7 @@
  *
  ******/
 #include "zt.h"
+#include "sysex_macro.h"
 #include <algorithm>
 #include <stdint.h>
 
@@ -1577,6 +1578,25 @@ void player::playback(midi_buf *buffer, int ticks)
                         int param     = GET_LOW_BYTE(evento->effect_data);
                         midimacro *m = (macro_idx >= 0 && macro_idx < ZTM_MAX_MIDIMACROS)
                                            ? song->midimacros[macro_idx] : NULL;
+                        // SysEx-by-filename convention: a macro whose name
+                        // ends in `.syx` dispatches as a SysEx file send,
+                        // ignoring the data array. Lets the user fire patch
+                        // dumps from pattern rows without inflating the .zt
+                        // format (the macro's name field already round-trips
+                        // through the existing MMAC chunk; old zTracker
+                        // sees an empty data array and silently does
+                        // nothing — safe forward-compat).
+                        if (m && zt_sysex_macro_is_file(m->name)) {
+                            char path[1280];
+                            unsigned char *buf = NULL;
+                            int len = 0;
+                            if (zt_sysex_macro_resolve_path(m->name, path, sizeof(path)) == 0 &&
+                                zt_sysex_macro_read_file(path, &buf, &len, 65536)) {
+                                MidiOut->sendSysEx(i->midi_device, buf, len);
+                                free(buf);
+                            }
+                            break;
+                        }
                         if (m && !m->isempty()) {
                             // Walk macro data, packing 3-byte short MIDI msgs
                             // (status + up to 2 data bytes), substituting

--- a/src/sysex_macro.cpp
+++ b/src/sysex_macro.cpp
@@ -1,0 +1,88 @@
+#include "sysex_macro.h"
+#include "conf.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#ifndef _WIN32
+#  include <unistd.h>
+#endif
+
+extern ZTConf zt_config_globals;
+
+extern "C" int zt_sysex_macro_is_file(const char *name) {
+    if (!name) return 0;
+    size_t len = strlen(name);
+    // Require at least one character before the ".syx" extension --
+    // a bare ".syx" isn't a usable filename.
+    if (len <= 4) return 0;
+    return (tolower((unsigned char)name[len-4]) == '.' &&
+            tolower((unsigned char)name[len-3]) == 's' &&
+            tolower((unsigned char)name[len-2]) == 'y' &&
+            tolower((unsigned char)name[len-1]) == 'x') ? 1 : 0;
+}
+
+static int dir_exists(const char *p) {
+    struct stat st;
+    if (!p || !*p || stat(p, &st) != 0) return 0;
+    return (st.st_mode & S_IFDIR) ? 1 : 0;
+}
+
+extern "C" int zt_sysex_macro_resolve_path(const char *name, char *out, size_t out_cap) {
+    if (!name || !out || out_cap < 16) return -1;
+    out[0] = '\0';
+
+    char folder[1024] = "";
+    if (zt_config_globals.syx_folder[0]) {
+        snprintf(folder, sizeof(folder), "%s", zt_config_globals.syx_folder);
+    } else {
+        // Match CUI_SysExLibrarian::resolve_folder() default cascade.
+        if (dir_exists("./syx")) {
+            snprintf(folder, sizeof(folder), "./syx");
+        } else {
+#ifndef _WIN32
+            const char *home = getenv("HOME");
+            if (home && *home)
+                snprintf(folder, sizeof(folder), "%s/.config/zt/syx", home);
+            else
+                snprintf(folder, sizeof(folder), "./syx");
+#else
+            snprintf(folder, sizeof(folder), "./syx");
+#endif
+        }
+    }
+    snprintf(out, out_cap, "%s/%s", folder, name);
+    return 0;
+}
+
+extern "C" int zt_sysex_macro_read_file(const char *path,
+                                        unsigned char **out_buf,
+                                        int *out_len,
+                                        int max_len) {
+    if (!path || !out_buf || !out_len) return 0;
+    *out_buf = NULL;
+    *out_len = 0;
+
+    struct stat st;
+    if (stat(path, &st) != 0) return 0;
+    if (st.st_size <= 0 || (max_len > 0 && (long)st.st_size > (long)max_len)) return 0;
+
+    FILE *fp = fopen(path, "rb");
+    if (!fp) return 0;
+    int len = (int)st.st_size;
+    unsigned char *buf = (unsigned char *)malloc((size_t)len);
+    if (!buf) { fclose(fp); return 0; }
+    int got = (int)fread(buf, 1, (size_t)len, fp);
+    fclose(fp);
+    if (got != len) { free(buf); return 0; }
+    if (got < 2 || buf[0] != 0xF0 || buf[got-1] != 0xF7) {
+        free(buf);
+        return 0;       // malformed: not a real SysEx file
+    }
+    *out_buf = buf;
+    *out_len = got;
+    return 1;
+}

--- a/src/sysex_macro.h
+++ b/src/sysex_macro.h
@@ -1,0 +1,44 @@
+#ifndef _ZT_SYSEX_MACRO_H_
+#define _ZT_SYSEX_MACRO_H_
+
+// Convention: a midimacro whose `name` ends in ".syx" (case-insensitive)
+// is dispatched by the playback engine as a SysEx file send. The macro's
+// data array is ignored; instead the file at `<syx_folder>/<name>` is
+// read and sent via MidiOut->sendSysEx.
+//
+// This keeps the .zt save format unchanged: the existing MMAC chunk
+// already persists `name`, so nothing extra needs to round-trip.
+//
+// Old zTracker reading a song with a `.syx`-named macro sees an empty
+// data array (no END token to walk) and dispatches nothing — safe
+// forward-compat (the macro is silently inert on older builds).
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Predicate: does `name` end in ".syx" (case-insensitive)?
+int  zt_sysex_macro_is_file(const char *name);
+
+// Build the absolute path for a SysEx-named macro by joining the
+// effective syx_folder (matches CUI_SysExLibrarian's resolution) with
+// `name`. Returns 0 on success and writes a null-terminated path into
+// `out` (capacity `out_cap`).
+int  zt_sysex_macro_resolve_path(const char *name, char *out, size_t out_cap);
+
+// Read a `.syx` file into a heap buffer. Caller frees with `free()`.
+// On success returns 1 and sets *out_buf and *out_len; on failure
+// returns 0. Refuses files that don't start with F0 / end with F7 or
+// exceed `max_len` bytes.
+int  zt_sysex_macro_read_file(const char *path,
+                              unsigned char **out_buf,
+                              int *out_len,
+                              int max_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _ZT_SYSEX_MACRO_H_

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -84,3 +84,13 @@ add_executable(test_sysex_inq
 target_include_directories(test_sysex_inq PRIVATE "${CMAKE_SOURCE_DIR}/src")
 target_compile_features(test_sysex_inq PRIVATE cxx_std_17)
 add_test(NAME sysex_inq COMMAND test_sysex_inq)
+
+# SysEx-by-filename macro helpers. Tests the predicate, path resolution,
+# and the .syx file reader. Stubs the ZTConf type locally to avoid
+# pulling the full conf.cpp into the test binary.
+add_executable(test_sysex_macro
+    test_sysex_macro.cpp
+)
+target_include_directories(test_sysex_macro PRIVATE "${CMAKE_SOURCE_DIR}/src")
+target_compile_features(test_sysex_macro PRIVATE cxx_std_17)
+add_test(NAME sysex_macro COMMAND test_sysex_macro)

--- a/tests/test_sysex_macro.cpp
+++ b/tests/test_sysex_macro.cpp
@@ -1,0 +1,137 @@
+// Unit tests for src/sysex_macro.{h,cpp} -- name predicate + path
+// resolution + .syx file reader. SDL-free, conf globals stubbed.
+//
+// We #include the .cpp directly so the test binary doesn't have to
+// pull in the full conf.cpp. The conf global is provided as a stub
+// in this translation unit instead.
+
+#include "sysex_macro.h"
+
+// Stub the ZTConf type just enough that sysex_macro.cpp can read
+// `zt_config_globals.syx_folder`. The real zTracker links the full
+// type via conf.h; here we provide a minimal definition that has
+// only the field we need.
+#define _CONF_H        // sentinel: skip conf.h's full declaration
+#define MAX_PATH 260
+struct ZTConf {
+    char ccizer_folder[MAX_PATH + 1];
+    char syx_folder[MAX_PATH + 1];
+};
+ZTConf zt_config_globals = {};
+
+#include "sysex_macro.cpp"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#ifdef _WIN32
+#  include <direct.h>
+#  include <io.h>
+#  define unlink _unlink
+static int test_mkdir(const char *p) { return _mkdir(p); }
+#else
+#  include <unistd.h>
+static int test_mkdir(const char *p) { return mkdir(p, 0755); }
+#endif
+
+static int failures = 0;
+static int checks   = 0;
+
+#define CHECK(expr) do {                                                \
+    checks++;                                                           \
+    if (!(expr)) { failures++;                                          \
+        fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #expr); \
+    }                                                                   \
+} while(0)
+
+static void write_tmp_bytes(const char *path, const unsigned char *bytes, int len) {
+    FILE *fp = fopen(path, "wb");
+    if (!fp) { perror("fopen"); exit(1); }
+    fwrite(bytes, 1, (size_t)len, fp);
+    fclose(fp);
+}
+
+static void test_predicate() {
+    CHECK(zt_sysex_macro_is_file("patch.syx") == 1);
+    CHECK(zt_sysex_macro_is_file("PATCH.SYX") == 1);
+    CHECK(zt_sysex_macro_is_file("foo.bar.syx") == 1);
+    CHECK(zt_sysex_macro_is_file(".syx") == 0);                 // need at least one char before
+    CHECK(zt_sysex_macro_is_file("syx") == 0);
+    CHECK(zt_sysex_macro_is_file("sysex") == 0);
+    CHECK(zt_sysex_macro_is_file("regular_macro") == 0);
+    CHECK(zt_sysex_macro_is_file("") == 0);
+    CHECK(zt_sysex_macro_is_file(NULL) == 0);
+}
+
+static void test_resolve_path_with_override() {
+    snprintf(zt_config_globals.syx_folder, sizeof(zt_config_globals.syx_folder),
+             "/tmp/zt_sxm_test");
+    char out[1024];
+    CHECK(zt_sysex_macro_resolve_path("patch.syx", out, sizeof(out)) == 0);
+    CHECK(strcmp(out, "/tmp/zt_sxm_test/patch.syx") == 0);
+    zt_config_globals.syx_folder[0] = '\0';
+}
+
+static void test_read_file_valid() {
+    const char *p = "/tmp/zt_sxm_valid.syx";
+    unsigned char data[] = {0xF0, 0x7E, 0x7F, 0x06, 0x01, 0xF7};
+    write_tmp_bytes(p, data, sizeof(data));
+    unsigned char *buf = NULL;
+    int len = 0;
+    CHECK(zt_sysex_macro_read_file(p, &buf, &len, 1024) == 1);
+    CHECK(len == (int)sizeof(data));
+    CHECK(memcmp(buf, data, sizeof(data)) == 0);
+    free(buf);
+    unlink(p);
+}
+
+static void test_read_file_malformed() {
+    const char *p = "/tmp/zt_sxm_bad.syx";
+    unsigned char missing_f0[] = {0x12, 0x34, 0xF7};   // no F0 prefix
+    write_tmp_bytes(p, missing_f0, sizeof(missing_f0));
+    unsigned char *buf = NULL;
+    int len = 0;
+    CHECK(zt_sysex_macro_read_file(p, &buf, &len, 1024) == 0);
+    CHECK(buf == NULL);
+    unlink(p);
+
+    unsigned char missing_f7[] = {0xF0, 0x12, 0x34};   // no F7 terminator
+    write_tmp_bytes(p, missing_f7, sizeof(missing_f7));
+    CHECK(zt_sysex_macro_read_file(p, &buf, &len, 1024) == 0);
+    unlink(p);
+}
+
+static void test_read_file_too_large() {
+    const char *p = "/tmp/zt_sxm_big.syx";
+    unsigned char data[100];
+    data[0] = 0xF0;
+    for (int i = 1; i < 99; i++) data[i] = (unsigned char)(i & 0x7F);
+    data[99] = 0xF7;
+    write_tmp_bytes(p, data, sizeof(data));
+    unsigned char *buf = NULL;
+    int len = 0;
+    CHECK(zt_sysex_macro_read_file(p, &buf, &len, 50) == 0);   // capped at 50 < 100
+    CHECK(zt_sysex_macro_read_file(p, &buf, &len, 200) == 1);  // capped at 200 > 100
+    free(buf);
+    unlink(p);
+}
+
+static void test_read_file_missing() {
+    unsigned char *buf = NULL;
+    int len = 0;
+    CHECK(zt_sysex_macro_read_file("/tmp/does_not_exist_xyz.syx",
+                                   &buf, &len, 1024) == 0);
+}
+
+int main(void) {
+    test_predicate();
+    test_resolve_path_with_override();
+    test_read_file_valid();
+    test_read_file_malformed();
+    test_read_file_too_large();
+    test_read_file_missing();
+    printf("sysex_macro: %d checks, %d failures\n", checks, failures);
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Stacked on PR #83 (chain: #78 → #79 → #80 → #81 → #82 → #83 → #84)

Merge order: #78 → #79 → #80 → #81 → #82 → #83 → #84.

## What this PR does

Final leg of the SysEx work: **fire .syx patch dumps from pattern rows**.

A `.syx` file in the configured `syx_folder` is dispatched whenever the playback engine hits a `Zxxyy` effect on a midimacro slot whose **name ends in `.syx`** (case-insensitive). The macro's data array is ignored; the file is loaded and sent via the cross-platform `MidiOut->sendSysEx` plumbing from PR #82.

## Why this design

- **No `.zt` format change.** The existing MMAC chunk already round-trips the macro `name`, so the convention persists for free.
- **Backward compatibility is automatic.** Old zTracker reading a song with a `.syx`-named macro sees an empty data array, no END token to walk, and dispatches nothing — silently inert on older builds rather than crashing or spitting random short messages.
- **No editor change required.** F4 MIDI Macro Editor already lets you edit the macro name; users just type `patch1.syx` instead of arbitrary text.

## How it ties together

```
Row in pattern    Macro slot 12               syx_folder/patch1.syx
[ ... Z0C00 ... ] -> name = "patch1.syx"  -> [F0 41 ... 1024 bytes ... F7]
                     data = (empty)            (sent via sendSysEx)
```

Combined with PR #83's auto-capture, the user's full loop is now:
1. **Shift+F5** — send a request file, capture synth's reply as `recv_*.syx`
2. **F4** — make a midimacro named after that captured file
3. **F2** — write a `Z<slot>00` effect on a row to fire the patch dump on playback

## New files

- `src/sysex_macro.{h,cpp}` — three helpers:
  - `zt_sysex_macro_is_file(name)` — predicate
  - `zt_sysex_macro_resolve_path(name, ...)` — joins with `syx_folder`
  - `zt_sysex_macro_read_file(path, ...)` — reads + validates `F0..F7` framing

## Existing files touched

- `playback.cpp` — `Z` effect handler checks the predicate first; SysEx path bypasses the per-tick event buffer (variable-length doesn't fit the fixed packing) and calls `sendSysEx` inline.
- `CUI_Midimacroeditor.cpp` — draws "(SysEx file mode: data grid is ignored)" hint in Brighttext when the focused macro's name matches the predicate.

## Tests

`tests/test_sysex_macro.cpp` — 6 tests, ~20 checks. Predicate (case insensitive, rejects bare `.syx` / `syx` / NULL), path resolution with override, file read for valid / malformed (missing F0 prefix or F7 terminator) / oversized / missing input. Brings ctest to **8 suites total**.

## Test plan

- [x] Builds clean on macOS arm64
- [x] `ctest --output-on-failure` — 8/8 suites pass
- [ ] Manual: F4, name a slot `request_universal_inquiry.syx`, save song; insert `Z<slot>00` on a row in F2; play — synth responds (visible in Shift+F5 recv log)
- [ ] Manual: open the song in a pre-#84 zTracker build — loads, plays, the SysEx-named macro slot is silently inert (no crash, no garbage MIDI out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
