### PR TITLE
F12 Sysconfig: fix CCizer/SysEx folder fields (vertical overlap + width)

### DIFF
--- a/src/CUI_Sysconfig.cpp
+++ b/src/CUI_Sysconfig.cpp
@@ -456,20 +456,24 @@ CUI_Sysconfig::CUI_Sysconfig(void) {
         ti->frame  = 1;
         ti->x      = 4 + 16;                          // matches left-column controls
         ti->y      = base_y + 7;                      // gap row 6 between Record Velocity (+5) and this
-        ti->xsize  = 56;                              // ends ~col 76, matches MIDI Out list right edge
+        ti->xsize  = 27;                              // ends col 47 -- one col gap before Skin Selection at col 49
         ti->length = MAX_PATH;
         ti->str    = (unsigned char*)zt_config_globals.ccizer_folder;
 
-        // SysEx folder picker (audit L13). Same row layout, one row
-        // below the CCizer folder so the two paths sit together as a
-        // "MIDI data folders" group. Empty value falls back through
-        // CUI_SysExLibrarian::resolve_folder()'s default cascade.
+        // SysEx folder picker (audit L13). Two rows below the CCizer
+        // folder, not one -- frame=1 TextInputs draw a top border at
+        // y-1 and a bottom border at y+1, so a 1-row gap makes the
+        // two frames overwrite each other's content rows (the bug
+        // that rendered both fields as solid yellow stripes). With
+        // y = base_y + 9, CCizer's bottom frame at +8 and SysEx's
+        // top frame at +8 share a single row and the content rows
+        // (+7 / +9) stay clean.
         ti = new TextInput;
         UI->add_element(ti, tabindex++);
         ti->frame  = 1;
         ti->x      = 4 + 16;
-        ti->y      = base_y + 8;
-        ti->xsize  = 56;
+        ti->y      = base_y + 9;
+        ti->xsize  = 27;                              // matches CCizer field width
         ti->length = MAX_PATH;
         ti->str    = (unsigned char*)zt_config_globals.syx_folder;
 }
@@ -533,7 +537,7 @@ void CUI_Sysconfig::draw(Drawable *S) {
         print(row(4),col(TRACKS_ROW_Y+7),"    Full Screen",COLORS.Text,S);
         print(row(4),col(TRACKS_ROW_Y+8),"Record Velocity",COLORS.Text,S);
         print(row(4),col(TRACKS_ROW_Y+10),"  CCizer Folder",COLORS.Text,S);
-        print(row(4),col(TRACKS_ROW_Y+11),"  SysEx Folder", COLORS.Text,S);
+        print(row(4),col(TRACKS_ROW_Y+12),"  SysEx Folder", COLORS.Text,S);
 #ifndef DISABLED_CONFIGURATION_VALUES
         print(row(4),col(TRACKS_ROW_Y+13),"     Key Repeat",COLORS.Text,S);
         print(row(4),col(TRACKS_ROW_Y+15),"       Key Wait",COLORS.Text,S);


### PR DESCRIPTION
## Bugs

The CCizer Folder and SysEx Folder TextInputs on F12 (added by PR #88's audit cluster) had two layout problems:

1. **Vertical overlap.** `frame=1` TextInput draws a top border at `y-1` and a bottom border at `y+1`, so each framed input occupies 3 character rows. The two fields were placed at `base_y+7` and `base_y+8` — only one row apart — so the frames cannibalized each other's content rows. Both fields rendered as solid yellow horizontal stripes.
2. **Horizontal overlap.** `xsize = 56` (cols 20-76) ran the inputs all the way across the page and *underneath* the Skin Selection ListBox at cols 49-76. The bottom rows of the skin list were obscured by the CCizer field.

Both visible in PR #98's smoke output and freshly captured via the headless harness.

## Fixes

| Field | Before | After |
|---|---|---|
| CCizer y | `base_y + 7` | `base_y + 7` (unchanged) |
| SysEx y | `base_y + 8` | `base_y + 9` |
| CCizer xsize | 56 | 27 |
| SysEx xsize | 56 | 27 |
| CCizer label row | `TRACKS_ROW_Y + 10` | unchanged |
| SysEx label row | `TRACKS_ROW_Y + 11` | `TRACKS_ROW_Y + 12` |

Vertical: bumping SysEx down one row gives each field its own 3-row band (top frame / content / bottom frame) so the frames stop colliding.

Horizontal: half-width inputs end at col 47, leaving a 1-col gap before the Skin Selection at col 49.

27 chars is plenty for typical paths (`./ccizer`, `~/.config/zt/syx`, `/Users/foo/Music/ztracker/ccizer`). The `length = MAX_PATH` cap on the input itself is unchanged — the user can scroll within the field to view longer paths.

## Test plan

- Builds clean on macOS arm64
- Manual via headless harness: `zt --headless --script <wait;F12;shot;quit>` — both fields render as proper black framed inputs, half-width, tucked under "Record Velocity", no transgression on Skin Selection.

This was the exact kind of regression the headless tooling (#98) was meant to catch — visual inspection of every page after a change, before merge instead of after.
