### PR TITLE
Windows SysEx: poll MHDR_DONE before unprepare (audit H1)

### DIFF
--- a/src/winmm_compat.h
+++ b/src/winmm_compat.h
@@ -14,8 +14,18 @@
 
 // SysEx send (Windows / WinMM). bytes must include 0xF0 prefix and 0xF7
 // terminator. Wraps midiOutLongMsg with the required MIDIHDR prepare /
-// unprepare dance. Synchronous: blocks until WinMM accepts the buffer
-// (typical OS-level call; not "blocks until receiver consumed it").
+// unprepare dance.
+//
+// The driver returns from midiOutLongMsg as soon as it queues the buffer
+// for transmission, NOT after the bytes are actually on the wire. Calling
+// midiOutUnprepareHeader before MHDR_DONE is set returns
+// MIDIERR_STILLPLAYING and leaves the driver still owning the buffer --
+// subsequent midiOutLongMsg calls then error with the same code because
+// the previous "in flight" buffer is still on the queue. We poll
+// MHDR_DONE with a short Sleep loop before unprepare so the call is
+// genuinely synchronous from the caller's perspective. Cap the poll loop
+// at ~5 seconds (a 4 KB SysEx at MIDI's 31250 baud takes ~1 second; 5 s
+// covers patch banks up to ~16 KB with margin).
 static inline MMRESULT zt_midi_out_sysex(HMIDIOUT h, const unsigned char *bytes, int len) {
     if (!h || !bytes || len <= 0) return MMSYSERR_ERROR;
     MIDIHDR hdr;
@@ -27,6 +37,20 @@ static inline MMRESULT zt_midi_out_sysex(HMIDIOUT h, const unsigned char *bytes,
         return MMSYSERR_ERROR;
     }
     MMRESULT r = midiOutLongMsg(h, &hdr, sizeof(hdr));
+    if (r == MMSYSERR_NOERROR) {
+        DWORD waited_ms = 0;
+        while ((hdr.dwFlags & MHDR_DONE) == 0 && waited_ms < 5000) {
+            Sleep(1);
+            waited_ms++;
+        }
+        if ((hdr.dwFlags & MHDR_DONE) == 0) {
+            // Driver never marked it done. Reset the device to free the
+            // buffer rather than leak it. Unprepare may still fail; that's
+            // fine -- the buffer is the caller's stack frame, freed when
+            // we return.
+            midiOutReset(h);
+        }
+    }
     midiOutUnprepareHeader(h, &hdr, sizeof(hdr));
     return r;
 }


### PR DESCRIPTION
## Audit fix: H1

Standalone PR off `master`. Fixes audit item H1 from `docs/plans/audit-ccizer-sysex-2026-04-30.md`.

## The bug

Windows / WinMM `midiOutLongMsg` returns as soon as the driver queues the buffer, **not** after the bytes are on the wire. `zt_midi_out_sysex` was calling `midiOutUnprepareHeader` immediately after — per MS docs that returns `MIDIERR_STILLPLAYING` and leaves the driver still owning the buffer. The next call to `midiOutLongMsg` errors with the same code because the previous in-flight header is still queued.

**Symptom:** first SysEx might land. Second and onward silently fail. Worse on synths with slow consume rates.

## Fix

Poll `(hdr.dwFlags & MHDR_DONE)` with `Sleep(1)` until set, capped at 5 seconds. On timeout, call `midiOutReset()` to free the buffer rather than leak it.

The poll loop blocks the calling thread for the dump duration — that's the right tradeoff for the **SysEx Librarian send path**. The **playback-thread Z-effect dispatch** is a separate concern handled by audit H3 (cache `.syx` bytes at song-load so the playback thread never hits cold I/O on the critical path) — that lands in a separate follow-up PR.

## Test plan

- [x] Builds clean on macOS arm64 (no Windows code touched on macOS path)
- [x] `ctest --output-on-failure` — 8/8 still pass
- [ ] Manual on Windows: send 2+ SysEx files in a row from Shift+F5 — both should land (the original bug had the second silently fail)
- [ ] Manual on Windows: send a large SysEx (~16 KB), confirm complete transmission

🤖 Generated with [Claude Code](https://claude.com/claude-code)
