### PR TITLE
Pattern Editor: drop stale MIDI-in queue on enter() (drawmode burst fix)

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,21 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_05_02 (Pattern Editor: drop stale MIDI-in on enter())
+-------------------------------------------------------------
+
+        * Pattern Editor (F2): clear the global MIDI-in queue on
+          enter() so messages that arrived while the user was on
+          F11/F12/Help/etc. don't burst-replay at the cursor on the
+          first update() tick. The queue is global but only PE /
+          InstEditor / PEParms / CcConsole drain it, so accumulation
+          is real. Previously the burst was especially harmful with
+          CC drawmode ON: every accumulated CC/PB was written as a
+          single Sxxyy/Wxxxx run at the cursor, with drawmode's
+          per-session UNDO_SAVE already consumed -- a pattern stomp
+          the user couldn't easily undo. Behaviour is now consistent
+          with returning to a fresh state.
+
 zt 2026_05_02 (CC Console: fix file-switch slider value leak)
 -------------------------------------------------------------
 

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -943,10 +943,25 @@ void CUI_Patterneditor::enter(void)
   cur_state = STATE_PEDIT;
   mousedrawing=0;
   //PATTERN_EDIT_ROWS = 32 + 4 + (INTERNAL_RESOLUTION_Y - 480) / 8;
-  
+
   // Dynamic row count based on current window height - see issue #15.
 
   PATTERN_EDIT_ROWS = CHARS_Y - TRACKS_ROW_Y - 1 - SPACE_AT_BOTTOM ;
+
+  // CC drawmode + page-switch: drop any MIDI-in messages that arrived
+  // while the user was off-page. The queue is global but only Pattern
+  // Editor / InstEditor / PEParms / CcConsole drain it; F11, F12, Help,
+  // MainMenu, etc. do not. With drawmode ON, returning to PE would
+  // otherwise burst-write every accumulated CC/PB at the current
+  // cursor as a single tick of update() drained the backlog -- a
+  // surprise pattern stomp the user can't easily undo (drawmode's
+  // session UNDO_SAVE only fires once per ON->OFF span). Clear on
+  // enter so drawmode only captures messages received after the user
+  // is actually back on Pattern Editor. With drawmode OFF the queue's
+  // legacy jazz-record path handles 0x80/0x90 directly, but stale
+  // notes from minutes ago aren't useful either, so clear unconditionally
+  // when entering -- cheap and behaviour-consistent.
+  midiInQueue.clear();
 
   //  this->mode = PEM_REGULARKEYS;
 }


### PR DESCRIPTION
## Summary

Fix a latent burst-write bug in the Pattern Editor when CC drawmode is on across page switches.

## Root cause

`g_cc_drawmode` is a process-global flag toggled by `Ctrl+Shift+§` (or the ESC menu). When ON, the Pattern Editor's MIDI-in pump (`CUI_Patterneditor.cpp:3135`) writes incoming `0xB0..0xBF` / `0xE0..0xEF` as `Sxxyy` / `Wxxxx` effects at the cursor row.

The MIDI-in queue (`midiInQueue`) is **also global**, but only four pages drain it: `CUI_Patterneditor`, `CUI_InstEditor`, `CUI_PEParms`, `CUI_CcConsole`. Songconfig (F11), Sysconfig (F12), Help, MainMenu — all do **not** drain.

So this scenario was possible:

1. User on Pattern Editor toggles drawmode ON, knobs work fine, CCs write at cursor.
2. User switches to F11. Knob tweaks continue producing CC messages → queue accumulates indefinitely.
3. User switches back to Pattern Editor.
4. First `update()` tick drains the entire backlog, writing every accumulated CC/PB as a single run at whatever the cursor row is now.

This was particularly bad because drawmode's per-session `UNDO_SAVE` already fired on the original ON toggle, so the burst-write **isn't undoable** with one Ctrl+Z.

## Fix

`CUI_Patterneditor::enter()` now clears `midiInQueue` unconditionally. With drawmode ON this is the bug fix; with drawmode OFF the cleared queue would have fed the legacy jazz-record path with notes from minutes-ago — also not useful — so clearing in both modes is behaviour-consistent and cheap. ~3 lines of code + comment + CHANGELOG entry.

## Test plan

- [x] Builds clean on macOS arm64 (`zt.app`)
- [x] 9/9 unit suites pass (`ctest`)
- [ ] Manual: with drawmode ON on PE, switch to F11, send several CCs from a knob controller, switch back to PE — cursor should stay where it was; pattern data should not stomp.
- [ ] Manual: with drawmode OFF, switch to F12 and back — keyjazz-style 0x90 notes received while away no longer auto-trigger when returning. (Confirms the second-mode behaviour change is benign.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
