### PR TITLE
CC Console: real ValueSlider widgets + need_refresh invariant

### DIFF
--- a/.claude/skills/ztrackerprime/SKILL.md
+++ b/.claude/skills/ztrackerprime/SKILL.md
@@ -136,6 +136,16 @@ Seven-PR feature stack landed end of April 2026 wiring Paketti-style CCizer bank
 - `tests/test_sysex_inq.cpp` — ~25 checks: empty / push-pop / FIFO / overflow / buffer-too-small / invalid input.
 - `tests/test_sysex_macro.cpp` — ~20 checks: predicate, path resolution, valid/malformed/oversized/missing file read.
 
+## INVARIANT: pages must bump `need_refresh` and use real widgets
+
+`main.cpp` gates `ActivePage->draw()` on `need_refresh != 0`. Two non-negotiable rules for any page added or modified:
+
+1. **Every key handler that mutates visible state ends with `need_refresh++;`** (and so does `enter()`, and any background pump that changes what should be on screen). Forget this and arrow keys silently mutate state without a redraw — the page looks frozen until some other path bumps the flag.
+
+2. **Interactive elements are real widgets, not ASCII art.** If the user is supposed to click a slider, the slider is a `ValueSlider` registered with `UI->add_element`, drawn by `UI->draw(S)`, mutated by `ValueSlider::mouseupdate`, and absorbed by the page's `update()` reading the `changed` flag. **Never** ship `printBG` text bars as a stand-in for "we'll iterate later" — they are visually identical in a screenshot but completely unclickable, and the user finds out by trying. The pool-of-N pattern (pre-allocate `N` widgets in the ctor, position the visible window per-frame, hide off-screen ones with `xsize=0`) is the idiom for variable-count slot grids; `CUI_CcConsole.cpp::position_sliders` is a worked example.
+
+Both rules were learnt the hard way during the CCizer / SysEx work — see PR #78 (text-bars regression) and the followup that wired real `ValueSlider`s + `need_refresh` bumps. Treat them as load-bearing for any new page.
+
 ## Deeper references (load on demand)
 
 - [`references/foot-guns.md`](references/foot-guns.md) — recurring bug classes: ListBox mousestate fragility, widget-upstream rule, user-reported-inputs-as-ground-truth.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,21 @@ When you fix a class of bug that has bitten more than once (preset apply, save-k
 
 ---
 
+## INVARIANT: every page key handler must `need_refresh++`
+
+`main.cpp`'s outer loop only calls `ActivePage->draw()` when `need_refresh != 0` (search `if (need_refresh)` near line 3184). A page that mutates state (cursor, scroll, focus, value, status line, learn flag) on a key without bumping `need_refresh` looks frozen to the user — the new state is computed but never drawn.
+
+**Rules:**
+1. Every `if (key == ...)` branch in a page's `update()` that changes any visible state ends with `need_refresh++;` before `return;`.
+2. `enter()` bumps `need_refresh++` so the first frame after page switch always paints.
+3. Background activity that mutates state (MIDI-in pump, file watch) bumps `need_refresh++` per change.
+4. Mouse-driven widget changes are handled by the widget itself (`ValueSlider::mouseupdate` already does `need_refresh++` and `need_redraw++`); the page doesn't need to bump again for those.
+5. **No "iterate later" placeholders for visible interactive elements.** If a page advertises clickable sliders, knobs, buttons — they must be real `UserInterfaceElement` widgets registered with `UI->add_element`, not `printBG` ASCII art. ASCII bars look the same as widgets in a screenshot and the user only finds out they can't click when they try. Widgets get drawn by `UI->draw(S)`; their min/max/value flow through `changed` flags the page absorbs after `UI->update()`.
+
+Failure mode if rule 1 is violated: arrow keys move the highlighted cursor in memory but the screen doesn't repaint until something else (mouse move, resize, MIDI in) bumps `need_refresh`. Looks like the page froze.
+
+Failure mode if rule 5 is violated: shipped pages with non-interactive ASCII "sliders" that the user discovers don't respond to mouse — embarrassment + rework. (Cf. PR #78 CC Console v1, fixed in a follow-up.)
+
 ## Recurring foot-guns
 
 ### ListBox subclass mousestate gotcha

--- a/docs/plans/audit-ccizer-sysex-2026-04-30.md
+++ b/docs/plans/audit-ccizer-sysex-2026-04-30.md
@@ -1,0 +1,267 @@
+# Brittleness audit — CCizer + SysEx work (PRs #78–#84)
+
+Date: 2026-04-30
+Scope: everything merged to `master` from PRs #78 through #85.
+
+This is a fresh-eyes review against the merged code. Items below are concrete:
+each one names the file/function, what's wrong, what fails in practice, and a
+specific fix. Severity = how likely a real user hits it.
+
+## Severity HIGH — real bugs
+
+### H1. Windows SysEx send leaks the `MIDIHDR` and starts failing after the first call
+**Where:** `src/winmm_compat.h::zt_midi_out_sysex` (Windows branch, lines 19–32).
+
+**Bug:** Calls `midiOutUnprepareHeader` immediately after `midiOutLongMsg`. Per
+MS docs, `midiOutUnprepareHeader` fails with `MIDIERR_STILLPLAYING` until
+`MHDR_DONE` is set in `dwFlags`. The driver still owns the buffer; we tear
+down the `MIDIHDR` while it's queued. Subsequent calls to `midiOutLongMsg`
+on the same handle may return `MIDIERR_STILLPLAYING` because the previous
+buffer is still "in flight" from the driver's POV.
+
+**Symptom:** First SysEx might land. The second and onward likely fail
+silently. Worse on synths that take 100+ ms to consume long dumps.
+
+**Fix:** Poll `(hdr.dwFlags & MHDR_DONE) == 0` with a short sleep loop
+before unpreparing, OR keep the `MIDIHDR` (heap-allocated) on a per-handle
+"in-flight" list and unprepare lazily on the next send / handle close. The
+poll-loop is the smaller change:
+
+```c
+while ((hdr.dwFlags & MHDR_DONE) == 0) Sleep(1);
+midiOutUnprepareHeader(h, &hdr, sizeof(hdr));
+```
+
+Caveat: blocks the calling thread for the duration of the dump (typical
+2-byte/ms = ~1 ms per 2 bytes). For SysEx librarian use that's acceptable;
+for playback-thread Z-effect dispatch it's blocking time the player can't
+afford.
+
+### H2. ESC menu's "Toggle CC Drawmode" leaves undo-session marker stale
+**Where:** `src/CUI_Patterneditor.cpp` (line 22, file-static
+`g_cc_draw_session_snapped`) and `src/CUI_MainMenu.cpp::mm_toggle_cc_drawmode`.
+
+**Bug:** `g_cc_draw_session_snapped` is a `static int` inside
+`CUI_Patterneditor.cpp`, invisible from the menu. The Ctrl+Shift+§ keypath
+in the Pattern Editor resets it, but `mm_toggle_cc_drawmode` only flips
+`g_cc_drawmode` and never touches the session marker.
+
+**Symptom:** Toggle drawmode OFF via the keypath (session marker reset to 0).
+Toggle ON via the ESC menu (session marker still 0 — but only by coincidence,
+since it was zeroed on the previous toggle). Toggle OFF via menu (still 0).
+Toggle ON via menu (still 0). Tweak knob — `UNDO_SAVE` fires (correct, since
+marker was 0). Tweak knob 100 more times — no further snapshots. Then toggle
+OFF/ON via menu without leaving Pattern Editor — marker is still 1 from the
+first session, so the SECOND knob run has no undo snapshot.
+
+**Fix:** Lift `g_cc_draw_session_snapped` to `extern int` in `zt.h`, define
+in `main.cpp` next to `g_cc_drawmode`, and reset it from
+`mm_toggle_cc_drawmode` too. Or wrap both toggles in a shared inline helper
+`zt_toggle_cc_drawmode()` defined in one place.
+
+### H3. File I/O in the playback thread (Z-effect SysEx dispatch)
+**Where:** `src/playback.cpp::case 'Z'` (lines 1589–1599) calls into
+`zt_sysex_macro_resolve_path` + `zt_sysex_macro_read_file` which do `stat`,
+`fopen`, `fread`, `malloc` inline.
+
+**Bug:** The Z-effect handler runs in the playback thread (`counter_thread` /
+`player_callback`). A cold disk read on the song's first SysEx-Z effect
+blocks that thread for whatever the disk takes. macOS spotlight reads or
+spinning-disk Linux setups can stall hundreds of milliseconds.
+
+**Symptom:** First playback of a pattern with a SysEx-Z effect drops MIDI
+ticks / late-arrival of subsequent notes. Subsequent plays are fine
+(filesystem cache).
+
+**Fix:** Resolve and read all `*.syx`-named macros at song-load time
+(`zt_module::load`) into an in-memory cache keyed by macro slot. Z-effect
+dispatch then just looks up the bytes, no I/O. Re-read on song save or
+on conf-change of `syx_folder`.
+
+Smaller alternative: read the file lazily at first use but cache for
+the rest of the playback session (per-macro `unsigned char *cached_bytes`
++ `int cached_len` on the `midimacro` struct).
+
+### H4. CC Console `learning` flag persists across page-leave
+**Where:** `src/CUI_CcConsole.cpp::enter` (179–186), `::leave` (188–189).
+
+**Bug:** `learning` is reset on ESC, on captured-MIDI-event, and on `L` press.
+Never reset on `enter()` or `leave()`. If the user presses `L`, then opens
+the ESC menu and switches to another page (without pressing ESC inside the
+console), `learning = 1` is preserved. Re-entering Shift+F3 silently leaves
+learn mode on; the next incoming CC binds to `slot_cur` with no warning.
+
+**Symptom:** Quietly mis-binds knobs in the rare case where the user changes
+pages mid-Learn.
+
+**Fix:** Add `learning = 0;` to `enter()` (and ideally `leave()` too).
+
+## Severity MEDIUM — correctness on edge cases
+
+### M5. zt.conf paths are read from playback thread without synchronization
+**Where:** `src/CUI_Sysconfig.cpp:461` binds the F12 `TextInput` directly at
+`zt_config_globals.ccizer_folder`'s buffer; `src/sysex_macro.cpp::zt_sysex_macro_resolve_path`
+reads the same buffer from the playback thread.
+
+**Bug:** Per-keystroke writes from F12 race with reads in the playback
+thread. C strings without locking is data-race-undefined-behavior even if
+the buffer is character-by-character non-tearing on x86.
+
+**Realistic impact:** Almost zero — users don't tweak F12 paths while
+playback is running. But it's a flagged data race that a sanitizer build
+would catch.
+
+**Fix:** Take a snapshot of the path on `zt_module::load` / `enter()` of
+the relevant page, or guard reads with a tiny `std::shared_mutex`.
+
+### M6. macOS SysEx send uses a 17 KB stack buffer
+**Where:** `src/winmm_compat.h::zt_midi_out_sysex` (macOS branch, line 587).
+
+**Bug:** `Byte buf[MAX_SYSEX + 1024]` = 17 KB on the stack. Default macOS
+thread stack is 512 KB so today this is fine. But if anyone later spawns a
+worker thread with a smaller stack and calls `sendSysEx` from it, this
+overflows.
+
+**Fix:** Heap-allocate the packet buffer. One-line change.
+
+### M7. Receive auto-save can collide on filenames after restart
+**Where:** `src/CUI_SysExLibrarian.cpp::drain_recv` — uses `recv_seq` (member,
+reset to 0 in ctor).
+
+**Bug:** `recv_seq` doesn't survive process restart. After restart, a new
+capture arriving in the same second as a pre-existing `recv_<TS>_000.syx`
+clobbers the file.
+
+**Realistic impact:** Very low — requires restart + same-second capture +
+matching wall clock seconds. But silent data loss when it happens.
+
+**Fix:** On `enter()`, scan the folder for the highest existing
+`recv_*_NNN` and seed `recv_seq` past it. Or include subsecond precision
+in the timestamp.
+
+### M8. CC Console doesn't auto-create the default folder
+**Where:** `src/CUI_CcConsole.cpp::resolve_folder` (lines 137–155).
+
+**Bug:** SysEx Librarian uses `make_dir_recursive` to create its folder.
+CC Console does not. If `ccizer_folder` zt.conf key is unset AND
+`./ccizer` doesn't exist (e.g. user moved the binary out of the build
+dir), `num_files = 0` with no clear error.
+
+**Fix:** Add `make_dir_recursive(folder)` call after resolve, mirroring
+the librarian. (Or: extract a shared helper.)
+
+### M9. `localtime()` is not thread-safe
+**Where:** `src/CUI_SysExLibrarian.cpp::drain_recv`.
+
+**Bug:** `localtime` returns a pointer to a static `struct tm`. Called only
+from the UI thread today, so no actual race. But standard portability
+gotcha.
+
+**Fix:** `localtime_r(&now, &tmbuf)` (POSIX) /
+`localtime_s(&tmbuf, &now)` (MSVC). Tiny.
+
+### M10. SysEx file size cap is 64 KB at playback dispatch
+**Where:** `src/playback.cpp:1594` calls `zt_sysex_macro_read_file(..., 65536)`.
+
+**Bug:** Some real-world dumps exceed 64 KB. Roland Integra-7, Korg Kronos,
+modular synth global state. Files larger than 64 KB silently fail to
+dispatch.
+
+**Fix:** Bump to 1 MB or remove the cap and rely on file-system size only.
+The `MAX_SYSEX = 16384` cap inside the macOS sender is a separate, lower
+cap — also worth raising.
+
+## Severity LOW — brittle patterns / future-proofing
+
+### L11. `zt_sysex_inq` lock-protected memcpy of 8 KB on every push
+Mutex contention between CoreMIDI callback thread and UI thread on every
+SysEx received. Real but not measurable for typical patch-dump rates.
+Lock-free SPSC ring would fix; almost certainly premature.
+
+### L12. CCBN chunk loader silently truncates on length mismatch
+`src/ztfile-io.cpp` CCBN load tolerates corrupt `length` (CDataBuf
+`getch` returns 0 past end), but doesn't warn the user. A corrupted song
+file results in instruments with bogus bank names.
+
+**Fix:** Track bytes-remaining and log a warning if length > remaining.
+
+### L13. F12 has no `syx_folder` TextInput
+Only `ccizer_folder` is exposed in F12. User edits `zt.conf` directly to
+move the SysEx folder. Inconsistent UX.
+
+**Fix:** Mirror the `ccizer_folder` TextInput pattern for `syx_folder`.
+
+### L14. F4 SysEx hint doesn't verify the file exists
+`zt_sysex_macro_is_file(name)` checks suffix only. F4 shows
+`(SysEx file mode: data grid is ignored)` even if the file is missing.
+Z-effect playback drops silently in that case.
+
+**Fix:** Resolve + `stat` at hint time; if missing, show
+`(SysEx file: NOT FOUND)` in red so the user knows the dispatch will
+no-op.
+
+### L15. `recv_*.syx` files accumulate forever
+No cap, no rotation. A busy session capturing every patch leaves
+hundreds of files in the folder, slowing the file-list scan.
+
+**Fix:** Optional `syx_recv_max_files` zt.conf key with LRU cleanup.
+Or just document it and trust the user to clean up.
+
+### L16. `g_loaded` (CC Console) and `g_ccizer_current` (process-wide)
+**Where:** `src/CUI_CcConsole.cpp` file-static + `src/ccizer.cpp` file-static.
+
+**Bug:** `zt_ccizer_set_current_file(&g_loaded)` exposes the address of a
+file-static. If `delete UIP_CcConsole` ever runs while another thread is
+reading the pointer, you get UAF. Currently the destructor is at app
+shutdown only, but it's a fragile setup.
+
+**Fix:** Either move ownership of the loaded file into a heap allocation
+that the CC Console manages, or document the lifetime invariant clearly
+in `ccizer.h`.
+
+## Process / quality observations
+
+### P17. Visual verification is still missing
+Across PRs #78–#85 I never got an end-to-end screenshot. The AppleScript
+window-detection issue I gave up on at session start. Build green +
+tests green ≠ "looks right." Manuel may find layout bugs at review time.
+
+**Fix:** Solve the SDL-window-detection issue properly. Two options:
+(1) capture by CGWindow ID via `CGWindowListCopyWindowInfo`, or
+(2) make the screenshot script detect the window by `pid` instead of
+process name, since the SDL window may not have an AppKit-visible
+NSWindow under all configurations.
+
+### P18. No integration test for the CCBN chunk
+`test_ccizer.cpp` covers parser only. There's no CTest that builds a tiny
+song with a per-instrument bank, saves it, reloads it, and asserts the
+bank survived. Save-format changes deserve roundtrip tests.
+
+**Fix:** New `test_ccbn_roundtrip.cpp` that uses the existing module-stub
+infrastructure to build → save → load → assert.
+
+### P19. SysEx receive parsing is macOS-only
+Documented as deferred, but worth restating: Linux ALSA-in is itself
+stubbed in `winmm_compat.h`, and Windows `midiInCallback` doesn't push
+SysEx into `zt_sysex_inq`. The librarian receive log will be empty on
+Linux/Windows even when the synth replies.
+
+**Fix:** Wire `MIM_LONGDATA` on Windows (`midi-io.cpp:344`-area) and add
+ALSA `snd_seq_event_input` SysEx path on Linux.
+
+## Suggested PR ordering for fixes
+
+1. **PR-A (high-impact, small):** H2 + H4 + M9 + L13. Pure UI lifecycle
+   + thread-safe time + new TextInput. ~80 LOC.
+2. **PR-B (Windows correctness):** H1. Critical for Windows users.
+   ~40 LOC + manual Win test.
+3. **PR-C (playback robustness):** H3 (lazy cache of `*.syx` macros) +
+   M10 (raise cap). ~150 LOC.
+4. **PR-D (folder hygiene):** M7 + M8 + L14 + L15. Library/folder UX
+   polish. ~100 LOC.
+5. **PR-E (cross-platform SysEx receive):** P19 — Linux ALSA-in receive
+   parse + Windows `midiInCallback` SysEx routing. ~250 LOC. Real
+   testing required on each platform.
+6. **PR-F (test debt):** P18 + screenshot scripts (P17). ~150 LOC.
+
+Each PR is small enough to land in one Manuel review pass.

--- a/src/CUI_CcConsole.cpp
+++ b/src/CUI_CcConsole.cpp
@@ -3,35 +3,53 @@
  * FILE  CUI_CcConsole.cpp
  *
  * DESCRIPTION
- *   CC Console (Shift+F3). Loads Paketti CCizer-format `.txt` files from
- *   the configured ccizer_folder and lets the user send MIDI Control
- *   Change (and Pitch Bend) messages out to the current MIDI Out device
- *   via on-screen sliders or knobs.
+ *   CC Console (Shift+F3). Real ValueSlider widgets per slot — mouse-
+ *   clickable, keyboard-adjustable. Tweak fires MIDI CC (or 14-bit
+ *   Pitchbend for `PB` slots) on the current channel out the current
+ *   MIDI Out device.
  *
- *   Layout:
- *     +-- Files ----------+  +-- <basename> -------------------------+
- *     | a.txt             |  |  Slot  CC   Name        View   Value |
- *     | b.txt             |  |   1    PB   Pitchbend   slider  64   |
- *     |▶c.txt             |  |   2    1    Mod         knob    23   |
- *     | ...               |  |   3    7    Volume      slider  100  |
- *     +-------------------+  +---------------------------------------+
+ *   Layout (one row per slot):
+ *
+ *     +-- Files ---------+   Slot CC#  Name              [slider]  val   Learn
+ *     | a.txt            |    > 1   PB  Pitchbend        [#####--]  8192 PB ch1
+ *     |>b.txt            |      2    1  Mod              [###----]    45 B0 4A
+ *     | ...              |      3    7  Volume           [######-]   100 ----
+ *     +------------------+    ...
+ *
+ *   Sliders are widgets in the page's UserInterface. Tab cycling
+ *   between them is disabled (no_tab_stop=1) so Tab still toggles
+ *   focus between Files pane / slot grid (page-level), and Up/Dn
+ *   walk through slot_cur (page-level). The slider widgets are pool-
+ *   allocated up to ZT_CCIZER_MAX_SLOTS (128) — positioned per-frame
+ *   based on slot_top so vertical scrolling reuses the same widgets.
+ *   Off-screen sliders get xsize=0 which disables their draw / mouse
+ *   / keyboard paths in ValueSlider::update().
+ *
+ *   Mouse interaction: click anywhere on a slider's bar to set its
+ *   value to that fractional position (ValueSlider's built-in
+ *   mouseupdate). Drag to scrub. The page's update() detects each
+ *   slider's `changed` flag after UI->update() and calls send_slot
+ *   so every motion sends MIDI in real time.
  *
  *   Keys:
- *     Tab          toggle focus (file list <-> slot grid)
- *     Up/Down      move selection
- *     Enter        load focused file
- *     Left/Right   adjust value (Shift = ×8, Ctrl = ×16)
- *     V            toggle slider <-> knob for focused slot
- *     [ / ]        decrement / increment MIDI channel
- *     Backspace    reset focused slot value to default
- *     Ctrl+S       save .cc-view sidecar
- *     ESC          back to Pattern Editor
+ *     Tab          toggle focus (Files <-> slot grid)
+ *     Up/Dn        move selection within focused pane
+ *     Enter        load focused file (Files pane only)
+ *     Lt/Rt        adjust focused slot's value (in slot grid)
+ *                    Shift = step×8, Ctrl = step×16
+ *     Backspace    reset focused slot's value
+ *     L            MIDI Learn for focused slot (next CC/PB binds)
+ *     U            unbind learn for focused slot
+ *     B            assign loaded file as current instrument's bank
+ *     Shift+B      clear current instrument's bank
+ *     [ / ]        adjust MIDI channel
+ *     Space        re-send focused slot's current value
+ *     Ctrl+S       save .cc-view + .cc-midi sidecars
+ *     ESC          back to Pattern Editor (cancels Learn first if active)
  *
- *   The .cc-view sidecar persists slider/knob choices next to the .txt
- *   so the Paketti file itself stays untouched.
- *
- *   Pattern-drawing, per-instrument bank assignment, and CC MIDI Learn
- *   are deferred -- see docs/plans/cc-followup-todo.md.
+ *   Every key handler bumps `need_refresh++` because the main loop
+ *   gates page draw() on it (see main.cpp `if (need_refresh)`). Forget
+ *   the bump and the screen freezes on input.
  *
  ******/
 #include "zt.h"
@@ -40,16 +58,30 @@
 #include <stdio.h>
 #include <string.h>
 
-// --------- Layout constants ---------
+// ---------- Layout constants ----------
 #define CC_BASE_Y       (TRACKS_ROW_Y + 0)
+
+// File list pane (left)
 #define CC_FILE_X       2
 #define CC_FILE_Y       (CC_BASE_Y + 2)
-#define CC_FILE_W       24
-#define CC_GRID_X       (CC_FILE_X + CC_FILE_W + 2)
+#define CC_FILE_W       26
+
+// Slot grid pane (right)
+#define CC_GRID_X       (CC_FILE_X + CC_FILE_W + 2)   // = 30
 #define CC_GRID_Y       (CC_BASE_Y + 2)
-#define CC_GRID_W_COLS  46
-#define CC_BAR_W        12
+#define CC_SLOT_COL     CC_GRID_X                      // "  1 " or "> 1 "
+#define CC_CC_COL       (CC_GRID_X + 5)                // "PB  " or "127 "
+#define CC_NAME_COL     (CC_GRID_X + 9)                // 17-char field
+#define CC_SLIDER_X     (CC_GRID_X + 27)               // ValueSlider widget x
+#define CC_SLIDER_W     10                             // ValueSlider xsize
+#define CC_LEARN_COL    (CC_SLIDER_X + CC_SLIDER_W + 5) // "B0 4A" or "PB ch3" or "----"
+
 #define CC_SPACE_BOTTOM 8
+
+// IDs for tagged UI elements. The slider pool starts at CC_SLIDER_ID_BASE
+// and runs for ZT_CCIZER_MAX_SLOTS — using a high base avoids collision
+// with the (currently empty) tab-stop pool.
+#define CC_SLIDER_ID_BASE 100
 
 static ZtCcizerFile g_loaded;
 
@@ -69,7 +101,6 @@ static void send_slot(const ZtCcizerSlot *s, int channel) {
         }
     }
     if (dev < 0) {
-        // Fall back to first opened device.
         for (int i = 0; i < (int)MidiOut->numOuputDevices; i++) {
             if (MidiOut->outputDevices[i] && MidiOut->outputDevices[i]->opened) {
                 dev = i; break;
@@ -87,30 +118,12 @@ static void send_slot(const ZtCcizerSlot *s, int channel) {
     }
 }
 
-// Build a textual slider bar, e.g. "[####------]"
-static void render_bar(char *buf, size_t bsz, int val, int maxv) {
-    if (maxv <= 0) maxv = 1;
-    int w = CC_BAR_W;
-    int filled = (val * w) / maxv;
-    if (filled < 0) filled = 0;
-    if (filled > w) filled = w;
-    if ((int)bsz < w + 3) { buf[0] = '\0'; return; }
-    buf[0] = '[';
-    for (int i = 0; i < w; i++) buf[1 + i] = (i < filled) ? '#' : '-';
-    buf[1 + w] = ']';
-    buf[2 + w] = '\0';
+static int slot_max(const ZtCcizerSlot *s) {
+    return (s->cc == ZT_CCIZER_PB_MARKER) ? 16383 : 127;
 }
 
-// Build a 2-char "knob" representation.  Eight detents drawn as one of
-// "<.", "<:", "<|", ":|", "|>", "|:", ":>", ".>".
-static void render_knob(char *buf, size_t bsz, int val, int maxv) {
-    static const char *frames[8] = {
-        "<.", "<:", "<|", ":|", "|>", "|:", ":>", ".>"
-    };
-    if (maxv <= 0) maxv = 1;
-    int idx = (val * 8) / (maxv + 1);
-    if (idx < 0) idx = 0; if (idx > 7) idx = 7;
-    snprintf(buf, bsz, "%s", frames[idx]);
+static int slot_default(const ZtCcizerSlot *s) {
+    return (s->cc == ZT_CCIZER_PB_MARKER) ? 8192 : 0;
 }
 
 // --------- Lifecycle ---------
@@ -125,7 +138,27 @@ CUI_CcConsole::CUI_CcConsole() {
     status_line[0] = '\0';
     folder[0] = '\0';
     num_files = 0;
+    last_visible_count = 0;
     memset(&g_loaded, 0, sizeof(g_loaded));
+    memset(last_values, 0, sizeof(last_values));
+
+    // Pre-allocate the slider pool. Each is hidden (xsize=0) until a
+    // file load + position_sliders() configures it. Tab-stops disabled
+    // so Tab/Up/Down keyboard nav stays page-owned.
+    for (int i = 0; i < ZT_CCIZER_MAX_SLOTS; i++) {
+        ValueSlider *vs = new ValueSlider(0);
+        vs->no_tab_stop = 1;
+        vs->frame = 0;
+        vs->x = CC_SLIDER_X;
+        vs->y = 0;
+        vs->xsize = 0;          // hidden by default
+        vs->ysize = 1;
+        vs->min = 0;
+        vs->max = 127;
+        vs->value = 0;
+        UI->add_element(vs, CC_SLIDER_ID_BASE + i);
+        sliders[i] = vs;
+    }
 }
 
 void CUI_CcConsole::rescan_folder(void) {
@@ -143,10 +176,7 @@ void CUI_CcConsole::load_by_basename(const char *bn) {
     if (!bn || !*bn) return;
     if (folder[0] == '\0') rescan_folder();
     if (folder[0] == '\0') return;
-    // Skip if it's already loaded — avoids re-reading on every
-    // cur_inst-change tick when the user stays on one instrument.
     if (loaded && strcmp(g_loaded.basename, bn) == 0) return;
-    // Find it in the current folder list.
     for (int i = 0; i < num_files; i++) {
         if (strcmp(files[i], bn) == 0) {
             file_cur = i;
@@ -154,8 +184,6 @@ void CUI_CcConsole::load_by_basename(const char *bn) {
             return;
         }
     }
-    // Not in the configured folder — don't try to follow an absolute path.
-    // Just leave whatever is currently loaded; the user can switch folders.
 }
 
 void CUI_CcConsole::load_selected(void) {
@@ -166,6 +194,11 @@ void CUI_CcConsole::load_selected(void) {
         loaded = 1;
         slot_cur = slot_top = 0;
         zt_ccizer_set_current_file(&g_loaded);
+        // Seed last_values so we don't false-trigger send_slot on the
+        // first absorb pass after load.
+        for (int i = 0; i < ZT_CCIZER_MAX_SLOTS; i++) {
+            last_values[i] = (i < g_loaded.num_slots) ? g_loaded.slots[i].value : 0;
+        }
         snprintf(status_line, sizeof(status_line),
                  "Loaded %s — %d slot(s).", g_loaded.basename, g_loaded.num_slots);
     } else {
@@ -174,27 +207,99 @@ void CUI_CcConsole::load_selected(void) {
         snprintf(status_line, sizeof(status_line),
                  "Failed to load %s.", files[file_cur]);
     }
+    need_refresh++;
+}
+
+void CUI_CcConsole::position_sliders(int grid_max_rows) {
+    // Hide all sliders by default; activate the visible window.
+    for (int i = 0; i < ZT_CCIZER_MAX_SLOTS; i++) {
+        sliders[i]->xsize = 0;
+    }
+    if (!loaded || g_loaded.num_slots == 0) {
+        last_visible_count = 0;
+        return;
+    }
+    int n = g_loaded.num_slots;
+    if (n > ZT_CCIZER_MAX_SLOTS) n = ZT_CCIZER_MAX_SLOTS;
+
+    // Clamp scroll so slot_cur stays in view.
+    if (slot_cur < slot_top) slot_top = slot_cur;
+    if (slot_cur >= slot_top + grid_max_rows)
+        slot_top = slot_cur - grid_max_rows + 1;
+    if (slot_top < 0) slot_top = 0;
+    if (slot_top + grid_max_rows > n) slot_top = n - grid_max_rows;
+    if (slot_top < 0) slot_top = 0;
+
+    int visible = 0;
+    for (int row = 0; row < grid_max_rows; row++) {
+        int idx = slot_top + row;
+        if (idx >= n) break;
+        ZtCcizerSlot *s = &g_loaded.slots[idx];
+        ValueSlider *vs = sliders[idx];
+        vs->x = CC_SLIDER_X;
+        vs->y = CC_GRID_Y + row;
+        vs->xsize = CC_SLIDER_W;
+        vs->min = 0;
+        vs->max = slot_max(s);
+        vs->value = s->value;
+        last_values[idx] = s->value;
+        visible++;
+    }
+    last_visible_count = visible;
+}
+
+void CUI_CcConsole::absorb_slider_changes(void) {
+    if (!loaded) return;
+    int n = g_loaded.num_slots;
+    if (n > ZT_CCIZER_MAX_SLOTS) n = ZT_CCIZER_MAX_SLOTS;
+    for (int i = 0; i < n; i++) {
+        ValueSlider *vs = sliders[i];
+        if (vs->xsize == 0) continue;       // off-screen, skip
+        if (vs->value == last_values[i]) continue;
+        // User moved this slider (mouse drag or keyboard inside the
+        // widget). Copy back to the slot and fire send.
+        ZtCcizerSlot *s = &g_loaded.slots[i];
+        int v = vs->value;
+        if (v < 0) v = 0;
+        if (v > slot_max(s)) v = slot_max(s);
+        s->value = (unsigned short)v;
+        last_values[i] = v;
+        slot_cur = i;
+        send_slot(s, channel);
+        snprintf(status_line, sizeof(status_line),
+                 "%s = %d  (ch %d)", s->name, v, channel);
+        need_refresh++;
+    }
 }
 
 void CUI_CcConsole::enter(void) {
     cur_state = STATE_CCCONSOLE;
+    learning = 0;          // never enter the page mid-learn
     rescan_folder();
     if (!loaded && num_files > 0) load_selected();
     snprintf(status_line, sizeof(status_line),
-             "Tab | Lt/Rt val | V slider/knob | L learn | U unbind | B bank-to-inst | Shift+B clear | [/] ch | Ctrl+S | ESC");
+             "Tab focus | Up/Dn pick | Click slider | Lt/Rt val | L learn | U unbind | B bank | [/] ch | Ctrl+S | ESC");
     Keys.flush();
+    need_refresh++;
+    UI->enter();
 }
 
 void CUI_CcConsole::leave(void) {
+    learning = 0;
 }
 
 // --------- Update ---------
 void CUI_CcConsole::update(void) {
+    int total_rows    = INTERNAL_RESOLUTION_Y / CHARACTER_SIZE_Y;
+    int grid_max_rows = total_rows - CC_GRID_Y - CC_SPACE_BOTTOM - 2;
+    if (grid_max_rows < 4) grid_max_rows = 4;
+
+    // Reposition the slider widget pool every frame so scrolling /
+    // file-load / window-resize stay correct without explicit
+    // invalidation calls from every key handler.
+    position_sliders(grid_max_rows);
+
     // ----- MIDI-in pump -----
-    // Drain any incoming MIDI messages while on this page. In Learn mode
-    // we capture (status, data1) into the focused slot. Always: a CC/PB
-    // message that matches a learnt slot updates that slot's value (and
-    // moves the cursor to it for visual feedback).
     while (midiInQueue.size() > 0) {
         int dw = midiInQueue.pop();
         unsigned char status = (unsigned char)(dw & 0xFF);
@@ -208,9 +313,9 @@ void CUI_CcConsole::update(void) {
             g_loaded.slots[slot_cur].learn_data1  = (hi == 0xE0) ? 0 : d1;
             learning = 0;
             snprintf(status_line, sizeof(status_line),
-                     "Learnt %s%s slot %d <- status %02X data1 %02X  (Ctrl+S to save)",
-                     g_loaded.basename, "",
-                     slot_cur + 1, status, d1);
+                     "Learnt %s slot %d <- status %02X data1 %02X  (Ctrl+S to save)",
+                     g_loaded.basename, slot_cur + 1, status, d1);
+            need_refresh++;
             continue;
         }
 
@@ -222,22 +327,32 @@ void CUI_CcConsole::update(void) {
                 if (hi == 0xE0) m->value = (unsigned short)(d1 | (d2 << 7));
                 else            m->value = d2;
                 slot_cur = match;
+                if (match < ZT_CCIZER_MAX_SLOTS) {
+                    sliders[match]->value = m->value;
+                    last_values[match] = m->value;
+                }
                 snprintf(status_line, sizeof(status_line),
                          "%s = %d  (learnt slot %d)",
                          m->name, (int)m->value, match + 1);
+                need_refresh++;
             }
         }
     }
 
+    // ----- Widget update (mouse drag / keyboard inside slider) -----
+    UI->update();
+    absorb_slider_changes();
+
     if (!Keys.size()) return;
 
-    KBMod  kstate = Keys.getstate();
-    KBKey  key    = Keys.getkey();
+    KBMod kstate = Keys.getstate();
+    KBKey key   = Keys.getkey();
 
     if (key == SDLK_ESCAPE) {
         if (learning) {
             learning = 0;
             snprintf(status_line, sizeof(status_line), "Learn cancelled.");
+            need_refresh++;
             return;
         }
         switch_page(UIP_Patterneditor);
@@ -246,17 +361,20 @@ void CUI_CcConsole::update(void) {
 
     if (key == SDLK_TAB) {
         focus = (focus == 0) ? 1 : 0;
+        need_refresh++;
         return;
     }
 
     if (key == SDLK_LEFTBRACKET) {
         if (channel > 1) channel--;
         snprintf(status_line, sizeof(status_line), "Channel: %d", channel);
+        need_refresh++;
         return;
     }
     if (key == SDLK_RIGHTBRACKET) {
         if (channel < 16) channel++;
         snprintf(status_line, sizeof(status_line), "Channel: %d", channel);
+        need_refresh++;
         return;
     }
 
@@ -266,13 +384,13 @@ void CUI_CcConsole::update(void) {
             int rc2 = zt_ccizer_save_learn_sidecar(&g_loaded);
             if (rc1 == 0 && rc2 == 0) {
                 snprintf(status_line, sizeof(status_line),
-                         "Saved %s.cc-view + %s.cc-midi.",
-                         g_loaded.basename, g_loaded.basename);
+                         "Saved %s.cc-view + .cc-midi.", g_loaded.basename);
             } else {
                 snprintf(status_line, sizeof(status_line),
                          "Failed to save sidecar (view=%d learn=%d).", rc1, rc2);
             }
         }
+        need_refresh++;
         return;
     }
 
@@ -280,15 +398,18 @@ void CUI_CcConsole::update(void) {
     if (focus == 0) {
         if (key == SDLK_UP) {
             if (file_cur > 0) file_cur--;
+            need_refresh++;
             return;
         }
         if (key == SDLK_DOWN) {
             if (file_cur + 1 < num_files) file_cur++;
+            need_refresh++;
             return;
         }
         if (key == SDLK_RETURN) {
             load_selected();
             focus = 1;
+            need_refresh++;
             return;
         }
         return;
@@ -300,64 +421,70 @@ void CUI_CcConsole::update(void) {
 
     if (key == SDLK_UP) {
         if (slot_cur > 0) slot_cur--;
+        need_refresh++;
         return;
     }
     if (key == SDLK_DOWN) {
         if (slot_cur + 1 < g_loaded.num_slots) slot_cur++;
+        need_refresh++;
         return;
     }
     if (key == SDLK_LEFT || key == SDLK_RIGHT) {
-        int sign  = (key == SDLK_LEFT) ? -1 : 1;
-        int step  = 1;
+        int sign = (key == SDLK_LEFT) ? -1 : 1;
+        int step = 1;
         if (kstate & KS_SHIFT) step = 8;
         if (kstate & KS_CTRL)  step = 16;
-        int maxv  = (s->cc == ZT_CCIZER_PB_MARKER) ? 16383 : 127;
-        int v     = (int)s->value + sign * step;
+        int maxv = slot_max(s);
+        int v = (int)s->value + sign * step;
         if (v < 0) v = 0; if (v > maxv) v = maxv;
         s->value = (unsigned short)v;
+        if (slot_cur < ZT_CCIZER_MAX_SLOTS) {
+            sliders[slot_cur]->value = v;
+            last_values[slot_cur] = v;
+        }
         send_slot(s, channel);
         snprintf(status_line, sizeof(status_line),
                  "%s = %d  (ch %d)", s->name, v, channel);
+        need_refresh++;
         return;
     }
     if (key == SDLK_BACKSPACE || key == SDLK_DELETE) {
-        s->value = (s->cc == ZT_CCIZER_PB_MARKER) ? 8192 : 0;
+        s->value = (unsigned short)slot_default(s);
+        if (slot_cur < ZT_CCIZER_MAX_SLOTS) {
+            sliders[slot_cur]->value = s->value;
+            last_values[slot_cur] = s->value;
+        }
         send_slot(s, channel);
         snprintf(status_line, sizeof(status_line),
                  "%s reset to %d", s->name, (int)s->value);
-        return;
-    }
-    if (key == SDLK_V) {
-        s->view = (s->view == ZT_CCIZER_VIEW_KNOB)
-                     ? ZT_CCIZER_VIEW_SLIDER
-                     : ZT_CCIZER_VIEW_KNOB;
-        snprintf(status_line, sizeof(status_line),
-                 "%s view = %s  (Ctrl+S to save)",
-                 s->name,
-                 s->view == ZT_CCIZER_VIEW_KNOB ? "knob" : "slider");
+        need_refresh++;
         return;
     }
     if (key == SDLK_L) {
-        // Toggle MIDI Learn for the focused slot. While learning, the
-        // next incoming CC/PB binds to slot_cur (handled in the MIDI-in
-        // pump above).
         learning = !learning;
         if (learning) {
             midiInQueue.clear();
             snprintf(status_line, sizeof(status_line),
-                     "LEARN: send a knob/CC/pitchbend for slot %d (%s)  ESC/L cancel",
+                     "LEARN: send a CC/PB for slot %d (%s)  ESC/L cancel",
                      slot_cur + 1, s->name);
         } else {
             snprintf(status_line, sizeof(status_line), "Learn cancelled.");
         }
+        need_refresh++;
+        return;
+    }
+    if (key == SDLK_U) {
+        s->learn_status = 0;
+        s->learn_data1  = 0;
+        snprintf(status_line, sizeof(status_line),
+                 "Unbound learn for slot %d  (Ctrl+S to save)", slot_cur + 1);
+        need_refresh++;
         return;
     }
     if (key == SDLK_B) {
-        // Assign the currently-loaded file as the bank for the current
-        // instrument (Shift+B clears it). Persisted in the .zt file via
-        // the CCBN chunk on next save.
         if (cur_inst < 0 || cur_inst >= MAX_INSTS || !song->instruments[cur_inst]) {
             snprintf(status_line, sizeof(status_line), "No current instrument.");
+            need_refresh++;
             return;
         }
         if (kstate & KS_SHIFT) {
@@ -365,6 +492,7 @@ void CUI_CcConsole::update(void) {
             file_changed++;
             snprintf(status_line, sizeof(status_line),
                      "Cleared CCizer bank for inst %d.", cur_inst);
+            need_refresh++;
             return;
         }
         if (loaded) {
@@ -381,21 +509,14 @@ void CUI_CcConsole::update(void) {
             snprintf(status_line, sizeof(status_line),
                      "Load a file first (Enter on Files pane).");
         }
+        need_refresh++;
         return;
     }
-    if (key == SDLK_U && loaded && slot_cur < g_loaded.num_slots) {
-        // Unbind learn for focused slot.
-        s->learn_status = 0;
-        s->learn_data1  = 0;
-        snprintf(status_line, sizeof(status_line),
-                 "Unbound learn for slot %d  (Ctrl+S to save)", slot_cur + 1);
-        return;
-    }
-    // SPACE re-fires the current value (useful for testing wiring).
     if (key == SDLK_SPACE) {
         send_slot(s, channel);
         snprintf(status_line, sizeof(status_line),
                  "Sent %s = %d (ch %d)", s->name, (int)s->value, channel);
+        need_refresh++;
         return;
     }
 }
@@ -404,41 +525,34 @@ void CUI_CcConsole::update(void) {
 void CUI_CcConsole::draw(Drawable *S) {
     if (S->lock() != 0) return;
 
-    int total_rows = INTERNAL_RESOLUTION_Y / CHARACTER_SIZE_Y;
+    int total_rows    = INTERNAL_RESOLUTION_Y / CHARACTER_SIZE_Y;
     int grid_max_rows = total_rows - CC_GRID_Y - CC_SPACE_BOTTOM - 2;
     if (grid_max_rows < 4) grid_max_rows = 4;
-    int file_max_rows = grid_max_rows;
 
     S->fillRect(col(1), row(CC_BASE_Y - 1),
                 INTERNAL_RESOLUTION_X - 2,
                 row(CC_GRID_Y + grid_max_rows + 2),
                 COLORS.Background);
 
-    char title[128];
+    char title[160];
     snprintf(title, sizeof(title),
              "CC Console (Shift+F3)  ch %d%s",
-             channel, loaded ? "" : " — no file loaded");
+             channel, learning ? "  [LEARN]" : "");
     printtitle(PAGE_TITLE_ROW_Y, title, COLORS.Text, COLORS.Background, S);
 
-    // ----- File list pane -----
+    // ----- File list pane (left) -----
     print(col(CC_FILE_X), row(CC_FILE_Y - 1),
           "Files", focus == 0 ? COLORS.Brighttext : COLORS.Text, S);
     if (folder[0]) {
         char fbuf[256];
         snprintf(fbuf, sizeof(fbuf), "(%s)", folder);
-        print(col(CC_FILE_X), row(CC_FILE_Y + file_max_rows),
+        print(col(CC_FILE_X), row(CC_FILE_Y + grid_max_rows),
               fbuf, COLORS.Lowlight, S);
-    } else {
-        print(col(CC_FILE_X), row(CC_FILE_Y + file_max_rows),
-              "(set ccizer_folder in zt.conf or place files in ./ccizer)",
-              COLORS.Lowlight, S);
     }
-
     if (file_cur < file_top) file_top = file_cur;
-    if (file_cur >= file_top + file_max_rows)
-        file_top = file_cur - file_max_rows + 1;
-
-    for (int i = 0; i < file_max_rows && file_top + i < num_files; i++) {
+    if (file_cur >= file_top + grid_max_rows)
+        file_top = file_cur - grid_max_rows + 1;
+    for (int i = 0; i < grid_max_rows && file_top + i < num_files; i++) {
         int idx = file_top + i;
         TColor fg = (idx == file_cur)
                         ? (focus == 0 ? COLORS.Brighttext : COLORS.Text)
@@ -447,7 +561,7 @@ void CUI_CcConsole::draw(Drawable *S) {
                         ? COLORS.SelectedBGLow
                         : COLORS.Background;
         char line[64];
-        snprintf(line, sizeof(line), "%c %-22.22s",
+        snprintf(line, sizeof(line), "%c %-24.24s",
                  (idx == file_cur) ? '>' : ' ', files[idx]);
         printBG(col(CC_FILE_X), row(CC_FILE_Y + i), line, fg, bg, S);
     }
@@ -456,10 +570,13 @@ void CUI_CcConsole::draw(Drawable *S) {
               "(empty folder)", COLORS.Lowlight, S);
     }
 
-    // ----- Slot grid pane -----
+    // ----- Slot grid pane (right) -----
     print(col(CC_GRID_X), row(CC_GRID_Y - 1),
-          "Slot CC#  Name              View          Value  Learn",
-          focus == 1 ? COLORS.Brighttext : COLORS.Text, S);
+          "Slot CC#  Name", focus == 1 ? COLORS.Brighttext : COLORS.Text, S);
+    print(col(CC_SLIDER_X), row(CC_GRID_Y - 1),
+          "Slider           Val", focus == 1 ? COLORS.Brighttext : COLORS.Text, S);
+    print(col(CC_LEARN_COL), row(CC_GRID_Y - 1),
+          "Learn", focus == 1 ? COLORS.Brighttext : COLORS.Text, S);
 
     if (!loaded) {
         print(col(CC_GRID_X), row(CC_GRID_Y),
@@ -470,29 +587,13 @@ void CUI_CcConsole::draw(Drawable *S) {
               "No slots in this file.",
               COLORS.Lowlight, S);
     } else {
-        if (slot_cur < slot_top) slot_top = slot_cur;
-        if (slot_cur >= slot_top + grid_max_rows)
-            slot_top = slot_cur - grid_max_rows + 1;
-
-        for (int i = 0; i < grid_max_rows && slot_top + i < g_loaded.num_slots; i++) {
-            int idx = slot_top + i;
+        for (int row_i = 0; row_i < grid_max_rows && slot_top + row_i < g_loaded.num_slots; row_i++) {
+            int idx = slot_top + row_i;
             ZtCcizerSlot *s = &g_loaded.slots[idx];
 
             char cc_lbl[8];
             if (s->cc == ZT_CCIZER_PB_MARKER) snprintf(cc_lbl, sizeof(cc_lbl), "PB");
             else                              snprintf(cc_lbl, sizeof(cc_lbl), "%d", (int)s->cc);
-
-            char view_str[16];
-            int  maxv = (s->cc == ZT_CCIZER_PB_MARKER) ? 16383 : 127;
-            if (s->view == ZT_CCIZER_VIEW_KNOB) {
-                char knob[8];
-                render_knob(knob, sizeof(knob), s->value, maxv);
-                snprintf(view_str, sizeof(view_str), "knob %s", knob);
-            } else {
-                char bar[CC_BAR_W + 4];
-                render_bar(bar, sizeof(bar), s->value, maxv);
-                snprintf(view_str, sizeof(view_str), "%s", bar);
-            }
 
             char learn_str[16];
             if (s->learn_status == 0) {
@@ -504,12 +605,6 @@ void CUI_CcConsole::draw(Drawable *S) {
                 snprintf(learn_str, sizeof(learn_str), "%02X %02X",
                          s->learn_status, s->learn_data1);
             }
-            char line[200];
-            snprintf(line, sizeof(line),
-                     "%c %3d  %-3s  %-16.16s %-13s %5d  %-6s",
-                     (idx == slot_cur) ? '>' : ' ',
-                     idx + 1, cc_lbl, s->name, view_str, (int)s->value,
-                     learn_str);
 
             TColor fg = (idx == slot_cur)
                             ? (focus == 1 ? COLORS.Brighttext : COLORS.Text)
@@ -517,13 +612,28 @@ void CUI_CcConsole::draw(Drawable *S) {
             TColor bg = (idx == slot_cur && focus == 1)
                             ? COLORS.SelectedBGLow
                             : COLORS.Background;
-            printBG(col(CC_GRID_X), row(CC_GRID_Y + i), line, fg, bg, S);
+            char prefix[16];
+            snprintf(prefix, sizeof(prefix), "%c%4d  %-3s  ",
+                     (idx == slot_cur) ? '>' : ' ', idx + 1, cc_lbl);
+            printBG(col(CC_SLOT_COL), row(CC_GRID_Y + row_i), prefix, fg, bg, S);
+
+            char name_buf[20];
+            snprintf(name_buf, sizeof(name_buf), "%-17.17s", s->name);
+            printBG(col(CC_NAME_COL), row(CC_GRID_Y + row_i), name_buf, fg, bg, S);
+
+            // The ValueSlider widget itself is drawn by UI->draw(S).
+
+            print(col(CC_LEARN_COL), row(CC_GRID_Y + row_i),
+                  learn_str, COLORS.Text, S);
         }
     }
 
     // ----- Status line -----
     print(col(2), row(CC_GRID_Y + grid_max_rows + 1),
           status_line, COLORS.Lowlight, S);
+
+    // Slider widgets paint here.
+    UI->draw(S);
 
     S->unlock();
 }

--- a/src/CUI_Page.h
+++ b/src/CUI_Page.h
@@ -545,8 +545,13 @@ class CUI_SysExLibrarian : public CUI_Page {
 };
 
 // CC Console (Shift+F3). Loads CCizer-format `.txt` files from the
-// configured ccizer_folder; each slot is shown as a slider or knob and
-// sends MIDI CC out to the current MIDI Out device when tweaked.
+// configured ccizer_folder. Each slot has a real ValueSlider widget
+// that's mouse-clickable AND keyboard-adjustable; tweaking fires MIDI
+// CC (or 14-bit Pitchbend for "PB" slots) out to the current MIDI Out
+// device. Up/Dn navigate slot_cur through the slot list, scrolling the
+// visible window; the slider widgets are repositioned per-frame to
+// match scroll state, and off-screen sliders get xsize=0 which
+// disables their mouse / keyboard / draw paths.
 class CUI_CcConsole : public CUI_Page {
     public:
         int focus;          // 0 = file list, 1 = slot grid
@@ -562,6 +567,12 @@ class CUI_CcConsole : public CUI_Page {
         int  num_files;
         char files[256][256];
 
+        // One ValueSlider per max-slot; positioned per-frame based on
+        // slot_top + visible window. Off-screen sliders get xsize=0.
+        ValueSlider *sliders[128];          // ZT_CCIZER_MAX_SLOTS
+        int          last_values[128];      // last seen value to detect changes
+        int          last_visible_count;    // for repaint optimization
+
         CUI_CcConsole();
 
         void enter(void);
@@ -572,10 +583,15 @@ class CUI_CcConsole : public CUI_Page {
         void rescan_folder(void);
         void load_selected(void);
         // Look up `bn` (basename, e.g. "microfreak.txt") in the current
-        // ccizer folder and load it. Used by the Pattern Editor to
-        // auto-route the CC Console to the focused instrument's bank
-        // when cur_inst changes. No-op if `bn` is empty or not found.
+        // ccizer folder and load it.
         void load_by_basename(const char *bn);
+
+        // Reposition the slider widget pool: visible slots get x/y/xsize/
+        // min/max/value, off-screen slots get xsize=0.
+        void position_sliders(int grid_max_rows);
+        // After UI->update() reports widget activity, copy any user-driven
+        // value changes back to slots and fire send_slot for each.
+        void absorb_slider_changes(void);
 };
 
 // Unified Shortcuts & MIDI Mappings page. cursor_y picks an action;

--- a/src/CUI_SysExLibrarian.cpp
+++ b/src/CUI_SysExLibrarian.cpp
@@ -283,6 +283,7 @@ void CUI_SysExLibrarian::drain_recv(void) {
 
         // Refresh the file list so the new file shows up immediately.
         rescan_folder();
+        need_refresh++;
     }
 }
 
@@ -292,6 +293,7 @@ void CUI_SysExLibrarian::enter(void) {
     snprintf(status_line, sizeof(status_line),
              "Up/Dn pick file | Enter or S send | R rescan | C clear log | ESC exit");
     Keys.flush();
+    need_refresh++;
 }
 
 void CUI_SysExLibrarian::leave(void) {
@@ -310,25 +312,30 @@ void CUI_SysExLibrarian::update(void) {
     }
     if (key == SDLK_UP) {
         if (file_cur > 0) file_cur--;
+        need_refresh++;
         return;
     }
     if (key == SDLK_DOWN) {
         if (file_cur + 1 < num_files) file_cur++;
+        need_refresh++;
         return;
     }
     if (key == SDLK_RETURN || key == SDLK_S) {
         send_selected();
+        need_refresh++;
         return;
     }
     if (key == SDLK_R) {
         rescan_folder();
         snprintf(status_line, sizeof(status_line),
                  "Rescanned: %d file(s) in %s", num_files, folder);
+        need_refresh++;
         return;
     }
     if (key == SDLK_C) {
         recent_count = 0;
         snprintf(status_line, sizeof(status_line), "Recent log cleared.");
+        need_refresh++;
         return;
     }
 }


### PR DESCRIPTION
## Two related bugs from the same v1 shortcut

The CC Console (Shift+F3) shipped with two bugs you correctly called out:

1. **The "sliders" were ASCII art (`[#####----]`), not clickable widgets.** A user looking at the screenshot has no way to know they can't click them — they just don't respond.
2. **Arrow keys "stopped updating the interface".** `main.cpp` gates `ActivePage->draw()` on `need_refresh != 0`; CC Console v1 had **zero** `need_refresh++` calls in any key handler. State changed in memory but the screen never repainted.

Both came from the same shortcut: rendering a fake page with `printBG` instead of wiring real widgets and the page-update protocol.

## What this PR does

### Real `ValueSlider` widgets per slot

- Pool of 128 (`ZT_CCIZER_MAX_SLOTS`) `ValueSlider` widgets pre-allocated in the constructor, registered with `UI->add_element`, tab-stops disabled so Tab/Up/Down stay page-owned.
- New `position_sliders(grid_max_rows)` runs every frame: visible slots get `x/y/xsize/min/max/value` bound to their backing slot; off-screen sliders get `xsize=0` which `ValueSlider::update/draw/mouseupdate` all early-out on.
- **Click anywhere on a slider's bar** to set value to that position (`ValueSlider::mouseupdate`'s built-in behavior). Drag to scrub. New `absorb_slider_changes()` reads each slider's `changed` flag after `UI->update()` and fires `send_slot` for every motion.
- Keyboard Lt/Rt still adjusts `slot_cur`'s slider directly and keeps the widget in sync.
- Drops the broken text-knob render and the `V` toggle (purely cosmetic with real widgets). `.cc-view` sidecar still loaded/saved for forward compat.

### `need_refresh++` on every key handler

- Every `if (key == ...)` in the CC Console's `update()` ends with `need_refresh++` before `return`.
- `enter()` bumps `need_refresh` so the first frame after page switch always paints.
- The MIDI-in pump bumps per message.
- `load_selected()` bumps.
- **Same fix applied to `CUI_SysExLibrarian`** (same bug shape).

### Project rule, written down

- New top-level **"INVARIANT: every page key handler must `need_refresh++`"** section in `CLAUDE.md`.
- Mirrored block in `.claude/skills/ztrackerprime/SKILL.md` so future AI sessions pick it up.
- Both files now also call out the **"no ASCII-art widgets"** rule — interactive elements must be real `UserInterfaceElement`s registered with `UI->add_element`. No `printBG` placeholders for clickable surfaces.

### Audit doc

`docs/plans/audit-ccizer-sysex-2026-04-30.md` — fresh-eyes brittleness audit of PRs #78-#84 with severity-ranked findings (H1..H4 real bugs, M5..M10 edge cases, L11..L16 brittle patterns, P17..P19 process). Rolling them out in follow-up PRs.

## Test plan

- [x] Builds clean on macOS arm64
- [x] `ctest --output-on-failure` — all 8 suites still pass
- [ ] Manual: Shift+F3 → arrow Up/Dn moves file selection (was frozen pre-fix)
- [ ] Manual: Tab to slot grid, arrow Up/Dn navigates slots, screen updates per press
- [ ] Manual: **mouse-click on a slider's bar** sets its value to click position; synth receives the matching CC
- [ ] Manual: drag slider — synth receives continuous CC stream
- [ ] Manual: Lt/Rt on a focused slot moves the slider visually AND sends CC
- [ ] Manual: Sysex Librarian (Shift+F5) Up/Dn now updates selection on every press

🤖 Generated with [Claude Code](https://claude.com/claude-code)
