### PR TITLE
CLAUDE.md + skill: bug reports = branch + PR + push, no asking

### DIFF
--- a/.claude/skills/ztrackerprime/SKILL.md
+++ b/.claude/skills/ztrackerprime/SKILL.md
@@ -179,6 +179,19 @@ The full list-pane construction pattern (with code) lives in [`references/list-p
 - Tag AI-assisted commits: `Co-Authored-By: Claude <noreply@anthropic.com>` (or current model identifier).
 - Don't duplicate content across PRs.
 
+### Bug reports = branch + PR + push, no asking
+
+When Esa reports a bug, the **default response is**: investigate → fix → branch → commit → push → open PR. Do not ask "want me to fix?" or "should I open a PR?" — that's the implicit ask. Just do it.
+
+The only acceptable preamble is one or two sentences naming the root cause and the fix, then go.
+
+- Branch: `esa/<short-descriptive>` (e.g. `esa/cc-console-file-switch-leak`).
+- Build clean + run `ctest` before pushing.
+- PR body: summary, root cause, fix, test plan checklist. Quote the user's own description of the symptom verbatim if they gave one — that anchors the PR to the report.
+- Push to `origin`; Esa has write access.
+
+Ask for clarification only if the bug **report itself** is ambiguous about the symptom — never about whether to fix it. Reference: PR #106 (CC Console file-switch slider value leak, 2026-05-02).
+
 ## Paketti as a feature reference
 
 Paketti (a Renoise tool) is a reference for tracker quality-of-life features ported / portable to zTracker. Already landed: Replicate at Cursor, Clone Pattern, Humanize Velocities, MIDI Macro + Arpeggio editors. Future candidates: Fill-with-note-at-cursor, Find/Replace note, Transpose selection, Groove templates, Chord memory. zTracker is MIDI-only, so sample-editor features are N/A.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,19 @@ If the trace doesn't show how the reported input produces the symptom, the model
 - Don't duplicate content across PRs.
 - Push branches directly to `origin` (no fork needed; Esa has write access).
 
+### Bug reports = branch + PR + push, no asking
+
+When Esa reports a bug, the **default response is**: investigate → fix → branch → commit → push → open PR. Do not ask "want me to fix?" or "should I open a PR?" — that's the implicit ask. Just do it.
+
+The only acceptable preamble is one or two sentences naming the root cause and the fix, then go.
+
+- Branch name: `esa/<short-descriptive>` (e.g. `esa/cc-console-file-switch-leak`).
+- Build clean + run `ctest` before pushing.
+- PR body: summary, root cause, fix, test plan checklist. Include the user's verbatim quote of the symptom if they gave one.
+- Push to `origin`; Esa has write access.
+
+Ask for clarification only if the bug **report itself** is ambiguous about the symptom — never about whether to fix it.
+
 ---
 
 ## Common user behaviour (learned)


### PR DESCRIPTION
## Summary

Documents an AI-collaboration policy in both `CLAUDE.md` and `.claude/skills/ztrackerprime/SKILL.md`:

> When Esa reports a bug, the **default response is**: investigate → fix → branch → commit → push → open PR.

No "want me to fix?" / "should I open a PR?" preamble — the bug report itself is the implicit ask.

The only acceptable preamble is one or two sentences naming the root cause and the fix, then go. Clarification is allowed only when the bug **report itself** is ambiguous about the symptom — never about whether to fix.

## Context

Crystallised during PR #106 (CC Console file-switch slider value leak, 2026-05-02). Esa stopped me mid-fix-confirmation: *"i expect that if i tell you a bug, you make a branch + PR and push it."* Codifying it here so it's repo-resident, visible to any contributor's AI agent, and survives session boundaries.

## Changes

- `CLAUDE.md` → new subsection under **PR discipline** with branch-naming convention, build/test gate, PR body shape.
- `.claude/skills/ztrackerprime/SKILL.md` → mirror the same rule with a back-reference to PR #106 as the originating incident.
- Pure docs; no code touched.

## Test plan

- [x] Markdown renders cleanly (no broken sections, lists intact)
- [x] Both files mention the same rule with consistent wording
- [x] No code or build files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)