### PR TITLE
Quit confirm: "Exit zTracker?" with OK/Cancel, OK-focused, balanced layout

### DIFF
--- a/src/CUI_Page.h
+++ b/src/CUI_Page.h
@@ -451,6 +451,20 @@ class CUI_RUSure : public CUI_Page {
 
         const char *str;
         VFunc OnYes;
+        // Which button is initially focused: 0 = Yes, 1 = No.
+        // Default is 1 (No) so destructive confirmations (overwrite,
+        // discard) require an explicit Yes -- pressing Enter at the
+        // prompt cancels. Callers that prompt for a clear-cut user
+        // action they already initiated (Ctrl-Q "Exit zTracker?")
+        // can set 0 so a second Enter commits.
+        int default_button;
+        // Per-popup button captions. Defaults are "  Yes" / "  No"
+        // for Y/N-style prompts. Callers wanting OK/Cancel framing
+        // (e.g. quit) can override before popup_window. Both reset
+        // to the defaults at the end of enter() so a one-shot
+        // override doesn't leak into the next popup.
+        const char *yes_caption;
+        const char *no_caption;
 
         CUI_RUSure();
 

--- a/src/CUI_RUSure.cpp
+++ b/src/CUI_RUSure.cpp
@@ -1,5 +1,6 @@
 #include "zt.h"
 #include "Button.h"
+#include <string.h>
 
 void BTNCLK_rusure_no(void) {
     Keys.flush();
@@ -18,10 +19,20 @@ void BTNCLK_rusure_yes(void) {
 }
 
 
+// Default Y/N captions. Callers can override via UIP_RUSure->yes_caption /
+// no_caption before popup_window; enter() applies and then resets.
+static const char *kDefaultYesCaption = "  Yes";
+static const char *kDefaultNoCaption  = "  No";
+
 CUI_RUSure::CUI_RUSure(void) {
 
     int tabindex=0;
     UI = new UserInterface;
+    default_button = 1;     // No-focused by default; safe for destructive prompts.
+    OnYes = NULL;
+    str = "";
+    yes_caption = kDefaultYesCaption;
+    no_caption  = kDefaultNoCaption;
 
     int window_width = 40 * col(1);
     int window_height = 12 * row(1);
@@ -52,7 +63,18 @@ CUI_RUSure::CUI_RUSure(void) {
 
 void CUI_RUSure::enter(void) {
     need_refresh = 1;
-    UI->cur_element = 1;
+    UI->cur_element = (default_button == 0) ? 0 : 1;
+    // Apply caller-provided button captions. draw() picks up the
+    // strings + recomputes button widths and positions every frame,
+    // so we just hand off here.
+    button_yes->caption = yes_caption ? yes_caption : kDefaultYesCaption;
+    button_no->caption  = no_caption  ? no_caption  : kDefaultNoCaption;
+    // Reset for next caller -- popups are reused, so a one-shot
+    // override doesn't leak into the next file-overwrite or
+    // discard-changes prompt.
+    default_button = 1;
+    yes_caption    = kDefaultYesCaption;
+    no_caption     = kDefaultNoCaption;
 }
 
 void CUI_RUSure::leave(void) {
@@ -109,11 +131,25 @@ void CUI_RUSure::draw(Drawable *S) {
     int start_y = (INTERNAL_RESOLUTION_Y / 2) - (window_height / 2);
     for(;start_y % 8;start_y--);
 
+    // Auto-size each button to fit its current caption with one cell of
+    // padding inside the frame. This lets a caller swap "Yes" for "OK"
+    // or "No" for "Cancel" without doing arithmetic in their setup
+    // code -- the captions just work.
+    int yes_len = button_yes->caption ? (int)strlen(button_yes->caption) : 0;
+    int no_len  = button_no->caption  ? (int)strlen(button_no->caption)  : 0;
+    button_yes->xsize = yes_len + 2;
+    button_no->xsize  = no_len  + 2;
 
-    button_yes->x = (start_x / 8) + 2 ;
-    button_yes->y = (start_y + (window_height / 2) ) / 8 +1; //23;
-    button_no->x = (start_x / 8) + 2 + 7 + 2;
-    button_no->y = (start_y + (window_height / 2) ) / 8 +1;
+    // Centre the (yes_btn + 2-cell gap + no_btn) cluster horizontally
+    // inside the popup window so OK/Cancel and Yes/No both look balanced.
+    int popup_cols    = window_width / 8;             // 20
+    int total_cols    = button_yes->xsize + 2 + button_no->xsize;
+    int left_pad_cols = (popup_cols - total_cols) / 2;
+    if (left_pad_cols < 1) left_pad_cols = 1;
+    button_yes->x = (start_x / 8) + left_pad_cols;
+    button_yes->y = (start_y + (window_height / 2)) / 8 + 1;
+    button_no->x  = button_yes->x + button_yes->xsize + 2;
+    button_no->y  = button_yes->y;
 
     if (S->lock()==0) {
         S->fillRect(start_x,start_y,start_x + window_width,start_y + window_height,COLORS.Background);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1308,8 +1308,15 @@ void doquit() {
 //
 //
 void quit() {
-  UIP_RUSure->str = " Sure to quit?";
+  UIP_RUSure->str = " Exit zTracker?";
   UIP_RUSure->OnYes = (VFunc)doquit;
+  // The user initiated the quit explicitly (Ctrl-Q / ESC menu Quit), so
+  // default focus to OK -- a second Enter commits. Other RUSure callers
+  // (file-overwrite, discard-changes) keep the default No-focused
+  // behaviour so an accidental Enter doesn't destroy work.
+  UIP_RUSure->default_button = 0;
+  UIP_RUSure->yes_caption    = "  OK";
+  UIP_RUSure->no_caption     = " Cancel";
   popup_window(UIP_RUSure);
 }
 


### PR DESCRIPTION
## Behaviour change

The "are you sure" popup that fires from Ctrl-Q (and the ESC menu Quit entry) now:

1. Shows **"Exit zTracker?"** instead of "Sure to quit?".
2. Uses **OK / Cancel** buttons instead of Yes / No.
3. Lands focus on **OK** so a single Enter commits.
4. Centres the OK / Cancel cluster horizontally — buttons stay balanced regardless of caption length.

Other RUSure prompts are **unchanged** — file-overwrite ("File exists, sure?"), unsaved-changes-discard ("You crazy?"), etc. all keep their Yes/No captions and No-focused safety so an accidental Enter doesn't destroy work.

## Implementation

`CUI_RUSure` gains three per-popup overrides — `default_button` (already in v1 of this PR), plus `yes_caption` and `no_caption`. All three reset to safe defaults at the end of `enter()` so a one-shot override doesn't leak into the next popup.

`CUI_RUSure::draw()` now auto-sizes each button from `strlen(caption) + 2` and centres the (yes_btn + 2-cell gap + no_btn) cluster inside the 20-cell-wide popup. So OK/Cancel and Yes/No both look balanced — no caller arithmetic needed.

`main.cpp::quit()` is the only caller that overrides the defaults:

```c
UIP_RUSure->str            = " Exit zTracker?";
UIP_RUSure->default_button = 0;       // OK-focused
UIP_RUSure->yes_caption    = "  OK";
UIP_RUSure->no_caption     = " Cancel";
```

Every other RUSure caller inherits the default (Yes-focused-on-No, "  Yes" / "  No" captions).

## Files

- `src/CUI_Page.h` — `default_button` + `yes_caption` + `no_caption` fields with comment explaining the safety convention.
- `src/CUI_RUSure.cpp` — initialise all three to defaults in ctor; respect + reset in `enter()`; draw() recomputes button widths from current captions and centres the cluster.
- `src/main.cpp::quit()` — sets the three fields before `popup_window`.

3 files, +64 / -7.

## Test plan

- [x] Builds clean on macOS arm64
- [x] Verified via the headless harness (PR #98):

  ```
  cat > /tmp/quit-test.txt <<'EOF'
  wait 200
  key ctrl+q
  wait 250
  shot /tmp/quit-confirm.png
  key esc
  wait 100
  quit
  EOF
  ./build/Program/zt --headless --script /tmp/quit-test.txt
  ```

  Result: screenshot shows the **"Exit zTracker?"** popup with **OK** highlighted (focused button) and **Cancel** to its right; both buttons are framed and balanced inside the popup. ESC dismisses cleanly. Status 0 on exit.

- [ ] Cross-check (manual, not yet done in this PR):
  - File-overwrite confirmation → still **Yes / No**, **No-focused**
  - Load-over-unsaved-changes "You crazy?" → still **Yes / No**, **No-focused**

The reset-to-defaults logic at the end of `CUI_RUSure::enter()` enforces the convention; if a future caller wants OK/Cancel framing they have to set the captions on every popup.
