### PR TITLE
Skill: codify list-pane idiom + 8 page-construction invariants

### DIFF
--- a/.claude/skills/ztrackerprime/SKILL.md
+++ b/.claude/skills/ztrackerprime/SKILL.md
@@ -136,19 +136,32 @@ Seven-PR feature stack landed end of April 2026 wiring Paketti-style CCizer bank
 - `tests/test_sysex_inq.cpp` — ~25 checks: empty / push-pop / FIFO / overflow / buffer-too-small / invalid input.
 - `tests/test_sysex_macro.cpp` — ~20 checks: predicate, path resolution, valid/malformed/oversized/missing file read.
 
-## INVARIANT: pages must bump `need_refresh` and use real widgets
+## INVARIANTS for any new or modified page
 
-`main.cpp` gates `ActivePage->draw()` on `need_refresh != 0`. Two non-negotiable rules for any page added or modified:
+These rules are non-negotiable. Every one of them was learned the hard way during the CCizer + SysEx + CC-Console work (PRs #78–#84, #95, #96). Don't re-learn them.
 
-1. **Every key handler that mutates visible state ends with `need_refresh++;`** (and so does `enter()`, and any background pump that changes what should be on screen). Forget this and arrow keys silently mutate state without a redraw — the page looks frozen until some other path bumps the flag.
+1. **Every key handler that mutates visible state ends with `need_refresh++;`** — including `enter()` and any background pump that changes what should be on screen. Forget this and arrow keys silently mutate state without a redraw; the page looks frozen until some other path bumps the flag. `main.cpp` gates `ActivePage->draw()` on `need_refresh != 0`.
 
-2. **Interactive elements are real widgets, not ASCII art.** If the user is supposed to click a slider, the slider is a `ValueSlider` registered with `UI->add_element`, drawn by `UI->draw(S)`, mutated by `ValueSlider::mouseupdate`, and absorbed by the page's `update()` reading the `changed` flag. **Never** ship `printBG` text bars as a stand-in for "we'll iterate later" — they are visually identical in a screenshot but completely unclickable, and the user finds out by trying. The pool-of-N pattern (pre-allocate `N` widgets in the ctor, position the visible window per-frame, hide off-screen ones with `xsize=0`) is the idiom for variable-count slot grids; `CUI_CcConsole.cpp::position_sliders` is a worked example.
+2. **Interactive elements are real widgets, not ASCII art.** A slider is a `ValueSlider` registered with `UI->add_element`, drawn by `UI->draw(S)`, mutated by `ValueSlider::mouseupdate`, and absorbed by the page's `update()` reading the `changed` flag. **Never** ship `printBG` text bars as a stand-in for "we'll iterate later" — visually identical in one screenshot, completely unclickable to the user. The pool-of-N pattern (pre-allocate `N` widgets in the ctor, position the visible window per-frame, hide off-screen ones with `xsize=0`) is the idiom for variable-count grids; `CUI_CcConsole.cpp::position_sliders` is the canonical worked example.
 
-Both rules were learnt the hard way during the CCizer / SysEx work — see PR #78 (text-bars regression) and the followup that wired real `ValueSlider`s + `need_refresh` bumps. Treat them as load-bearing for any new page.
+3. **Any list pane uses a real `ListBox` subclass.** Never hand-draw `> filename` with a custom highlight. F11 SkinSelector / F4 / Shift+F4 / Shift+F3 all share one pattern, documented in [`references/list-pane-idiom.md`](references/list-pane-idiom.md). New list-driven pages copy that pattern verbatim — anonymous-namespace `: ListBox` subclass, `is_sorted=true`, `use_checks=true`, `use_key_select=true`, Space-applies override on `update()`, never call `ListBox::OnSelect` from the subclass.
+
+4. **Per-frame `need_redraw = 1` on always-visible widgets.** `UserInterface::draw` skips elements with `need_redraw == 0`. If any sibling fires `needaclear++` the whole element area is cleared and stale-need_redraw widgets vanish. The page's `update()` (or `position_sliders()`) stamps `need_redraw = 1` on the listbox, the grid-focus stub, and every visible pool widget, every frame. Worked example: PR #96.
+
+5. **Each visual column is its own `print` / `printBG`** anchored to its own `col(CC_*_COL)` constant. Never pack adjacent columns into one packed `snprintf` — adjacent fields will smash into each other (`PBPitchbend`, `LeUani`) the first time a string is longer than expected. Headers and data rows reference the *same constants* so they stay aligned.
+
+6. **Tab cycles `UI->cur_element` between IDs.** Page-level "focus" is *derived* from `cur_element` each frame, not stored. Use a 1x1 `UserInterfaceElement` stub (e.g. `MmGridFocus`, `CcSlotGridFocus`) for non-list panes that need Tab focus.
+
+7. **Pages whose own ESC handler matters add their `STATE_*` to the global ESC exclusion list** in `main.cpp::global_keys` (the list with `STATE_HELP / ABOUT / LUA_CONSOLE / SONG_MESSAGE / KEYBINDINGS`). Otherwise the global handler eats ESC first and the page's "ESC cancels capture" hint is a lie. PR #95 was a one-line fix for `STATE_KEYBINDINGS`.
+
+8. **Visual verification before claiming done.** Build green + ctest green ≠ "the page works." Launch the binary, send the F-key, capture the window, drive each user-visible key (arrow, Tab, Space, Enter, Esc, click), diff the screenshots. If you cannot do that step, say so explicitly — don't ship hope.
+
+The full list-pane construction pattern (with code) lives in [`references/list-pane-idiom.md`](references/list-pane-idiom.md). Read it before adding any new page that has a list, a grid, or both.
 
 ## Deeper references (load on demand)
 
-- [`references/foot-guns.md`](references/foot-guns.md) — recurring bug classes: ListBox mousestate fragility, widget-upstream rule, user-reported-inputs-as-ground-truth.
+- [`references/list-pane-idiom.md`](references/list-pane-idiom.md) — **REQUIRED READING before adding any list / grid page.** The full pattern: `ListBox` subclass + grid-focus stub + Tab cycling + per-frame `need_redraw=1` + column-per-print + global-ESC exclusion + visual-verification gate.
+- [`references/foot-guns.md`](references/foot-guns.md) — recurring bug classes: ListBox mousestate fragility, widget-upstream rule, vanishing-sibling on `needaclear`, user-reported-inputs-as-ground-truth.
 - [`references/keyjazz-slot.md`](references/keyjazz-slot.md) — Shift+F4 keyjazz UIE pattern.
 - [`references/test-harness.md`](references/test-harness.md) — sdl_stub / module_stub / `ZT_TEST_NO_SDL`.
 - [`references/cli-flags.md`](references/cli-flags.md) — `zt_parse_cli` + Copy Relaunch Command.

--- a/.claude/skills/ztrackerprime/references/foot-guns.md
+++ b/.claude/skills/ztrackerprime/references/foot-guns.md
@@ -50,6 +50,26 @@ When the user reports a specific input ("I pressed Ctrl-S"), that IS what they p
 
 Generalisation of the ListBox case. Resetting state at the *top* of an event handler — before the switch dispatches the current event — clobbers the very state the dispatch is supposed to see. If a state field gates downstream behavior (`act++`, `dirty=1`, an event-consumed flag), reset it AFTER the switch, not before. When in doubt: trace one event end-to-end, note which fields it depends on at each step, and only clear those fields *after* the last reader.
 
+## Vanishing sibling widgets on `needaclear`
+
+`UserInterface::draw` skips elements whose `need_redraw == 0`. Most widgets self-arm `need_redraw=1` only on internal change — value tweak, mouse drag, focus change. So once a widget has rendered, it sits dormant.
+
+The trap: when *any* sibling fires `needaclear++` (the numeric-input popup return path in `ValueSlider::update` is one example), `UI::draw` clears row 12+ wholesale and only `need_redraw==1` elements repaint that frame. Every dormant widget silently disappears until *its* next state change.
+
+Symptoms:
+
+- Drag one slider → all the others vanish.
+- Click into a list → the slot grid disappears.
+- Tab into a different pane → the previously-active pane vanishes.
+
+**Fix idiom:** any page with always-visible widgets stamps `need_redraw = 1` on each one *every frame* in the page's `update()` (or `position_sliders()` for pool widgets). Cheap (an int write) and eliminates the bug class. Worked example: `CUI_CcConsole::position_sliders` + `update()` after PR #96.
+
+## Global ESC handler shadows page ESC
+
+`main.cpp::global_keys` intercepts ESC and pops up the Main Menu when `cur_state` isn't in an exclusion list (`STATE_HELP`, `STATE_ABOUT`, `STATE_LUA_CONSOLE`, `STATE_SONG_MESSAGE`, `STATE_KEYBINDINGS`, ...). It runs *before* the active page's `update()`, so any page whose own ESC handler does something user-visible — "Capture cancelled.", "Learn cancelled.", "Discard unsaved?" — is shadowed by default. The page's ESC code only fires when ESC happens to be in a context the global handler doesn't claim.
+
+When you add a new page whose ESC has dedicated meaning, **add its `STATE_*` to that exclusion list in the same PR**. PR #95 was a one-line fix for `STATE_KEYBINDINGS` after the user reported pressing ESC and getting the menu instead of "Capture cancelled."
+
 ## Saturated ring buffer with `head == tail`
 
 `KeyBuffer` originally checked `head != tail` to gate read/peek. Fails when the buffer is exactly full (head wraps back to tail). Fix: gate on `cursize > 0`. If you write a fixed-capacity ring with two pointers, also keep a count.

--- a/.claude/skills/ztrackerprime/references/list-pane-idiom.md
+++ b/.claude/skills/ztrackerprime/references/list-pane-idiom.md
@@ -1,0 +1,227 @@
+# List-pane idiom (file list, preset list, device list, ...)
+
+Any pane that shows a vertical list of named items the user picks from must use the **real `ListBox` widget**, never a hand-drawn `> filename` text marker. Worked examples in master:
+
+- `SkinSelector` (F11 Sysconfig — skin picker)
+- `MmPresetSelector` / `ArPresetSelector` (F4 / Shift+F4 — preset picker)
+- `MidiOutDeviceSelector` / `MidiInDeviceOpener` (F12 — device picker)
+- `CcFileSelector` (Shift+F3 — CCizer file picker; PR #96)
+
+The pattern is identical across all of them. New list-driven pages (and rewrites of old ones) MUST follow it.
+
+## Why a real `ListBox`, not a hand-drawn list
+
+A hand-drawn `printBG` list looks visually similar in a single screenshot but breaks in every other dimension: no mouse click, no typeahead, no scroll, no consistent highlight color, no tab-focus integration, no widget-upstream bug fixes. The user **will** find it by trying to click. (CC Console shipped this way at #78 and got rebuilt at #96 — don't repeat that.)
+
+## The pattern (5 pieces)
+
+### 1. The list widget — `ListBox` subclass
+
+In an anonymous namespace at the top of the page's `.cpp`:
+
+```cpp
+namespace {
+class FooListSelector : public ListBox {
+public:
+    FooListSelector() {
+        empty_message       = "(none found)";
+        is_sorted           = true;        // alphabetical, matches F11
+        use_checks          = true;        // checkmark on the active item
+        use_key_select      = true;        // typeahead jump
+        wrap_focus_at_edges = false;       // clamp at edges (no Tab spillover)
+        frame               = 1;
+    }
+    void OnChange()       override {}
+    void OnSelectChange() override {}
+    int update() override {
+        // Mirror F4/Shift+F4: Space applies, just like Enter.
+        // Base ListBox::update only treats Enter as a select trigger.
+        KBKey k = Keys.checkkey();
+        if (k == SDLK_SPACE) {
+            Keys.getkey();
+            LBNode *p = getNode(cur_sel + y_start);
+            if (p) OnSelect(p);
+            need_refresh++;
+            need_redraw++;
+            return 0;
+        }
+        return ListBox::update();
+    }
+    void OnSelect(LBNode *selected) override {
+        if (!selected || !g_self_for_listbox) return;
+        g_self_for_listbox->load_selected();
+        selectNone();
+        selected->checked = true;
+        // NEVER call ListBox::OnSelect from a subclass — see foot-guns.md
+        // (it sets mousestate=0 mid-click, freezes the UI on every BUTTON_UP).
+    }
+};
+} // namespace
+```
+
+The `g_self_for_listbox` static back-pointer is set in the page constructor: `g_self_for_listbox = this;`. Use it because anonymous-namespace types can't carry a typed page pointer without leaking the class name into the header.
+
+### 2. The non-list pane — 1x1 stub UIE
+
+For the *other* pane on the page (slot grid, edit form, etc.) — the part that doesn't have a real widget but needs Tab focus — add a 1x1 stub UIE so Tab can claim "we are on the grid":
+
+```cpp
+class FooGridFocus : public UserInterfaceElement {
+public:
+    FooGridFocus() { xsize = 1; ysize = 1; }
+    int update() override { return 0; }
+    void draw(Drawable *S, int active) override { (void)S; (void)active; }
+};
+```
+
+The page's `update()` then routes arrow keys / letter keys to its own logic when `UI->cur_element == FOO_GRIDFOCUS_ID`. (See `MmGridFocus` on F4, `CcSlotGridFocus` on Shift+F3.)
+
+### 3. Constructor — register both, plus any pool widgets
+
+```cpp
+#define FOO_LIST_ID        50
+#define FOO_GRIDFOCUS_ID   51
+#define FOO_SLIDER_ID_BASE 100
+
+CUI_FooPage::CUI_FooPage() {
+    UI = new UserInterface;
+    g_self_for_listbox = this;
+
+    auto *fs = new FooListSelector;
+    fs->x = LIST_X; fs->y = LIST_Y;
+    fs->xsize = LIST_W; fs->ysize = 16;   // ysize = LAST visible row index
+    UI->add_element(fs, FOO_LIST_ID);
+    list_selector = fs;
+
+    auto *gf = new FooGridFocus;
+    gf->x = GRID_X; gf->y = GRID_Y;
+    UI->add_element(gf, FOO_GRIDFOCUS_ID);
+    grid_focus = gf;
+
+    // ...slider/widget pool registration...
+}
+```
+
+`list_selector` and `grid_focus` are members typed as `ListBox *` and `UserInterfaceElement *` in the page's header. Forward-declare both at the top of `CUI_Page.h`.
+
+### 4. Per-frame `update()` — derive focus, stamp `need_redraw`, resize
+
+```cpp
+void CUI_FooPage::update(void) {
+    int total_rows    = INTERNAL_RESOLUTION_Y / CHARACTER_SIZE_Y;
+    int grid_max_rows = total_rows - GRID_Y - SPACE_BOTTOM - 2;
+    if (grid_max_rows < 4) grid_max_rows = 4;
+
+    // Resize listbox to current viewport. ysize is LAST row index.
+    if (list_selector) {
+        list_selector->ysize = grid_max_rows - 2;
+        list_selector->need_redraw = 1;          // see "vanishing-sibling" below
+    }
+    if (grid_focus) grid_focus->need_redraw = 1;
+
+    // Page-level focus is DERIVED from cur_element; never stored.
+    int focus_now = (UI->cur_element == FOO_LIST_ID) ? 0 : 1;
+
+    // ...position_sliders() etc, each visible widget gets need_redraw = 1...
+
+    UI->update();
+    // ...absorb widget changes...
+
+    if (!Keys.size()) return;
+    KBMod kstate = Keys.getstate();
+    KBKey key   = Keys.getkey();
+
+    if (key == SDLK_TAB) {
+        UI->cur_element = (UI->cur_element == FOO_LIST_ID)
+                              ? FOO_GRIDFOCUS_ID
+                              : FOO_LIST_ID;
+        need_refresh++;
+        return;
+    }
+    if (focus_now == 0) {
+        // Up/Down/Enter/Space/typeahead are handled by the listbox's
+        // own update() via UI->update() above. Nothing to do here.
+        return;
+    }
+    // ...slot-grid / edit-form key handlers...
+}
+```
+
+### 5. `enter()` — rebuild items, land focus on the list
+
+```cpp
+void CUI_FooPage::enter(void) {
+    cur_state = STATE_FOOPAGE;
+    rescan_folder();        // populates files[] and calls rebuild_list_items()
+    UI->cur_element = FOO_LIST_ID;
+    Keys.flush();
+    need_refresh++;
+    UI->enter();
+}
+
+void CUI_FooPage::rebuild_list_items(void) {
+    if (!list_selector) return;
+    list_selector->clear();
+    for (int i = 0; i < num_files; i++) {
+        LBNode *p = list_selector->insertItem(files[i]);
+        if (p && active_basename_matches(files[i])) p->checked = true;
+    }
+    list_selector->setCursor(active_index_in_files);
+}
+```
+
+## Vanishing-sibling fix (must read)
+
+`UserInterface::draw` skips elements with `need_redraw == 0`:
+
+```cpp
+while (e) {
+    if (e->need_redraw) {
+        e->draw(S, (e->ID == cur_element));
+        e->need_redraw = 0;
+    }
+    e = e->next;
+}
+```
+
+If anything in the same UI fires `needaclear++` (e.g. the numeric-input popup return path in `ValueSlider::update`), the *whole* element area is cleared — and any sibling widget that didn't independently set `need_redraw=1` that frame **vanishes** until the next time *it* changes.
+
+The fix is the convention shown in #4 above: any per-frame `update()` that has a "always-visible widget" (the listbox, a stub UIE, a pool of sliders) **stamps `need_redraw = 1` on each one every frame**. This is cheap (it's just an int write; `draw()` is still gated by widget-internal flags) and it eliminates the entire bug class. Worked example: `CUI_CcConsole.cpp::position_sliders` + `update()` in PR #96.
+
+You'll know you forgot it because: drag one slider → the others disappear; click into the list → the slot grid disappears; Tab → the previously-focused pane vanishes.
+
+## Layout: column-per-print, never one packed sprintf
+
+When laying out a row of (slot, CC#, name, slider, value, learn) — paint each column as its own `printBG` at its own `col(CC_*_COL)`. **Never** pack adjacent columns into one `snprintf("%-Ns%-Ms ...", ...)`. Two reasons:
+
+1. **Overlap.** A 12-char packed prefix at `col=30` + a name field starting at `col=39` will smash the prefix tail into the name (`PBPitchbend`, `1 Mod Wheel`, `43Filter Cutoff`).
+2. **Header drift.** Headers and data rows must use the *same column constants*. If the data row is one packed string but the headers are separate prints, they go out of sync the first time you adjust a column.
+
+Headers should also be one print per column, anchored to the same constants:
+
+```cpp
+TColor hdr_fg = (focus_now == 1) ? COLORS.Brighttext : COLORS.Text;
+print(col(CC_SLOT_COL),  row(GRID_Y - 1), "Slot",   hdr_fg, S);
+print(col(CC_CC_COL),    row(GRID_Y - 1), "CC#",    hdr_fg, S);
+print(col(CC_NAME_COL),  row(GRID_Y - 1), "Name",   hdr_fg, S);
+print(col(CC_SLIDER_X),  row(GRID_Y - 1), "Slider", hdr_fg, S);
+print(col(CC_LEARN_COL), row(GRID_Y - 1), "Learn",  hdr_fg, S);
+```
+
+Don't tack value-display words like `"Val"` onto the slider header — it overlaps the next column ("LeUani" in the wild). The slider widget shows its own value to the right of its bar.
+
+## Global ESC handler exclusion
+
+`global_keys()` in `main.cpp` intercepts `ESC` and pops up the Main Menu unless `cur_state` is in an exclusion list. **Any new page whose own ESC handler matters (cancel-capture, cancel-learn, in-progress dialog, etc.) must add its `STATE_*` to that exclusion list** — otherwise the page's ESC handler is shadowed and only fires when the menu is dismissed. PR #95 was a one-line fix for `STATE_KEYBINDINGS`; the same trap applies to any new page.
+
+## Don't claim "feature works" from `tests pass` + a screencap
+
+CI green and 8/8 ctest passing tells you the page compiles and the unit-tested pure modules behave. They do not tell you the page renders, that Tab toggles focus, that the listbox repopulates, or that the slider stays painted under drag. Before declaring a list-driven page done:
+
+1. Launch the binary yourself (`open .../zt.app`).
+2. Send F-key to switch to the page (osascript `key code` works for F-keys; AppleScript permissions need to be enabled for your terminal).
+3. Capture by `CGWindowListCopyWindowInfo` window-id (`scripts/zt-screenshot.sh` post-#94 does this — use it).
+4. Send each key the user is supposed to press: arrow Down, Tab, Space, Enter, Esc.
+5. Diff the screenshots. Verify the listbox highlight moves, the slider stays painted, the value updates, ESC actually exits.
+
+If the page passes its tests but you can't visually verify it, say "I can't verify the UI; I checked X, Y, Z but not the actual page render." Don't ship hopes — the user finds out by trying.


### PR DESCRIPTION
## Summary

Codifies the lessons from PRs #95 (Shift+F2 ESC shadow) and #96 (CC Console rebuild) into the project-local `.claude/skills/ztrackerprime/` skill so future contributors and AI agents nail page construction on the first try, not the third.

## What was wrong

The skill already had a "real widgets, not ASCII art" rule and a `need_refresh` rule, but the CC Console rebuild surfaced six more invariants the original CC Console (PRs #78-#84) silently violated:

- Hand-drew the file list with a `> filename` text marker instead of using `ListBox`
- Stored `focus` as a page member instead of deriving from `UI->cur_element`
- Skipped `need_redraw=1` per-frame stamping → siblings vanished when one slider was dragged
- Packed Slot/CC#/Name into one `snprintf` → "PBPitchbend", "1 Mod Wheel", "43Filter Cutoff"
- Slider header included "Val" → overlapped the Learn header as "LeUani"
- Forgot to add `STATE_KEYBINDINGS` to the global ESC exclusion list (separate but same family)
- Shipped without launching the binary and pressing keys

Every one of these existed in master because the skill didn't say "don't do that," and they all got found by the user, not by tests.

## What this PR adds

### `references/list-pane-idiom.md` (new, ~150 lines)

The full pattern in code form: anonymous-namespace `: ListBox` subclass + 1x1 `UserInterfaceElement` grid stub + ID constants + constructor wiring + per-frame `update()` + `enter()` rebuild. Cross-references the four worked examples already in master: SkinSelector (F11), MmPresetSelector (F4), ArPresetSelector (Shift+F4), CcFileSelector (Shift+F3). Includes the column-per-print rule, the global-ESC-exclusion rule, and the visual-verification gate.

This file is what the next contributor reads before adding any list-driven page. Copy the pattern, fill in the names, ship.

### `SKILL.md` "INVARIANTS" expanded from 2 to 8 rules

Each rule is one sentence + the why + a worked-example pointer. The list now covers everything that needed to go right for the CC Console rebuild to land cleanly: real widgets, real ListBox, per-frame need_redraw, column-per-print, derived focus, ESC exclusion, visual verification.

### `references/foot-guns.md` adds two

- **Vanishing sibling widgets on `needaclear`** — `UI::draw` skips `need_redraw==0` elements; any sibling firing `needaclear++` wipes them until they self-arm. Worked example: PR #96.
- **Global ESC handler shadows page ESC** — `main.cpp::global_keys` runs first; pages with their own ESC handler must add their `STATE_*` to the exclusion list. Worked example: PR #95.

## Test plan

Doc-only PR — no code, no build impact, no CI gate to satisfy. Verify by reading.

The next PR that adds a list-and-grid page is the real test. If it lands on the first review pass without any of the six rules being broken, the skill update did its job.
