### PR TITLE
CC Console: fix slider value leak on file switch

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,27 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_05_02 (CC Console: fix file-switch slider value leak)
+-------------------------------------------------------------
+
+        * CC Console (Shift+F3): switching between Paketti CCizer
+          files no longer leaks slider values from the previous file
+          into the new one. The page reuses a fixed pool of
+          ValueSlider widgets across files; previously load_selected()
+          re-seeded the in-memory values + last_values[] for the new
+          file but never reset sliders[]->value for slots outside the
+          visible window. As a result every off-screen slot the user
+          had dragged in file1 carried its old value into file2 ---
+          absorb_slider_changes() (which iterates ALL loaded slots,
+          not just visible ones) saw the stale-vs-fresh mismatch,
+          wrote file1's values into file2's in-memory state AND
+          fired a MIDI message for every previously-tweaked slot.
+          Scrolling to a hidden slot in file2 then displayed the
+          leaked value as if it were file2's own. Fix: reset the
+          entire widget pool's values to match the freshly-loaded
+          file in load_selected(), in lockstep with the existing
+          last_values[] seed.
+
 zt 2026_04_30 (CC Console + Shift+F2/F3 reshuffle)
 --------------------------------------------------
 

--- a/src/CUI_CcConsole.cpp
+++ b/src/CUI_CcConsole.cpp
@@ -360,10 +360,20 @@ void CUI_CcConsole::load_selected(void) {
         loaded = 1;
         slot_cur = slot_top = 0;
         zt_ccizer_set_current_file(&g_loaded);
-        // Seed last_values so we don't false-trigger send_slot on the
-        // first absorb pass after load.
+        // Seed last_values AND reset the entire ValueSlider widget pool
+        // to match the freshly-loaded file. The widget pool is fixed
+        // (ZT_CCIZER_MAX_SLOTS) and reused across files; without this
+        // reset, sliders[] still hold the previous file's user-dragged
+        // values for any slot outside the visible window. position_sliders()
+        // only refreshes vs->value for visible rows, so absorb_slider_changes()
+        // would then see stale-vs-fresh mismatches on hidden slots, write
+        // file1's values into g_loaded and squirt out a MIDI flood for
+        // every off-screen slot the user had touched. Reset all slots up
+        // front so the very next absorb sees vs->value == last_values[i].
         for (int i = 0; i < ZT_CCIZER_MAX_SLOTS; i++) {
-            last_values[i] = (i < g_loaded.num_slots) ? g_loaded.slots[i].value : 0;
+            unsigned short v = (i < g_loaded.num_slots) ? g_loaded.slots[i].value : 0;
+            last_values[i] = v;
+            sliders[i]->value = v;
         }
         snprintf(status_line, sizeof(status_line),
                  "Loaded %s — %d slot(s).", g_loaded.basename, g_loaded.num_slots);


### PR DESCRIPTION
## Summary

Switching Paketti CCizer files in the CC Console (Shift+F3) leaked the previous file's slider values into the new file. Symptoms reported by user:

> if i have modified say, 30 sliders in file1.. and i switch to file2? guess what. file2 sliders now have the same parameters that file1 had. that's not valid at all.

Plus a hidden MIDI flood: every off-screen slot the user had touched in file1 fired a MIDI message at file-switch time, *with file2's CC# but file1's value*.

## Root cause

The page keeps a fixed pool of `ZT_CCIZER_MAX_SLOTS` `ValueSlider` widgets and rebinds them across files. `load_selected()` re-seeded the in-memory data + `last_values[]` for the new file but never reset `sliders[i]->value` for slots outside the currently visible window. `position_sliders()` only syncs `vs->value = s->value` for visible rows.

Per-frame `update()` runs:
1. `position_sliders` — visible rows: `vs <- s` (file2 fresh values)
2. `UI->update` — user input drives `vs->value`
3. `absorb_slider_changes` — iterates **all loaded slots**, fires when `vs->value != last_values[i]`

For hidden slots step 3 saw `vs->value` = file1 stale (e.g. 87) vs `last_values[i]` = file2's freshly-seeded 0, treated it as a user edit, wrote 87 into `g_loaded.slots[i].value` and sent MIDI for it. Scrolling later showed the leaked value as if it were file2's own.

## Fix

In `load_selected()` reset the entire widget pool's values to match the freshly-loaded file, in lockstep with the existing `last_values[]` seed. Next `absorb_slider_changes` then sees `vs->value == last_values[i]` for every slot and stays silent until the user actually drags.

```cpp
for (int i = 0; i < ZT_CCIZER_MAX_SLOTS; i++) {
    unsigned short v = (i < g_loaded.num_slots) ? g_loaded.slots[i].value : 0;
    last_values[i] = v;
    sliders[i]->value = v;   // <-- new
}
```

5 lines of behavior change + a CHANGELOG entry.

## Test plan

- [x] Builds clean on macOS arm64 (`zt.app`)
- [x] 9/9 unit suites pass (`ctest`), including the existing `ccizer` suite
- [ ] Manual smoke: load a file with 30+ slots in `assets/ccizer/`, drag several mid-list sliders, switch to a different file, scroll through the new file — slot values should be file2's parsed defaults; no MIDI flood at switch time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)