### PR TITLE
Shift+F3 rename: "Paketti CCizer" + show inst/port/channel in title

### DIFF
--- a/doc/help.txt
+++ b/doc/help.txt
@@ -110,7 +110,7 @@
                   Keyboard | MIDI1 | MIDI2 | MIDI3). Up/Dn/Lt/Rt move,
                   Enter edits, Backspace clears, Ctrl+S saves both
                   tables to zt.conf.
- SHIFT-F3       : CC Console — load Paketti CCizer-format `.txt` files
+ SHIFT-F3       : Paketti CCizer — load Paketti CCizer-format `.txt` files
                   and send MIDI CC / Pitch Bend out via on-screen
                   sliders or knobs. Tab focus, Enter loads, Lt/Rt
                   adjusts (Shift x8, Ctrl x16), V toggles slider/knob,

--- a/src/CUI_CcConsole.cpp
+++ b/src/CUI_CcConsole.cpp
@@ -716,10 +716,55 @@ void CUI_CcConsole::draw(Drawable *S) {
                 row(CC_GRID_Y + grid_max_rows + 2),
                 COLORS.Background);
 
-    char title[160];
+    // Title shows the destination of every CC the page sends out:
+    //   inst <NN: name>   port <alias-or-name>   ch <N>
+    // Routing rules mirror send_slot(): use cur_inst's midi_device
+    // (and channel) when set, otherwise the first opened MIDI Out
+    // device. The title text is the source of truth for "where am I
+    // sending right now" -- previously it was just "ch N" with no
+    // way to tell which port or which instrument was active.
+    char inst_field[80];
+    if (cur_inst >= 0 && cur_inst < MAX_INSTS && song->instruments[cur_inst]) {
+        const char *iname = (const char *)song->instruments[cur_inst]->title;
+        if (iname && *iname) {
+            snprintf(inst_field, sizeof(inst_field),
+                     "inst %02d:%s", cur_inst, iname);
+        } else {
+            snprintf(inst_field, sizeof(inst_field), "inst %02d", cur_inst);
+        }
+    } else {
+        snprintf(inst_field, sizeof(inst_field), "inst --");
+    }
+
+    int dev = -1;
+    if (cur_inst >= 0 && cur_inst < MAX_INSTS && song->instruments[cur_inst]
+        && song->instruments[cur_inst]->midi_device != 0xff) {
+        dev = song->instruments[cur_inst]->midi_device;
+    }
+    if (dev < 0) {
+        for (int i = 0; i < (int)MidiOut->numOuputDevices; i++) {
+            if (MidiOut->outputDevices[i] && MidiOut->outputDevices[i]->opened) {
+                dev = i; break;
+            }
+        }
+    }
+    char port_field[80];
+    if (dev >= 0 && MidiOut->outputDevices[dev]) {
+        const char *al = MidiOut->get_alias((unsigned int)dev);
+        if (al && *al) {
+            snprintf(port_field, sizeof(port_field), "port %s", al);
+        } else {
+            snprintf(port_field, sizeof(port_field), "port %d", dev);
+        }
+    } else {
+        snprintf(port_field, sizeof(port_field), "port (none)");
+    }
+
+    char title[200];
     snprintf(title, sizeof(title),
-             "CC Console (Shift+F3)  ch %d%s",
-             channel, learning ? "  [LEARN]" : "");
+             "Paketti CCizer (Shift+F3)   %s   %s   ch %d%s",
+             inst_field, port_field, channel,
+             learning ? "   [LEARN]" : "");
     printtitle(PAGE_TITLE_ROW_Y, title, COLORS.Text, COLORS.Background, S);
 
     // ----- File list pane (left) -----

--- a/src/CUI_MainMenu.cpp
+++ b/src/CUI_MainMenu.cpp
@@ -273,7 +273,7 @@ static const mm_entry MM_ENTRIES[] = {
     {MM_CMD,        "Palette Editor",           "Shift+Ctrl+F12",       CMD_SWITCH_PALETTE,         NULL},
 #endif
     {MM_CMD,        "Shortcuts & MIDI Mappings","Shift+F2",             CMD_SWITCH_KEYBINDINGS,     NULL},
-    {MM_CMD,        "CC Console",               "Shift+F3",             CMD_SWITCH_CCCONSOLE,       NULL},
+    {MM_CMD,        "Paketti CCizer",           "Shift+F3",             CMD_SWITCH_CCCONSOLE,       NULL},
     {MM_CMD,        "SysEx Librarian",          "Shift+F5",             CMD_SWITCH_SYSEX_LIB,       NULL},
     {MM_FUNC,       "Toggle CC Drawmode",       "Ctrl+Shift+\xA7",      0,                          mm_toggle_cc_drawmode},
     {MM_CMD,        "Lua Console",              "Ctrl+Alt+L",           CMD_SWITCH_LUA_CONSOLE,     NULL},


### PR DESCRIPTION
## Summary

Two small UX changes to **Shift+F3**:

1. **Page title rename** — "CC Console (Shift+F3)" → "Paketti CCizer (Shift+F3)". CCizer is the file format the page is built around; **Paketti CCizer** is the upstream name (Esa's Renoise tool that the `.txt` format originated in) and the user-facing call-out for what this page actually does. Generic "CC Console" gave no hint that the same `.txt` files round-trip with Paketti.

2. **Title shows live routing context** — `inst <NN:name>   port <alias-or-name>   ch <N>`. Previously only `ch 1` was visible. The user couldn't tell which instrument or which MIDI port the next slider tweak would send to. Routing rules mirror `send_slot()`: `cur_inst`'s `midi_device` if set, otherwise the first opened MIDI Out device.

## Field formats

| State | Display |
|---|---|
| Named instrument | `inst 03:Lead Pad` |
| Instrument with empty title | `inst 03` |
| No instrument selected (cur_inst OOB or song uninit) | `inst --` |
| Device alias set in F12 | `port IAC Bus 1` |
| Device opened, no alias | `port 0` |
| No opened device | `port (none)` |

## Other changes

- **Main menu entry** "CC Console" → "Paketti CCizer" (`src/CUI_MainMenu.cpp`).
- **`doc/help.txt`** `SHIFT-F3` line updated.

Source-internal references (comments, struct field names, code paths like `STATE_CCCONSOLE`, `UIP_CcConsole`, `CUI_CcConsole`) keep "CC Console" as the historical identifier — renaming those is just churn without user benefit.

## Test plan

- [x] Builds clean on macOS arm64
- [x] Headless verification: `--headless --script <wait;Shift+F3;shot;quit>` shows title `Paketti CCizer (Shift+F3)   inst 00:   port (none)   ch 1`. With a song loaded and a MIDI Out device opened, fields would resolve to `inst 03:Lead Pad   port IAC Bus 1   ch 5`.
- [x] ESC menu entry shows "Paketti CCizer" with the Shift+F3 binding.
- [x] F1 Help SHIFT-F3 line shows "Paketti CCizer" as the page name, then describes the format.
