### PR TITLE
Skill + CLAUDE.md: document CCizer + SysEx pages (PRs #78-#84)

### DIFF
--- a/.claude/skills/ztrackerprime/SKILL.md
+++ b/.claude/skills/ztrackerprime/SKILL.md
@@ -43,28 +43,56 @@ ctest --output-on-failure      # unit-test harness (Linux CI runs this)
 | File | Purpose |
 |---|---|
 | `src/main.cpp` | Entry, main loop, key dispatch, `switch_page`, CLI parser |
-| `src/CUI_Patterneditor.cpp` | Pattern editor (F2) + 10+ pattern operations |
+| `src/CUI_Patterneditor.cpp` | Pattern editor (F2) + 10+ pattern operations + Ctrl+Shift+§ CC drawmode |
 | `src/CUI_Midimacroeditor.cpp` / `CUI_Arpeggioeditor.cpp` | F4 / Shift+F4 editors |
+| `src/CUI_KeyBindings.cpp` | Unified Shortcuts & MIDI Mappings page (**Shift+F2** — moved from Shift+F3 to free that slot) |
+| `src/CUI_CcConsole.cpp` | CC Console (**Shift+F3**) — Paketti CCizer file load + sliders/knobs send-out + MIDI Learn |
+| `src/CUI_SysExLibrarian.cpp` | SysEx Librarian (**Shift+F5**) — `.syx` file send + auto-capture of incoming SysEx |
 | `src/CUI_*.cpp` | Other pages (Sysconfig, Songconfig, Help, InstEditor, MainMenu, Playsong, etc.) |
 | `src/CUI_Page.{h,cpp}` | Base class for pages |
 | `src/UserInterface.{h,cpp}` | Widget classes — `CheckBox`, `ValueSlider`, `TextInput`, `Frame`, `Button`, `TextBox`, `ListBox`, `MidiOutDeviceOpener`, `SkinSelector`, `VUPlay`. Fix rendering bugs HERE, not in callers. |
 | `src/keybuffer.{h,cpp}` | Key state (KS_ALT/KS_CTRL/KS_META/KS_SHIFT) + `KS_HAS_ALT` macro. `ZT_TEST_NO_SDL` guard for SDL-free unit tests. |
 | `src/font.cpp` | `print()` / `printtitle()` / `printBG()` drawing primitives |
-| `src/zt.h` | STATE_/CMD_ enums, page globals, layout macros |
-| `src/conf.{h,cpp}` | zt.conf parsing, `zt_config_globals` |
-| `src/module.{h,cpp}` | Song data (patterns, tracks, events, instruments, arpeggios, midimacros) |
-| `src/playback.{h,cpp}` | MIDI output timing, R-effect arpeggio + Z-effect macro dispatch |
+| `src/zt.h` | STATE_/CMD_ enums, page globals (`UIP_CcConsole`, `UIP_SysExLibrarian`, ...), layout macros, `g_cc_drawmode` |
+| `src/conf.{h,cpp}` | zt.conf parsing, `zt_config_globals`. Keys include `ccizer_folder`, `syx_folder` |
+| `src/module.{h,cpp}` | Song data (patterns, tracks, events, instruments, arpeggios, midimacros). `instrument` carries `ccizer_bank` (per-instrument Paketti CCizer file). |
+| `src/playback.{h,cpp}` | MIDI output timing, R-effect arpeggio + Z-effect macro dispatch. **Z on a `*.syx`-named midimacro** dispatches the file as SysEx (see `sysex_macro.h`). |
+| `src/winmm_compat.h` | Cross-platform MIDI shim. Exposes `midiOut*` (WinMM-style API) on Win/macOS/Linux. Adds `zt_midi_out_sysex(handle, bytes, len)` for SysEx send. macOS `zt_coremidi_read_proc` parses incoming `F0..F7` into `zt_sysex_inq_push`. |
+| `src/sysex_inq.{h,cpp}` | Process-wide receive queue for incoming SysEx (16 slots × 8 KB; overflow drops oldest). `std::mutex` protected. |
+| `src/sysex_macro.{h,cpp}` | Helpers for the `*.syx`-named-midimacro convention: predicate, path resolution against `syx_folder`, file read with `F0..F7` framing check. |
+| `src/ccizer.{h,cpp}` | CCizer parser, `.cc-view` slider/knob sidecar, `.cc-midi` MIDI Learn sidecar, folder scan, MIDI byte builder, `zt_ccizer_current_file()` (read by Pattern Editor for friendly slot names in CC drawmode status). |
 | `src/preset_data.h` | F4/Shift+F4 preset arrays + pure apply functions |
 | `src/preset_selector.h` | Pure listbox decision logic (click / arrow / Space / P-cycle) |
 | `src/page_sync.h` | F4/Shift+F4 widget↔data sync helpers |
 | `src/save_key_dispatch.h` | Global Ctrl-S dispatch decision |
 | `src/editor_layout.h` | Shared character-grid constants for F4/Shift+F4 |
-| `tests/` | CTest unit-test executables (preset / selector / page-sync / save-key / keybuffer) |
+| `assets/ccizer/` | Bundled CCizer banks (sc88st, microfreak, minilogue, monologue, Prophet6, deepmind6, waldorf_blofeld, tb03, se02, pro800, polyend_*, midi_control_example) — copied from Paketti. README.md documents the format. |
+| `assets/syx/` | Bundled SysEx files. `request_universal_inquiry.syx` = `F0 7E 7F 06 01 F7` for first-test handshakes. README.md documents the librarian workflow. |
+| `tests/` | CTest unit-test executables — 8 suites: `presets`, `selector`, `page_sync`, `save_key`, `keybuffer`, `ccizer`, `sysex_inq`, `sysex_macro` |
 | `doc/help.txt` | In-app F1 help — update when adding keybinds or CLI flags |
 | `doc/CHANGELOG.txt` | Release notes, chronological |
 | `.github/workflows/build.yml` | 5-platform CI matrix; Linux job runs `ctest` |
 
 For the live PR queue: `gh pr list --repo m6502/ztrackerprime`.
+
+## Page / shortcut map (current)
+
+| Key | Page | Notes |
+|---|---|---|
+| F1 | Help | |
+| F2 | Pattern Editor | F2 again from PE → PEParms |
+| F3 | Instrument Editor | F3 row 11 shows `CCizer Bank: <basename>` (per-instrument bank) |
+| F4 | MIDI Macro Editor | A macro whose name ends in `.syx` is dispatched as a SysEx file send by the playback engine; data grid is ignored (hint shown). |
+| **Shift+F2** | **Shortcuts & MIDI Mappings** | Was Shift+F3 historically; moved 2026-04-30 to free the slot for CC Console. |
+| **Shift+F3** | **CC Console** | Loads CCizer `.txt`, sliders/knobs send CC out, `L` to MIDI Learn, `B` to assign as current instrument's bank. |
+| Shift+F4 | Arpeggio Editor | |
+| F5 | Play Song | |
+| **Shift+F5** | **SysEx Librarian** | Lists `.syx` files. Enter sends. Incoming SysEx auto-saved as `recv_<timestamp>.syx`. |
+| F6 / F7 / F8 / F9 | Play Pattern / From Cursor / Stop / Panic | |
+| F10 | Song Message Editor | |
+| F11 | Song Configuration / Order | |
+| F12 | System Configuration | Includes `CCizer Folder` text input (binds to `ccizer_folder` zt.conf key). |
+| **Ctrl+Shift+§** | **CC drawmode toggle** | While ON, incoming CC writes `Sxxyy` and PB writes `Wxxxx` at the cursor row. Per-session UNDO_SAVE. `[CC DRAW]` badge shown top-right of Pattern Editor while active. |
 
 ## Coordinate system
 
@@ -74,6 +102,39 @@ For the live PR queue: `gh pr list --repo m6502/ztrackerprime`.
 - Some legacy code calls `print(row(2), col(13), ...)` — this works only because `FONT_SIZE_X == FONT_SIZE_Y == 8`. Confusing; don't propagate.
 
 Layout macros: `INITIAL_ROW=1`, `PAGE_TITLE_ROW_Y=9`, `TRACKS_ROW_Y=11`, `SPACE_AT_BOTTOM=8`.
+
+## CCizer + SysEx architecture (2026-04-29 → 2026-04-30, PRs #78–#84)
+
+Seven-PR feature stack landed end of April 2026 wiring Paketti-style CCizer banks and a complete SysEx librarian into zTracker. The architecture has three layers worth keeping in mind:
+
+**1. Per-page (UI)**
+- **Shift+F3 CC Console** (`CUI_CcConsole.cpp`) — file list of `.txt` CCizer banks, slot grid with sliders/knobs, V toggles slider↔knob, L to MIDI Learn (`(status, data1)` → slot), U to unbind, B to assign loaded file as current instrument's bank. `[/]` adjusts MIDI channel.
+- **Shift+F5 SysEx Librarian** (`CUI_SysExLibrarian.cpp`) — file list of `.syx` files in `syx_folder`. Enter/S sends. Receive log auto-pops from `zt_sysex_inq` and writes new files as `recv_<TS>.syx`. R rescans, C clears log.
+- **Pattern Editor CC drawmode** (`CUI_Patterneditor.cpp`) — Ctrl+Shift+§ flips `g_cc_drawmode`. While on, the existing MIDI-in pump in update() routes `0xB0..0xBF` / `0xE0..0xEF` to `update_event(...)` writing `S<cc><val>` / `W<14bit>`. Cursor advances by EditStep. Single UNDO_SAVE per session (file-static `g_cc_draw_session_snapped`).
+
+**2. Process-wide**
+- `g_cc_drawmode` (in `zt.h`) — toggle.
+- `zt_ccizer_current_file()` (in `ccizer.h`) — last-loaded file pointer, so the Pattern Editor's drawmode status can show friendly slot names ("Cutoff = 92") instead of raw CC numbers.
+- `zt_sysex_inq_*` (in `sysex_inq.h`) — ring buffer of incoming complete SysEx messages. Filled by the macOS CoreMIDI read_proc; drained by `CUI_SysExLibrarian::drain_recv` every update().
+- `MidiOut->sendSysEx(dev, bytes, len)` — virtual on `OutputDevice`, default no-op. `MidiOutputDevice` impl asserts F0/F7 framing and calls `zt_midi_out_sysex` in `winmm_compat.h`. Backed by CoreMIDI `MIDIPacketListAdd` (256-byte chunks), Win `midiOutLongMsg`, ALSA `snd_seq_ev_set_sysex`.
+
+**3. Persistence**
+- `ccizer_folder` zt.conf key — folder of `.txt` files. Resolution: override → `<exe-dir>/ccizer` → macOS `Resources/ccizer` → Linux `share/zt/ccizer` → `~/.config/zt/ccizer`. F12 page exposes the text input.
+- `syx_folder` zt.conf key — folder of `.syx` files. Resolution: override → `./syx` (next to binary or in `.app Resources`) → `~/.config/zt/syx`. Auto-created.
+- `<file>.cc-view` sidecar — per-CCizer slot slider/knob choice. Written next to the `.txt`.
+- `<file>.cc-midi` sidecar — per-CCizer slot MIDI Learn binding. Format: `<slot> <status hex> <data1 hex>`.
+- `instrument.ccizer_bank[256]` — per-instrument CCizer file. Persisted via new optional `CCBN` chunk in `.zt`. Format: `short int count` then per entry `unsigned char inst_idx, short int length, bytes path`. **Fully backward+forward compatible**: old zTracker reading new `.zt` skips the unrecognized chunk via `readblock`'s built-in advance-past behavior.
+
+**SysEx-by-filename convention** (`sysex_macro.h`): a midimacro whose `name` ends in `.syx` (case insensitive, requires len > 4) is dispatched by the playback engine's `Z` effect handler as a file send. The macro's data array is ignored. **No `.zt` format change** — the existing MMAC chunk already round-trips the name. Old zTracker sees an empty data array and silently does nothing — safe forward-compat.
+
+**Cross-platform status** (as of 2026-04-30):
+- SysEx send: works on macOS (CoreMIDI), Windows (WinMM), Linux (ALSA).
+- SysEx receive: macOS only. Linux ALSA-in is itself stubbed in the platform layer; Windows WinMM-in receive parsing is on the followup TODO.
+
+**Test suites added**:
+- `tests/test_ccizer.cpp` — 51 checks: parser, comments/blanks, out-of-range, view sidecar round-trip, MIDI byte builder, folder resolution, dir scan.
+- `tests/test_sysex_inq.cpp` — ~25 checks: empty / push-pop / FIFO / overflow / buffer-too-small / invalid input.
+- `tests/test_sysex_macro.cpp` — ~20 checks: predicate, path resolution, valid/malformed/oversized/missing file read.
 
 ## Deeper references (load on demand)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,22 +36,32 @@ CMake option `ZT_BUILD_TESTS` (default ON) controls whether the `tests/` subdire
 | File | Purpose |
 |---|---|
 | `src/main.cpp` | Entry, main loop, key dispatch, `switch_page`, CLI parser. |
-| `src/CUI_Patterneditor.cpp` | Pattern editor (F2). 10+ pattern operations. |
-| `src/CUI_Midimacroeditor.cpp` | MIDI Macro editor (F4). |
+| `src/CUI_Patterneditor.cpp` | Pattern editor (F2). 10+ pattern operations. **Ctrl+Shift+§ toggles `g_cc_drawmode`** — incoming CC writes `Sxxyy` / PB writes `Wxxxx` at the cursor row. |
+| `src/CUI_Midimacroeditor.cpp` | MIDI Macro editor (F4). A macro whose name ends in `.syx` dispatches as a SysEx file send (see `sysex_macro.h`); the data grid is ignored. |
 | `src/CUI_Arpeggioeditor.cpp` | Arpeggio editor (Shift+F4). |
+| `src/CUI_KeyBindings.cpp` | Unified Shortcuts & MIDI Mappings (**Shift+F2** — moved from Shift+F3 to free that slot for the CC Console). |
+| `src/CUI_CcConsole.cpp` | CC Console (**Shift+F3**) — Paketti CCizer file load + sliders/knobs send-out + per-slot MIDI Learn (`L` to learn, `U` to unbind, `B` to assign as current instrument's bank). |
+| `src/CUI_SysExLibrarian.cpp` | SysEx Librarian (**Shift+F5**) — `.syx` file send + auto-capture of incoming SysEx as `recv_<timestamp>.syx`. |
 | `src/CUI_*.cpp` | Other pages: Sysconfig, Songconfig, Help, About, InstEditor, MainMenu, etc. |
 | `src/UserInterface.{h,cpp}` | Widget classes — `CheckBox`, `ValueSlider`, `TextInput`, `Frame`, `Button`, `TextBox`, `ListBox`, `MidiOutDeviceOpener`, `SkinSelector`, `VUPlay`. **Fix rendering bugs in the widget class, not at every caller.** |
 | `src/keybuffer.{h,cpp}` | Key buffer + KS_ALT/KS_CTRL/KS_META/KS_SHIFT state. `KS_HAS_ALT(s)` macro accepts ALT or macOS Cmd. Header has a `ZT_TEST_NO_SDL` guard so it can be compiled into SDL-free unit tests via `tests/sdl_stub.h`. |
 | `src/font.cpp` | `print()` / `printtitle()` / `printBG()` drawing primitives. |
-| `src/zt.h` | Kitchen-sink: `STATE_*` enum, `CMD_*` enum, page globals, layout macros (`TRACKS_ROW_Y`, `CHARS_Y`, `SPACE_AT_BOTTOM`, etc.). |
-| `src/module.{h,cpp}` | Song data: patterns, tracks, events, instruments, arpeggios, midimacros. |
-| `src/playback.{h,cpp}` | MIDI output timing, playback state, R-effect arpeggio + Z-effect macro dispatch. |
+| `src/zt.h` | Kitchen-sink: `STATE_*` enum (incl. `STATE_CCCONSOLE`, `STATE_SYSEX_LIB`), `CMD_*` enum, page globals (`UIP_CcConsole`, `UIP_SysExLibrarian`), `g_cc_drawmode`, layout macros. |
+| `src/module.{h,cpp}` | Song data: patterns, tracks, events, instruments, arpeggios, midimacros. `instrument` carries `ccizer_bank[256]` (per-instrument Paketti file). |
+| `src/playback.{h,cpp}` | MIDI output timing, playback state, R-effect arpeggio + Z-effect macro dispatch. **Z on a `*.syx`-named midimacro** dispatches the file as SysEx via `MidiOut->sendSysEx`. |
+| `src/winmm_compat.h` | Cross-platform MIDI shim. `zt_midi_out_sysex` for SysEx send (CoreMIDI `MIDIPacketListAdd` / WinMM `midiOutLongMsg` / ALSA `snd_seq_ev_set_sysex`). macOS `zt_coremidi_read_proc` parses incoming `F0..F7` into `zt_sysex_inq_push`. |
+| `src/sysex_inq.{h,cpp}` | Process-wide receive queue for incoming SysEx (16 slots × 8 KB; `std::mutex` protected; overflow drops oldest). |
+| `src/sysex_macro.{h,cpp}` | Helpers for the `*.syx`-named-midimacro convention: predicate + `syx_folder` path resolution + framing-checked file reader. |
+| `src/ccizer.{h,cpp}` | CCizer parser, `.cc-view` slider/knob sidecar, `.cc-midi` MIDI Learn sidecar, folder scan, MIDI byte builder, `zt_ccizer_current_file()` (Pattern Editor reads it for friendly slot names in CC drawmode status). |
+| `src/conf.{h,cpp}` | zt.conf — adds `ccizer_folder` + `syx_folder` keys. |
 | `src/preset_data.h` | F4/Shift+F4 preset arrays + pure `*_apply_preset_to(struct*, idx)` apply functions. Header-only, SDL-free, exhaustively unit-tested. |
 | `src/preset_selector.h` | Pure decision logic for the preset listbox (click / arrow / Space / P-cycle). Unit-tested. |
 | `src/page_sync.h` | F4/Shift+F4 widget↔data sync helpers. Prevents the "preset reverts on next frame" class of bug. |
 | `src/save_key_dispatch.h` | Global Ctrl-S dispatch (open save dialog / pass through / let page handle). Unit-tested. |
 | `src/editor_layout.h` | Shared character-grid constants for F4/Shift+F4 editors. |
-| `tests/` | CTest unit-test executables. 5 suites, 285+ checks. Linux CI runs them. |
+| `assets/ccizer/` | Bundled CCizer banks (Paketti subset) + README. CMake POST_BUILD copies into `.app Resources/ccizer` and `<exe-dir>/ccizer`. |
+| `assets/syx/` | Bundled SysEx files. `request_universal_inquiry.syx` for first-test handshakes. |
+| `tests/` | CTest unit-test executables. **8 suites**: presets / selector / page_sync / save_key / keybuffer / ccizer / sysex_inq / sysex_macro. Linux CI runs them. |
 | `doc/help.txt` | In-app F1 help. **Update this when adding keybinds or CLI flags.** |
 | `doc/CHANGELOG.txt` | Release notes, chronological. |
 | `.github/workflows/build.yml` | CI: 5-platform build matrix + Linux ctest run. |
@@ -102,15 +112,49 @@ The ESC menu has a "Copy Relaunch Command" entry that captures current state (op
 
 ---
 
+## Page / shortcut map
+
+| Key | Page |
+|---|---|
+| F1 / F2 / F3 | Help / Pattern Editor / Instrument Editor |
+| F4 / Shift+F4 | MIDI Macro Editor / Arpeggio Editor |
+| **Shift+F2** | **Shortcuts & MIDI Mappings** (moved from Shift+F3 on 2026-04-30) |
+| **Shift+F3** | **CC Console** — Paketti CCizer file load + sliders/knobs send-out + MIDI Learn |
+| F5 / F6 / F7 / F8 / F9 | Play / Play Pattern / From Cursor / Stop / Panic |
+| **Shift+F5** | **SysEx Librarian** — `.syx` send + auto-capture as `recv_<TS>.syx` |
+| F10 / F11 / F12 | Song Message / Song Config / System Config (incl. CCizer Folder input) |
+| **Ctrl+Shift+§** | **CC drawmode toggle** — incoming CC writes `Sxxyy`, PB writes `Wxxxx` |
+
+---
+
+## CCizer + SysEx (PRs #78–#84, end of April 2026)
+
+Three feature areas wired in seven stacked PRs:
+
+1. **CC Console** (Shift+F3, `CUI_CcConsole.cpp`). Loads CCizer-format `.txt` files from `ccizer_folder`. Each slot is shown as a slider or knob; tweaking sends MIDI CC out. `V` toggles the widget choice (persists in a `<file>.cc-view` sidecar). `L` enters MIDI Learn — the next incoming `0xB0..0xBF` / `0xE0..0xEF` binds to the focused slot (persists in `<file>.cc-midi`). `B` assigns the loaded file as the current instrument's bank.
+
+2. **Per-instrument CCizer bank**. `instrument.ccizer_bank[256]` (in `module.h`) is the filename. Persisted via a NEW optional `CCBN` chunk in the `.zt` save format; old zTracker silently skips it via `readblock`'s built-in advance-past behavior, so format compatibility is bidirectional. Pattern Editor auto-loads the focused instrument's bank on `cur_inst` change so the user's "1st CC for instrument N" mental model maps directly to slot 1 of the right file.
+
+3. **SysEx**. Foundation in `winmm_compat.h` (`zt_midi_out_sysex`) + `OutputDevice::sendSysEx` + receive queue `sysex_inq.{h,cpp}`. macOS callback parses incoming `F0..F7` into the queue. **SysEx Librarian** (Shift+F5) lists `.syx` files in `syx_folder`, sends on Enter, auto-saves received messages as `recv_<timestamp>.syx`. **Pattern dispatch convention**: a midimacro whose `name` ends in `.syx` (case-insensitive, len > 4) is dispatched as a SysEx file send by the Z-effect handler — no `.zt` format change because the existing MMAC chunk already round-trips the name.
+
+Cross-platform status (2026-04-30): SysEx send works on all three platforms; receive parsing is macOS-only today (Linux/Windows on the followup TODO).
+
+Tests for all three: `test_ccizer` (51 checks), `test_sysex_inq` (~25), `test_sysex_macro` (~20). Bundled assets under `assets/ccizer/` (Paketti subset) and `assets/syx/` (universal device inquiry).
+
+---
+
 ## Test harness
 
-`tests/` builds five CTest executables:
+`tests/` builds eight CTest executables:
 
 - `test_presets` — preset arrays + apply functions.
 - `test_selector` — listbox click / arrow / Space / P-cycle decision logic.
 - `test_page_sync` — apply→refresh→sync per-frame cycle.
 - `test_save_key` — global Ctrl-S dispatch.
 - `test_keybuffer` — real `KeyBuffer` from `src/keybuffer.cpp`, compiled under `ZT_TEST_NO_SDL` against `tests/sdl_stub.h`.
+- `test_ccizer` — Paketti CCizer parser (`PB`/CC# tokens, comments, blanks, out-of-range), `.cc-view` view-hint sidecar round-trip, MIDI byte builder for CC + 14-bit Pitchbend, folder resolution, `.txt` directory scan.
+- `test_sysex_inq` — process-wide SysEx receive queue: empty / push-pop round-trip / FIFO ordering / overflow drops oldest / undersized pop buffer (message stays queued) / invalid input rejection.
+- `test_sysex_macro` — `*.syx`-named-midimacro convention helpers: predicate (case-insensitive, rejects bare `.syx`), path resolution against `syx_folder`, and the framing-checked file reader (rejects missing `F0`/`F7`, oversized, missing).
 
 Run all: `ctest --test-dir build --output-on-failure`. CI runs them on the Linux job after every push.
 


### PR DESCRIPTION
## Standalone PR (off `master`, not stacked)

Pure docs — touches `CLAUDE.md` and `.claude/skills/ztrackerprime/SKILL.md` only. Lands cleanly regardless of the merge order of #78–#84 (it doesn't reference any specific code change those PRs introduce in a way that breaks if they're not merged yet — but the doc accurately describes what those PRs ship).

## What this PR does

Updates the in-repo contributor docs after the seven-PR CCizer + SysEx feature stack so future AI sessions (and human contributors) pick up the new pages, conf keys, and conventions without reading every PR body.

Both files get:

- **Page / shortcut map**: Shift+F2 (Shortcuts & MIDI Mappings, moved from Shift+F3), Shift+F3 (CC Console), Shift+F5 (SysEx Librarian), Ctrl+Shift+§ (CC drawmode toggle).
- **Key-files table** updated with `CUI_CcConsole.cpp`, `CUI_SysExLibrarian.cpp`, `winmm_compat.h` (SysEx shim), `sysex_inq.{h,cpp}`, `sysex_macro.{h,cpp}`, `ccizer.{h,cpp}`, `conf.{h,cpp}` (`ccizer_folder` + `syx_folder` keys), `module.{h,cpp}` (`instrument.ccizer_bank` field), playback.cpp's Z-effect dispatch, `assets/ccizer/`, `assets/syx/`.
- **Test count corrected**: 5 → 8 suites (added `test_ccizer`, `test_sysex_inq`, `test_sysex_macro`).

The skill gets a dedicated **CCizer + SysEx architecture** section walking the three-layer split (per-page UI, process-wide plumbing, persistence) plus the cross-platform status table — send works on macOS / Windows / Linux, receive is macOS-only as of 2026-04-30. CLAUDE.md gets a shorter mirrored summary.

Both files note the optional `CCBN` `.zt` chunk for per-instrument banks and the SysEx-by-filename convention so anyone touching playback or the save format understands the contract before changing it.

## Test plan

- [x] No code changed; CI is informational
- [ ] Manual: open the SKILL.md / CLAUDE.md in GitHub's preview — table renders, anchors work, no broken markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)
