### PR TITLE
Audit M6 + M7: macOS SysEx heap-alloc + recv_seq survives restart

### DIFF
--- a/src/CUI_SysExLibrarian.cpp
+++ b/src/CUI_SysExLibrarian.cpp
@@ -289,9 +289,30 @@ void CUI_SysExLibrarian::drain_recv(void) {
 void CUI_SysExLibrarian::enter(void) {
     cur_state = STATE_SYSEX_LIB;
     rescan_folder();
+    // Seed recv_seq past any existing `recv_<TS>_NNN.syx` files so a
+    // capture in the same wall-clock second after a restart doesn't
+    // clobber a previous file. Scans the rescanned `files[]` array,
+    // parses the trailing _NNN, takes max+1. Audit M7.
+    int max_seq = -1;
+    for (int i = 0; i < num_files; i++) {
+        const char *fn = files[i];
+        if (strncmp(fn, "recv_", 5) != 0) continue;
+        // Find the LAST `_NNN.syx`. Walk backwards from the dot.
+        size_t flen = strlen(fn);
+        if (flen < 9) continue;
+        if (strcmp(fn + flen - 4, ".syx") != 0) continue;
+        // Locate the underscore before the NNN -- 7 chars before .syx
+        // ("_NNN.syx" = 8 chars, but NNN width is %03d so >= 3 digits).
+        const char *us = strrchr(fn, '_');
+        if (!us) continue;
+        int n = atoi(us + 1);
+        if (n > max_seq) max_seq = n;
+    }
+    if (max_seq + 1 > recv_seq) recv_seq = max_seq + 1;
     snprintf(status_line, sizeof(status_line),
              "Up/Dn pick file | Enter or S send | R rescan | C clear log | ESC exit");
     Keys.flush();
+    need_refresh++;
 }
 
 void CUI_SysExLibrarian::leave(void) {

--- a/src/winmm_compat.h
+++ b/src/winmm_compat.h
@@ -574,17 +574,24 @@ static inline MMRESULT midiOutReset(HMIDIOUT) { return MMSYSERR_NOERROR; }
 // multiple packets — for SysEx longer than 256 bytes we segment into
 // multiple packets within one packet list (timestamp 0 = "now"). The
 // receiver reassembles by spec since 0xF0..0xF7 framing is preserved.
+//
+// The packet-list buffer is heap-allocated (audit M6). Previously it
+// was a 17 KB stack array which is fine on default-stack threads
+// (>= 512 KB) but risky on small-stack worker threads. Caller is
+// responsible for splitting > 256 KB dumps; we cap at 256 KB to bound
+// the malloc.
 static inline MMRESULT zt_midi_out_sysex(HMIDIOUT h, const unsigned char *bytes, int len) {
     zt_coremidi_out_handle *ctx = (zt_coremidi_out_handle *)h;
     if (!ctx || !ctx->out_port || !bytes || len <= 0) return MMSYSERR_ERROR;
 
-    // Build the packet list with per-packet chunks of up to 256 bytes.
-    // sizeof storage: header + N * (packet hdr + 256 bytes) — pick a
-    // generous static buffer that handles patches up to ~16 KB; for
-    // larger dumps the caller can split.
-    enum { MAX_SYSEX = 16384, CHUNK = 256 };
+    enum { MAX_SYSEX = 256 * 1024, CHUNK = 256 };
     if (len > MAX_SYSEX) return MMSYSERR_ERROR;
-    Byte buf[MAX_SYSEX + 1024];
+    // Storage: packet-list overhead is per-packet (header + payload).
+    // Reserve len + (len/CHUNK + 1)*32 for headers, plus base list
+    // header. 64 KB safety margin covers any version-skew metadata.
+    size_t buf_sz = (size_t)len + ((size_t)len / CHUNK + 1) * 64 + 1024;
+    Byte *buf = (Byte *)malloc(buf_sz);
+    if (!buf) return MMSYSERR_ERROR;
     MIDIPacketList *pl = (MIDIPacketList *)buf;
     MIDIPacket *pkt = MIDIPacketListInit(pl);
 
@@ -592,15 +599,16 @@ static inline MMRESULT zt_midi_out_sysex(HMIDIOUT h, const unsigned char *bytes,
     while (offset < len) {
         int chunk = len - offset;
         if (chunk > CHUNK) chunk = CHUNK;
-        pkt = MIDIPacketListAdd(pl, sizeof(buf), pkt, 0,
+        pkt = MIDIPacketListAdd(pl, buf_sz, pkt, 0,
                                 (UInt16)chunk, bytes + offset);
-        if (!pkt) return MMSYSERR_ERROR;
+        if (!pkt) { free(buf); return MMSYSERR_ERROR; }
         offset += chunk;
     }
 
     // First attempt with the cached endpoint.
     if (ctx->endpoint != 0) {
         if (MIDISend(ctx->out_port, ctx->endpoint, pl) == noErr) {
+            free(buf);
             return MMSYSERR_NOERROR;
         }
     }
@@ -611,10 +619,12 @@ static inline MMRESULT zt_midi_out_sysex(HMIDIOUT h, const unsigned char *bytes,
         if (fresh != 0 && fresh != ctx->endpoint) {
             ctx->endpoint = fresh;
             if (MIDISend(ctx->out_port, ctx->endpoint, pl) == noErr) {
+                free(buf);
                 return MMSYSERR_NOERROR;
             }
         }
     }
+    free(buf);
     return MMSYSERR_ERROR;
 }
 


### PR DESCRIPTION
## Audit fix: M6 + M7

Two small audit items off `master`. Both standalone — no deps on other open PRs.

### M6 — macOS SysEx send heap-allocates the packet list buffer
Was a 17 KB stack array (`Byte buf[MAX_SYSEX + 1024]` with MAX_SYSEX=16 KB). Default thread stack is 512 KB so OK today, but fragile if anyone later spawns a worker thread with a smaller stack. Now heap-allocated, cap raised from 16 KB → 256 KB to cover real-world Integra-7 / Kronos patch banks. Caller splits anything bigger.

### M7 — SysEx Librarian seeds `recv_seq` past existing files
`recv_seq` was reset to 0 in the ctor, so a capture in the same wall-clock second after a restart could clobber a previous `recv_<TS>_000.syx`. `enter()` now scans `files[]` for `recv_*_NNN.syx`, parses the trailing NNN, and seeds `recv_seq = max+1`.

## Test plan
- [x] Builds clean on macOS arm64
- [x] `ctest --output-on-failure` — 8/8 still pass
- [ ] Manual: capture a SysEx, restart zt, capture another in the same second — second filename has higher NNN
- [ ] Manual: send a 200 KB patch dump on macOS — completes (was capped at 16 KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
