### PR TITLE
Headless + script CLI: run zt windowless, drive from a file, dump PNGs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ set(ZT_SOURCES
   src/sysex_inq.cpp
   src/CUI_SysExLibrarian.cpp
   src/sysex_macro.cpp
+  src/zt_headless.cpp
 )
 
 if(WIN32)

--- a/docs/headless-script.md
+++ b/docs/headless-script.md
@@ -1,0 +1,100 @@
+# Headless / scripted operation
+
+`zt --headless --script <file>` runs zTracker without opening a window, driving the running app from a script and dumping PNG screenshots on demand. Designed for CI smoke tests, headless layout regression, and AI-driven page verification — anywhere "spin up a real GUI session, press keys, take a screenshot" is too heavy.
+
+## Quick start
+
+```sh
+mkdir -p /tmp/zt-headless-shots
+./build/Program/zt --headless --script tests/scripts/smoke.txt
+ls /tmp/zt-headless-shots/
+```
+
+The bundled `tests/scripts/smoke.txt` walks F1 / F2 / F4 / Shift+F2 / Shift+F3 / Shift+F4 / Shift+F5 / F11 / F12 and dumps one PNG per page. About 2 seconds end-to-end on a modern machine.
+
+## How it works
+
+`--headless` sets `SDL_HINT_VIDEO_DRIVER=dummy` (and the audio equivalent) before `SDL_Init`, so SDL never opens a window. The renderer + texture pipeline still runs against an in-memory `SDL_Surface` with format `ARGB8888` — exactly the surface the pages already paint into. The script driver dumps that surface to PNG via libpng's simplified API (the surface's BGRA byte order matches `PNG_FORMAT_BGRA`, so no per-pixel byte-swap is needed).
+
+`--script <file>` makes the main loop call `zt_headless_pump()` once per frame *before* `SDL_PollEvent`. The pump reads commands from the script file and either injects them into the global `Keys` ring, defers them via `SDL_GetTicks`, dumps a PNG, or sets `do_exit`. From the page's perspective the synthetic keys are indistinguishable from real ones — `Keys.insert(SDLK_F2, SDL_KMOD_NONE)` is exactly what the real `keyhandler()` would have done after `SDL_EVENT_KEY_DOWN`.
+
+`--headless` and `--script` are independent. `--headless` alone still requires some external way to feed input (typically not useful, but lets you check that the binary boots clean under the dummy driver). `--script` without `--headless` is also valid — it drives a normal windowed session, useful when you want to *see* the script run.
+
+## Script syntax
+
+Each line is one command. Blank lines and lines starting with `#` are ignored.
+
+| Command | Effect |
+|---|---|
+| `key <chord>` | Inject a synthetic keystroke. Chord syntax: zero or more `shift+ / ctrl+ / alt+ / meta+ / cmd+` modifier prefixes followed by the key name. |
+| `wait <ms>` | Defer the next command for `<ms>` milliseconds (capped at 60000). The main loop keeps running, so the page renders and processes the last batch of keys before the next fires. |
+| `shot <path>` | Dump the current screen surface to a PNG at `<path>`. Parent directory must already exist. |
+| `quit` (or `exit`) | Set `do_exit`. The main loop tears down on its next pass. CI scripts should always end with this. |
+
+### Key names
+
+Lowercase, case-insensitive in practice:
+
+- Function keys: `f1` … `f12`
+- Navigation: `up`, `down`, `left`, `right`, `home`, `end`, `pageup`, `pagedown`
+- Editing: `tab`, `return` (alias `enter`), `space`, `esc` (alias `escape`), `backspace`, `delete`
+- Punctuation: `grave` (the `§` key on Finnish ISO), `leftbracket`, `rightbracket`
+- Letters: `a` … `z` (single character)
+- Digits: `0` … `9` (single character)
+
+### Modifier prefixes
+
+`shift+`, `ctrl+`, `alt+`, `meta+` (alias `cmd+`). Combine with `+`:
+
+```
+key shift+f3            # CC Console
+key ctrl+s              # save
+key ctrl+shift+r        # reset all keyboard bindings to defaults
+key meta+q              # macOS Cmd+Q (Pattern Editor: Transpose-Up)
+```
+
+## Worked example
+
+A self-contained smoke test that verifies the CC Console renders, accepts arrow Down, loads a file with Space, and exits clean:
+
+```
+# Boot.
+wait 200
+
+# Open CC Console.
+key shift+f3
+wait 150
+shot /tmp/cc-1-empty.png
+
+# Move down two files, load with Space.
+key down
+wait 50
+key down
+wait 50
+key space
+wait 200
+shot /tmp/cc-2-loaded.png
+
+# Tab to the slot grid, arrow-Down twice, capture.
+key tab
+key down
+key down
+wait 100
+shot /tmp/cc-3-grid-down.png
+
+quit
+```
+
+`zt --headless --script that.txt` produces three PNGs and exits with status 0.
+
+## Limitations
+
+- **No mouse input.** The script driver currently injects keystrokes only. Click / drag would require synthesising `SDL_EVENT_MOUSE_*` events into the page's `mouse*handler` paths; possible but not yet wired. The major pages have full keyboard coverage.
+- **MIDI subsystem still initialises.** On macOS, `--headless` opens CoreMIDI as usual; you'll see whatever virtual ports the OS exposes. To suppress: drop the `MidiOut = new midiOut` call behind `if (!cli_args.headless)` in main. Not yet done because some scripts may want to drive `--midi-in <port>` headlessly.
+- **macOS dock icon.** The dummy driver still registers the process with the OS in a way that may briefly show in `Activity Monitor`. No window opens, no Dock icon, no menu bar. The process exits the moment the script's `quit` fires.
+
+## Future work
+
+- **Golden-image diff suite.** A new `tests/test_pages.cpp` could ship per-platform golden PNGs, run the smoke script, and pixel-diff. Linux CI would catch "I broke the CC Console layout" before review. Pixel tolerances per platform need empirical calibration first — that's a follow-up PR.
+- **Mouse synthesis.** `mouse_move <x> <y>`, `mouse_click <x> <y>` for drag-test coverage of widgets with click-only behaviour (slider drags, listbox click-to-focus).
+- **Status-bar capture.** A `status` command that dumps the current `status_line` text to stdout, so tests can assert "after Ctrl+S, status reads 'Saved …'" without pixel-diffing.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,6 +72,7 @@
 #include <vector>
 
 #include "zt.h"
+#include "zt_headless.h"
 #include "lua_engine.h"
 #include "keybindings.h"
 #include "save_key_dispatch.h"
@@ -3256,12 +3257,16 @@ static int zt_backend_set_video_mode(char *errstr)
 #ifdef __APPLE__
     // Free Cmd-Q from the auto-created NSApp menu so the Pattern Editor can
     // use it as Transpose-Up (KS_HAS_ALT treats Cmd as Alt). Quit reachable
-    // via Ctrl-Q / Ctrl-Alt-Q.
-    zt_macos_disable_cmd_q();
-    // Free Cmd-W from the Window menu's Close item so it reaches our
-    // keyhandler instead of dismissing the SDL window. Pattern Editor
-    // treats Cmd-W as Ctrl-W (clear unused volumes in selection).
-    zt_macos_disable_cmd_w();
+    // via Ctrl-Q / Ctrl-Alt-Q. Skipped under --headless because the dummy
+    // video driver doesn't create an NSApp menu in the first place; the
+    // disable call would touch a NULL menu and crash.
+    if (!zt_headless_active()) {
+        zt_macos_disable_cmd_q();
+        // Free Cmd-W from the Window menu's Close item so it reaches our
+        // keyhandler instead of dismissing the SDL window. Pattern Editor
+        // treats Cmd-W as Ctrl-W (clear unused volumes in selection).
+        zt_macos_disable_cmd_w();
+    }
 #endif
     zt_renderer = SDL_CreateRenderer(zt_main_window, NULL);
     if (!zt_renderer) {
@@ -3613,6 +3618,12 @@ struct ZtCliArgs {
     // --midi-clock is one source by definition; multiple master clocks
     // would fight each other.
     const char *midi_clock_port = NULL;
+    // --headless suppresses the visible window: SDL's `dummy` video
+    // driver runs the renderer/texture pipeline against an in-memory
+    // surface, which the script driver dumps via libpng. Pairs with
+    // --script to drive the running app to a chosen state and exit.
+    bool        headless        = false;
+    const char *script_path     = NULL;
 };
 
 static void zt_print_cli_help(const char *progname) {
@@ -3636,12 +3647,25 @@ static void zt_print_cli_help(const char *progname) {
         "                              chase: turns on midi_in_sync +\n"
         "                              midi_in_sync_chase_tempo so the song\n"
         "                              tempo follows incoming F8 clock.\n"
+        "      --headless              Run without opening a window (SDL's\n"
+        "                              dummy video driver). The renderer\n"
+        "                              still produces frames into an\n"
+        "                              in-memory surface, which --script\n"
+        "                              can dump as PNG. Use for CI smoke\n"
+        "                              tests, headless layout regression,\n"
+        "                              or AI-driven page verification.\n"
+        "      --script <file>         Drive the running app from a script.\n"
+        "                              Lines: 'key <chord>', 'wait <ms>',\n"
+        "                              'shot <png-path>', 'quit'. See\n"
+        "                              docs/headless-script.md for the full\n"
+        "                              command set.\n"
         "\n"
         "Examples:\n"
         "  %s mysong.zt\n"
         "  %s --midi-in \"IAC Driver Bus 1\"\n"
-        "  %s --midi-clock 0 mysong.zt\n",
-        progname, progname, progname, progname);
+        "  %s --midi-clock 0 mysong.zt\n"
+        "  %s --headless --script tests/scripts/smoke.txt\n",
+        progname, progname, progname, progname, progname);
 }
 
 // Strip leading '-' or '--' so we accept "-midi-in" or "--midi-in" --
@@ -3720,6 +3744,11 @@ static int zt_parse_cli(int argc, char *argv[], ZtCliArgs *out) {
         if (r < 0) return -1;
         if (r > 0) { out->midi_clock_port = value; continue; }
 
+        if (zt_cli_match_flag(a, "headless")) { out->headless = true; continue; }
+        r = zt_cli_match_flag_with_value(argc, argv, &i, "script", &value);
+        if (r < 0) return -1;
+        if (r > 0) { out->script_path = value; continue; }
+
         if (a[0] == '-') {
             fprintf(stderr, "zt: unknown flag '%s' (try --help)\n", a);
             return -1;
@@ -3769,6 +3798,19 @@ int main(int argc, char *argv[])
       zt_print_cli_help(base ? base + 1 : prog);
       return 0;
   }
+
+  // Headless mode: tell SDL to use the dummy video driver BEFORE SDL_Init
+  // so no window opens. The renderer + texture pipeline still works
+  // against an in-memory surface; the script driver dumps PNGs from it.
+  // SDL_HINT_VIDEO_DRIVER must be set before SDL_Init -- once a driver
+  // is initialised the hint is ignored.
+  if (cli_args.headless) {
+      SDL_SetHint(SDL_HINT_VIDEO_DRIVER, "dummy");
+      // Audio dummy too -- the desktop audio device is irrelevant in
+      // CI / headless self-test contexts and would just spam errors.
+      SDL_SetHint(SDL_HINT_AUDIO_DRIVER, "dummy");
+  }
+  zt_headless_init(cli_args.headless, cli_args.script_path);
 
   char *w;
   const char path_sep =
@@ -3925,6 +3967,12 @@ int main(int argc, char *argv[])
           zt_text_input_stop();
         }
       }
+
+      // Headless script driver runs once per frame BEFORE SDL_PollEvent.
+      // Injects synthetic keystrokes via Keys.insert(), times waits with
+      // SDL_GetTicks, dumps PNGs from `screen_buffer_surface`, and sets
+      // do_exit on `quit`. No-op when --headless / --script weren't set.
+      zt_headless_pump(screen_buffer_surface);
 
       SDL_Event e;
 

--- a/src/zt_headless.cpp
+++ b/src/zt_headless.cpp
@@ -1,0 +1,275 @@
+/*************************************************************************
+ *
+ * FILE  zt_headless.cpp
+ *
+ * Scripted, windowless operation. See zt_headless.h for the CLI surface.
+ *
+ ******/
+
+#include "zt_headless.h"
+
+#include <SDL.h>
+#include <png.h>
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "keybuffer.h"
+
+// Pulled from main.cpp -- the global key ring and the "user requested
+// quit" flag. We don't pull main.cpp's full surface in here; just the
+// two symbols the script driver needs to talk to.
+extern KeyBuffer Keys;
+extern int       do_exit;
+
+// ---------------------------------------------------------------------------
+// Module-local state.
+
+static bool        g_active           = false;
+static FILE       *g_script_fp        = NULL;
+static char        g_script_path[1024] = {0};
+static int         g_script_lineno    = 0;
+static bool        g_script_done      = false;
+
+// `wait` defers the next command by N milliseconds. We measure with
+// SDL_GetTicks so it tracks wall time, not frame count -- robust against
+// frame-rate changes.
+static Uint64      g_wait_until_ms    = 0;
+
+// ---------------------------------------------------------------------------
+// CLI plumbing.
+
+void zt_headless_init(bool active, const char *script_path) {
+    g_active = active;
+    if (script_path && *script_path) {
+        snprintf(g_script_path, sizeof(g_script_path), "%s", script_path);
+        g_script_fp = fopen(g_script_path, "r");
+        if (!g_script_fp) {
+            fprintf(stderr, "zt: --script: failed to open '%s': %s\n",
+                    g_script_path, strerror(errno));
+            // No script => behave as if `quit` was the first command, so
+            // a misconfigured CI run exits fast instead of hanging on a
+            // black window.
+            g_script_done = true;
+            do_exit = 1;
+        }
+    }
+}
+
+bool zt_headless_active(void) {
+    return g_active;
+}
+
+// ---------------------------------------------------------------------------
+// Key-name lookup. Maps the textual names we accept in `key <name>`
+// commands to SDL keysym constants. Modifier prefixes (`shift+`, `ctrl+`,
+// `alt+`, `meta+`) are stripped by the caller before we look up the bare
+// key name.
+
+struct KeyName { const char *name; KBKey key; };
+
+static const KeyName g_key_names[] = {
+    // Function keys.
+    {"f1", SDLK_F1}, {"f2", SDLK_F2}, {"f3", SDLK_F3}, {"f4", SDLK_F4},
+    {"f5", SDLK_F5}, {"f6", SDLK_F6}, {"f7", SDLK_F7}, {"f8", SDLK_F8},
+    {"f9", SDLK_F9}, {"f10", SDLK_F10}, {"f11", SDLK_F11}, {"f12", SDLK_F12},
+    // Navigation.
+    {"up", SDLK_UP}, {"down", SDLK_DOWN}, {"left", SDLK_LEFT}, {"right", SDLK_RIGHT},
+    {"home", SDLK_HOME}, {"end", SDLK_END},
+    {"pageup", SDLK_PAGEUP}, {"pagedown", SDLK_PAGEDOWN},
+    // Editing.
+    {"tab", SDLK_TAB}, {"return", SDLK_RETURN}, {"enter", SDLK_RETURN},
+    {"space", SDLK_SPACE}, {"esc", SDLK_ESCAPE}, {"escape", SDLK_ESCAPE},
+    {"backspace", SDLK_BACKSPACE}, {"delete", SDLK_DELETE},
+    // Punctuation that crops up in keybindings.
+    {"grave", SDLK_GRAVE},          // The § key on Finnish ISO.
+    {"leftbracket", SDLK_LEFTBRACKET}, {"rightbracket", SDLK_RIGHTBRACKET},
+    // Letters and digits resolved by direct lowercasing below.
+};
+
+static KBKey resolve_key_name(const char *name) {
+    if (!name || !*name) return 0;
+    // Single character: digit or letter -> SDLK_a .. SDLK_z / SDLK_0 ..
+    // SDLK_9. The SDLK_* values for ASCII letters/digits coincide with
+    // the lowercase ASCII codepoint, so we can return the byte directly.
+    if (name[1] == '\0') {
+        char c = (char)tolower((unsigned char)name[0]);
+        if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+            return (KBKey)c;
+        }
+    }
+    char buf[32];
+    size_t i = 0;
+    for (; name[i] && i + 1 < sizeof(buf); i++) {
+        buf[i] = (char)tolower((unsigned char)name[i]);
+    }
+    buf[i] = '\0';
+    for (size_t j = 0; j < sizeof(g_key_names)/sizeof(g_key_names[0]); j++) {
+        if (strcmp(buf, g_key_names[j].name) == 0) return g_key_names[j].key;
+    }
+    return 0;
+}
+
+// Parse a `[mods+]key` token. `mods` is one or more of shift/ctrl/alt/meta
+// joined by `+`. Returns 1 on success and writes *key_out / *mod_out.
+static int parse_keychord(const char *tok, KBKey *key_out, KBMod *mod_out) {
+    KBMod mods = SDL_KMOD_NONE;
+    char buf[64];
+    snprintf(buf, sizeof(buf), "%s", tok);
+    char *p = buf;
+    for (;;) {
+        char *plus = strchr(p, '+');
+        if (!plus) break;
+        *plus = '\0';
+        // Lowercase the modifier word in-place.
+        for (char *q = p; *q; q++) *q = (char)tolower((unsigned char)*q);
+        if      (!strcmp(p, "shift")) mods |= SDL_KMOD_SHIFT;
+        else if (!strcmp(p, "ctrl"))  mods |= SDL_KMOD_CTRL;
+        else if (!strcmp(p, "alt"))   mods |= SDL_KMOD_ALT;
+        else if (!strcmp(p, "meta") || !strcmp(p, "cmd")) mods |= SDL_KMOD_GUI;
+        else {
+            fprintf(stderr, "zt: --script: unknown modifier '%s' on line %d\n",
+                    p, g_script_lineno);
+            return 0;
+        }
+        p = plus + 1;
+    }
+    KBKey k = resolve_key_name(p);
+    if (!k) {
+        fprintf(stderr, "zt: --script: unknown key '%s' on line %d\n",
+                p, g_script_lineno);
+        return 0;
+    }
+    *key_out = k;
+    *mod_out = mods;
+    return 1;
+}
+
+// ---------------------------------------------------------------------------
+// PNG dump. SDL_PIXELFORMAT_ARGB8888 on little-endian is laid out in memory
+// as B,G,R,A bytes -- libpng's PNG_FORMAT_BGRA matches that exactly, so we
+// don't need a per-pixel byte-swap.
+
+int zt_headless_dump_png(SDL_Surface *surface, const char *path) {
+    if (!surface || !path || !*path) return 0;
+
+    SDL_LockSurface(surface);
+    int w = surface->w;
+    int h = surface->h;
+    int pitch = surface->pitch;
+    void *pixels = surface->pixels;
+
+    png_image img;
+    memset(&img, 0, sizeof(img));
+    img.version = PNG_IMAGE_VERSION;
+    img.width   = (png_uint_32)w;
+    img.height  = (png_uint_32)h;
+    img.format  = PNG_FORMAT_BGRA;     // matches little-endian ARGB8888.
+
+    int rc = png_image_write_to_file(&img, path,
+                                     0 /* convert_to_8bit */,
+                                     pixels, pitch,
+                                     NULL /* colormap */);
+    if (!rc) {
+        fprintf(stderr, "zt: --script: png write '%s' failed: %s\n",
+                path, img.message);
+    }
+    SDL_UnlockSurface(surface);
+    return rc;
+}
+
+// ---------------------------------------------------------------------------
+// Script driver.
+
+static void exec_command(SDL_Surface *frame_surface, const char *cmd, char *args) {
+    // `key <chord>`
+    if (!strcmp(cmd, "key")) {
+        // Trim leading whitespace.
+        while (*args && isspace((unsigned char)*args)) args++;
+        char *end = args + strlen(args);
+        while (end > args && isspace((unsigned char)end[-1])) *--end = '\0';
+        if (!*args) {
+            fprintf(stderr, "zt: --script: 'key' needs an argument on line %d\n",
+                    g_script_lineno);
+            return;
+        }
+        KBKey k = 0;
+        KBMod m = 0;
+        if (!parse_keychord(args, &k, &m)) return;
+        Keys.insert(k, m, 0, 0);
+        return;
+    }
+    // `wait <ms>`
+    if (!strcmp(cmd, "wait")) {
+        long ms = strtol(args, NULL, 10);
+        if (ms < 0) ms = 0;
+        if (ms > 60000) ms = 60000;     // 1 min hard cap (CI safety).
+        g_wait_until_ms = SDL_GetTicks() + (Uint64)ms;
+        return;
+    }
+    // `shot <path>`
+    if (!strcmp(cmd, "shot")) {
+        while (*args && isspace((unsigned char)*args)) args++;
+        char *end = args + strlen(args);
+        while (end > args && isspace((unsigned char)end[-1])) *--end = '\0';
+        if (!*args) {
+            fprintf(stderr, "zt: --script: 'shot' needs a path on line %d\n",
+                    g_script_lineno);
+            return;
+        }
+        zt_headless_dump_png(frame_surface, args);
+        return;
+    }
+    // `quit`
+    if (!strcmp(cmd, "quit") || !strcmp(cmd, "exit")) {
+        do_exit = 1;
+        g_script_done = true;
+        return;
+    }
+    fprintf(stderr, "zt: --script: unknown command '%s' on line %d\n",
+            cmd, g_script_lineno);
+}
+
+void zt_headless_pump(SDL_Surface *frame_surface) {
+    if (!g_active || g_script_done || !g_script_fp) return;
+    if (g_wait_until_ms && SDL_GetTicks() < g_wait_until_ms) return;
+    g_wait_until_ms = 0;
+
+    // Run commands until we either hit a `wait` (which sets g_wait_until_ms
+    // and returns next frame), the script ends, or a `quit` fires. This
+    // means a script of N immediate `key` commands fires them all in one
+    // pump call -- which is fine, the page sees them in queue order.
+    char line[1024];
+    while (fgets(line, sizeof(line), g_script_fp)) {
+        g_script_lineno++;
+        // Strip trailing newline + CR.
+        size_t len = strlen(line);
+        while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r')) {
+            line[--len] = '\0';
+        }
+        // Skip blanks and comments.
+        char *p = line;
+        while (*p && isspace((unsigned char)*p)) p++;
+        if (*p == '\0' || *p == '#') continue;
+        // Split into command + args.
+        char *args = p;
+        while (*args && !isspace((unsigned char)*args)) args++;
+        if (*args) { *args = '\0'; args++; }
+        // Lowercase the command word.
+        for (char *q = p; *q; q++) *q = (char)tolower((unsigned char)*q);
+
+        exec_command(frame_surface, p, args);
+
+        if (g_wait_until_ms || g_script_done) return;
+    }
+
+    // EOF: stop driving the loop. The main loop continues to render
+    // until something else (do_exit / SDL quit) ends it. CI scripts
+    // should always end with `quit`.
+    g_script_done = true;
+    fclose(g_script_fp);
+    g_script_fp = NULL;
+}

--- a/src/zt_headless.h
+++ b/src/zt_headless.h
@@ -1,0 +1,57 @@
+#ifndef _ZT_HEADLESS_H_
+#define _ZT_HEADLESS_H_
+
+// Headless / scripted operation. Two CLI flags drive this module:
+//
+//   --headless       Sets SDL_HINT_VIDEO_DRIVER=dummy before SDL_Init so no
+//                    window opens. The renderer + texture pipeline still
+//                    runs against the in-memory ARGB8888 surface, which we
+//                    can dump to PNG via libpng's simplified API.
+//
+//   --script <file>  Drives the running app from a script. Each line is
+//                    one command. Comments (#...) and blanks are ignored.
+//                    Commands:
+//                       key <name>           inject a synthetic keystroke
+//                                            (e.g.  key F2,
+//                                                   key shift+F3,
+//                                                   key ctrl+s,
+//                                                   key down, key tab,
+//                                                   key space, key return)
+//                       wait <ms>            sleep this thread for <ms>
+//                                            milliseconds (lets the page's
+//                                            update() / draw() run a few
+//                                            frames before the next key)
+//                       shot <path>          dump the current screen surface
+//                                            to a PNG at <path>
+//                       quit                 sets do_exit so the main loop
+//                                            tears down cleanly
+//
+// Together they let the dev (or CI) drive zt to any state, capture the
+// frame, diff it, and exit -- without ever opening a window.
+//
+// Designed to be called from main.cpp's render loop and from main(),
+// nothing more. No SDL types in this header so the keybuffer / module
+// unit tests don't have to drag SDL in just to compile against zt.h.
+
+struct SDL_Surface;
+
+// CLI flag plumbing. Set once from zt_parse_cli's caller in main().
+// `script_path` ownership stays with the caller (typically argv).
+void  zt_headless_init(bool active, const char *script_path);
+bool  zt_headless_active(void);
+
+// Pump the script forward by one frame: inject any keystrokes whose
+// scheduled time has elapsed, dump any pending PNG, advance until we hit
+// a `wait` or run out of commands. Called once per main-loop iteration
+// from main.cpp BEFORE the SDL_PollEvent block.
+//
+// `frame_surface` is the current screen surface (zt's `screen_buffer_surface`)
+// -- used by `shot` commands to dump the current frame.
+void  zt_headless_pump(SDL_Surface *frame_surface);
+
+// Dump an SDL ARGB8888 surface to a PNG. Returns 1 on success, 0 on failure.
+// Exposed so internal `shot` commands and any future test harness can share
+// the same writer.
+int   zt_headless_dump_png(SDL_Surface *frame_surface, const char *path);
+
+#endif

--- a/tests/scripts/smoke.txt
+++ b/tests/scripts/smoke.txt
@@ -1,0 +1,74 @@
+# Smoke script: visit each major page, dump a screenshot, exit.
+# Run with:  ./build/Program/zt --headless --script tests/scripts/smoke.txt
+# Output PNGs land in /tmp/zt-headless-shots/ -- create the dir first.
+#
+# Lines are: command [arg]
+#   key <chord>   inject a synthetic keystroke. Modifiers via `shift+`,
+#                 `ctrl+`, `alt+`, `meta+` (alias `cmd+`). Examples:
+#                   key F2
+#                   key shift+F3
+#                   key ctrl+s
+#                   key down
+#                   key tab
+#                   key space
+#                   key return
+#                   key esc
+#   wait <ms>     defer the next command for <ms> milliseconds. The main
+#                 loop keeps running so the page can render / process the
+#                 last batch of keys before the next one fires.
+#   shot <path>   dump the current screen surface to a PNG. The directory
+#                 must already exist.
+#   quit          set do_exit; the main loop tears down on its next pass.
+#
+# Comments (`#`) and blank lines are ignored.
+
+# Let the boot finish painting Pattern Editor.
+wait 200
+shot /tmp/zt-headless-shots/01-f2-pattern-editor.png
+
+# Help (F1).
+key f1
+wait 200
+shot /tmp/zt-headless-shots/02-f1-help.png
+
+# Pattern Editor (F2) -- back from Help.
+key f2
+wait 200
+shot /tmp/zt-headless-shots/03-f2-pattern-editor.png
+
+# MIDI Macro Editor (F4).
+key f4
+wait 200
+shot /tmp/zt-headless-shots/04-f4-midimacro.png
+
+# Arpeggio Editor (Shift+F4).
+key shift+f4
+wait 200
+shot /tmp/zt-headless-shots/05-shift-f4-arpeggio.png
+
+# Shortcuts & MIDI Mappings (Shift+F2).
+key shift+f2
+wait 200
+shot /tmp/zt-headless-shots/06-shift-f2-keybindings.png
+key esc
+wait 100
+
+# CC Console (Shift+F3).
+key shift+f3
+wait 200
+shot /tmp/zt-headless-shots/07-shift-f3-cc-console.png
+
+# SysEx Librarian (Shift+F5).
+key shift+f5
+wait 200
+shot /tmp/zt-headless-shots/08-shift-f5-sysex-librarian.png
+
+# Song Configuration (F11) and System Configuration (F12).
+key f11
+wait 200
+shot /tmp/zt-headless-shots/09-f11-songconfig.png
+key f12
+wait 200
+shot /tmp/zt-headless-shots/10-f12-sysconfig.png
+
+quit


### PR DESCRIPTION
## Summary

`zt` can now run without opening a window, take direction from a script file, and dump PNG screenshots on demand. Lets devs and CI verify layout/keyhandling end-to-end without an interactive desktop session — and lets AI contributors test their own changes without hijacking the user's keyboard via osascript.

## What's new

Two CLI flags:

- `--headless` — Sets `SDL_HINT_VIDEO_DRIVER=dummy` (and audio equivalent) before `SDL_Init` so no window opens. The renderer + texture pipeline still runs against an in-memory ARGB8888 surface, which the script driver dumps as PNG via libpng's simplified API (`PNG_FORMAT_BGRA` matches little-endian ARGB8888 byte order — no per-pixel swap).
- `--script <file>` — Drive the running app from a file. Lines are `key <chord>` / `wait <ms>` / `shot <png-path>` / `quit`. Comments (`#`) and blanks ignored. Modifier prefixes `shift+` / `ctrl+` / `alt+` / `meta+` (alias `cmd+`) supported.

## How it works

`zt_headless_pump()` runs once per main-loop iteration **before** `SDL_PollEvent` and calls `Keys.insert()` with synthetic `SDLK_*` values + `SDL_KMOD_*` modifiers — indistinguishable from real keystrokes from the page's perspective. Wait timing uses `SDL_GetTicks` so it tracks wall time, not frame count (robust against frame-rate jitter).

macOS `Cmd-Q` / `Cmd-W` disable calls are gated behind `!zt_headless_active()` because the dummy video driver doesn't construct an `NSApp` menu, and the disable calls would dereference NULL.

## Files

| File | Purpose |
|---|---|
| `src/zt_headless.{h,cpp}` | Module + script parser + PNG dump |
| `src/main.cpp` | CLI flags + SDL hint + per-frame pump |
| `CMakeLists.txt` | Add `zt_headless.cpp` to build |
| `tests/scripts/smoke.txt` | Walks F1/F2/F4/Shift+F2/Shift+F3/Shift+F4/Shift+F5/F11/F12, dumps a PNG per page, exits clean (~2 sec) |
| `docs/headless-script.md` | Command reference + worked example + limitations + future-work outline |

## Test plan

- [x] Builds clean on macOS arm64
- [x] `mkdir -p /tmp/zt-headless-shots && ./build/Program/zt --headless --script tests/scripts/smoke.txt` → exits with status 0, produces 10 PNGs, no window opens, no keystrokes hijack the user's desktop session
- [ ] Linux CI follow-up: same script can run as a CTest with the dummy driver; pixel-diff against committed golden PNGs lives in a separate PR once tolerances are calibrated per platform

## Future work (separate PRs)

- Mouse synthesis (`mouse_move <x> <y>`, `mouse_click <x> <y>`) for drag-test coverage of widgets with click-only behaviour
- `status` command that dumps the current `status_line` text to stdout for assertion-style tests
- Golden-image diff suite (per-platform PNGs in `tests/golden/`, pixel-diff in CTest)
