### PR TITLE
Pattern Editor: ALT+SHIFT+Q / ALT+SHIFT+A — transpose selection by octave

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,16 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_05_02 (Pattern Editor: octave transpose for selections)
+---------------------------------------------------------------
+
+        + Pattern Editor: ALT+SHIFT+Q / ALT+SHIFT+A transpose the
+          current selection up / down by one octave (12 semitones).
+          ALT+Q / ALT+A continue to do single semitone steps. Notes
+          clamp at 0x00 / 0x7F so an octave shift past either end
+          saturates rather than wrapping. Cmd+Shift+Q / Cmd+Shift+A
+          on macOS land in the same path via KS_META→KS_ALT mapping.
+
 zt 2026_05_02 (Pattern Editor: drop stale MIDI-in on enter())
 -------------------------------------------------------------
 
@@ -39,7 +49,6 @@ zt 2026_05_02 (CC Console: fix file-switch slider value leak)
           entire widget pool's values to match the freshly-loaded
           file in load_selected(), in lockstep with the existing
           last_values[] seed.
-
 zt 2026_04_30 (CC Console + Shift+F2/F3 reshuffle)
 --------------------------------------------------
 

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -74,8 +74,10 @@
  CTRL-T : Set all effect and effect data fields of block to same
           value as first row in block
  CTRL-K : Interpolate volume (block)
- ALT-Q  : Transpose block up
- ALT-A  : Transpose block down
+ ALT-Q        : Transpose block up   (1 semitone)
+ ALT-A        : Transpose block down (1 semitone)
+ ALT-SHIFT-Q  : Transpose block up   (1 octave)
+ ALT-SHIFT-A  : Transpose block down (1 octave)
  CTRL-J : Popup scale volume window (10-200%)
  CTRL-A : Popup Naturalizing window (1-100%)
  CTRL-[ : Decrease all volumes in block by 8

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -2562,7 +2562,7 @@ void CUI_Patterneditor::update()
           }
           break;
 
-          case SDLK_Q: /* Transpose up */
+          case SDLK_Q: /* Transpose selection up by 1 semitone */
             if (selected) {
               for(i=select_track_start;i<=select_track_end;i++) {
                 for(j=select_row_start;j<=select_row_end;j++) {
@@ -2575,7 +2575,7 @@ void CUI_Patterneditor::update()
               need_refresh++;
             }
             break;
-          case SDLK_A: /* Transpose down */
+          case SDLK_A: /* Transpose selection down by 1 semitone */
             if (selected) {
               for(i=select_track_start;i<=select_track_end;i++) {
                 for(j=select_row_start;j<=select_row_end;j++) {
@@ -2712,11 +2712,48 @@ case SDLK_DELETE:
               song->patterns[cur_edit_pattern]->tracks[need_refresh]->ins_row(cur_edit_row);
           } else {
             song->patterns[cur_edit_pattern]->tracks[cur_edit_track]->ins_row(cur_edit_row);
-          }           
+          }
           need_refresh++;
           break;
         }
-        
+
+        // Alt+Shift+Q / Alt+Shift+A : Transpose selection by an OCTAVE.
+        // KS_HAS_ALT excludes Shift, so the +1/-1 semitone block above
+        // never sees Shift+Alt; this is a sibling gate. Cmd+Shift+Q/A
+        // also lands here on macOS via the KS_META→KS_ALT mapping.
+        if ((kstate & (KS_ALT | KS_META)) && (kstate & KS_SHIFT) && !(kstate & KS_CTRL)) {
+          if (key == SDLK_Q && selected) {
+            for (i = select_track_start; i <= select_track_end; i++) {
+              for (j = select_row_start; j <= select_row_end; j++) {
+                if ((e = song->patterns[cur_edit_pattern]->tracks[i]->get_event(j))) {
+                  if (e->note < 0x80) {
+                    int nn = (int)e->note + 12;
+                    if (nn > 0x7F) nn = 0x7F;
+                    e->note = (unsigned char)nn;
+                  }
+                }
+              }
+            }
+            need_refresh++;
+            break;
+          }
+          if (key == SDLK_A && selected) {
+            for (i = select_track_start; i <= select_track_end; i++) {
+              for (j = select_row_start; j <= select_row_end; j++) {
+                if ((e = song->patterns[cur_edit_pattern]->tracks[i]->get_event(j))) {
+                  if (e->note > 0 && e->note < 0x80) {
+                    int nn = (int)e->note - 12;
+                    if (nn < 0) nn = 0;
+                    e->note = (unsigned char)nn;
+                  }
+                }
+              }
+            }
+            need_refresh++;
+            break;
+          }
+        }
+
         /* END SPECIAL KEYS */
         
         if ((kstate == KS_CTRL && ( key == SDLK_LEFT || key == SDLK_RIGHT || key == SDLK_UP || key == SDLK_DOWN )) || kstate == KS_NO_SHIFT_KEYS || kstate == KS_SHIFT || midiInQueue.size()>0) {


### PR DESCRIPTION
## Summary

Adds octave-step variants of the existing semitone transpose shortcuts in the Pattern Editor.

| Key | Action |
|---|---|
| `ALT+Q` / `ALT+A` | Transpose selection up / down by **1 semitone** (existing) |
| `ALT+SHIFT+Q` / `ALT+SHIFT+A` | Transpose selection up / down by **1 octave** (new) |

On macOS the `KS_META→KS_ALT` mapping means `Cmd+Shift+Q` / `Cmd+Shift+A` reach the same handler.

## Why

A common Paketti / IT-style operation. Holding ALT and tapping Q twelve times gets you an octave; this gives one-press parity. It was on the Paketti-port wishlist in the skill (`Transpose selection`) but only the per-semitone variant existed in master.

## Implementation

`KS_HAS_ALT` is defined to **exclude** Shift, so the existing semitone block never sees `Shift+Alt`. Adding the octave handler inside that block would be unreachable. The fix is a sibling gate placed immediately after the `KS_HAS_ALT` block ends, gated on `(kstate & (KS_ALT | KS_META)) && (kstate & KS_SHIFT) && !(kstate & KS_CTRL)` — same modifier semantics, plus Shift, minus Ctrl.

Notes clamp at `0x00` / `0x7F` rather than wrapping. The original semitone path used `++` / `--` with min/max guards; the octave path uses `+= 12` / `-= 12` with the same boundary clamp.

`doc/help.txt` line 77–78 updated; `doc/CHANGELOG.txt` gets a new section.

## Test plan

- [x] Builds clean on macOS arm64 (`zt.app`)
- [x] 9/9 unit suites pass (`ctest`)
- [ ] Manual: select a block of notes, ALT+SHIFT+Q → all notes shift up by 12. ALT+SHIFT+A → back. Verify clamping at note 127 / 0.
- [ ] Manual: ALT+Q / ALT+A still do single-semitone steps (regression check).
- [ ] Manual on macOS: Cmd+Shift+Q / Cmd+Shift+A behave identically to ALT+SHIFT variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
