### PR TITLE
Shift+F2: ESC cancels capture/learn instead of opening main menu

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1345,6 +1345,7 @@ void global_keys(Drawable *S)
             && cur_state != STATE_ABOUT
             && cur_state != STATE_LUA_CONSOLE
             && cur_state != STATE_SONG_MESSAGE
+            && cur_state != STATE_KEYBINDINGS
             && UIP_MainMenu) {
             (void)Keys.getkey();
             popup_window(UIP_MainMenu);


### PR DESCRIPTION
## Bug

In the Shortcuts & MIDI Mappings page (Shift+F2), pressing **Enter** on a Keyboard or MIDI cell starts a capture/learn session and shows:

> Press new key combo for '...' (ESC to cancel)
> LEARN: send MIDI for ... (ESC to cancel)

Pressing **ESC** opens the Main Menu instead of cancelling. Capture mode silently stays active. The status hint is a lie.

## Cause

`global_keys()` in `src/main.cpp:1341-1353` intercepts ESC and pops up the main menu unless `cur_state` is in an exclusion list. The list covers `STATE_HELP / ABOUT / LUA_CONSOLE / SONG_MESSAGE` — `STATE_KEYBINDINGS` was missing. The page's own ESC handler (`CUI_KeyBindings.cpp:132-137`) is correct, but never fires because the global handler eats ESC first.

## Fix

Add `cur_state != STATE_KEYBINDINGS` to the exclusion list. One line.

The page handles ESC correctly on its own:
- If capturing/learning -> cancel
- Otherwise -> switch_page(UIP_Patterneditor) (same destination as the menu's "Pattern Editor" entry, so no regression for users who hit ESC outside capture mode)

## Test plan

- Builds clean on macOS arm64
- ctest --output-on-failure -- 8/8 pass
- Manual: Shift+F2, Enter on a row, ESC -> status reads "Capture cancelled.", page stays
- Manual: Shift+F2, Enter on a MIDI cell, ESC -> status reads "Learn cancelled.", page stays
- Manual: Shift+F2 idle, ESC -> page exits to Pattern Editor (existing fallback)

Co-Authored-By: Claude Opus 4.7 (1M context)
