### PR TITLE
Pattern Editor: Ctrl+Shift+F — Fill Selection with Note at Cursor

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,22 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_05_02 (Pattern Editor: Fill Selection with Note at Cursor)
+------------------------------------------------------------------
+
+        + Pattern Editor: Ctrl+Shift+F replicates the (note,
+          instrument, length) of the event at the cursor row across
+          every cell in the current selection. Volume / effect /
+          effect_data in each row are left alone -- per-row creative
+          decisions stay intact, and only the note identity is
+          stamped. Single UNDO_SAVE makes the whole fill one
+          Ctrl+Z. If the cursor row has no note, fill is a no-op
+          with a status message.
+          ! Listed on the Paketti-port wishlist as
+            "Fill-with-note-at-cursor"; matches Paketti's behavior
+            of replicating the source note across a selection.
+
+
 zt 2026_05_02 (Pattern Editor: octave transpose for selections)
 ---------------------------------------------------------------
 
@@ -48,8 +64,7 @@ zt 2026_05_02 (CC Console: fix file-switch slider value leak)
           leaked value as if it were file2's own. Fix: reset the
           entire widget pool's values to match the freshly-loaded
           file in load_selected(), in lockstep with the existing
-          last_values[] seed.
-zt 2026_04_30 (CC Console + Shift+F2/F3 reshuffle)
+          last_values[] seed.zt 2026_04_30 (CC Console + Shift+F2/F3 reshuffle)
 --------------------------------------------------
 
         + Shift+F3 is now the CC Console. It loads Paketti

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -41,6 +41,8 @@
  CTRL-SHIFT-G    : Double Pattern (duplicate rows, max 256)
  CTRL-SHIFT-H    : Halve Pattern (keep every other row, min 32)
  CTRL-SHIFT-D    : Clone Pattern (copy to next empty slot and jump to it)
+ CTRL-SHIFT-F    : Fill Selection with Note at Cursor (note + inst + length;
+                   leaves volume / effects in each row untouched)
  CTRL-SHIFT-R    : Reverse Selection (reverse row order in selected block)
  CTRL-SHIFT-Down : Rotate Track Down (last row wraps to first)
  CTRL-SHIFT-Up   : Rotate Track Up (first row wraps to last)

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -1927,6 +1927,38 @@ void CUI_Patterneditor::update()
           status_change = 1; need_refresh++; key = 0;
         }
 
+        // Fill Selection with Note at Cursor: Ctrl+Shift+F
+        // Take the (note, instrument, length) of the event at the cursor
+        // row in the cursor track, replicate across every cell in the
+        // selection. Volume / effect / effect_data are left untouched
+        // (per-row creative decisions stay yours). If the cursor row has
+        // no note, error out without modifying anything. Single
+        // UNDO_SAVE makes the whole fill one Ctrl+Z.
+        if ((kstate & KS_CTRL) && (kstate & KS_SHIFT) && key == SDLK_F) {
+          if (!selected) {
+            statusmsg = "Fill: no selection";
+          } else {
+            event *src = song->patterns[cur_edit_pattern]->tracks[cur_edit_track]->get_event(cur_edit_row);
+            if (!src || src->note >= 0x80 || src->note == 0) {
+              statusmsg = "Fill: cursor row has no note";
+            } else {
+              UNDO_SAVE();
+              int src_note   = src->note;
+              int src_inst   = src->inst;
+              int src_length = src->length;
+              for (int t = select_track_start; t <= select_track_end; t++) {
+                track *trk = song->patterns[cur_edit_pattern]->tracks[t];
+                if (!trk) continue;
+                for (int j = select_row_start; j <= select_row_end; j++) {
+                  trk->update_event(j, src_note, src_inst, -1, src_length, -1, -1);
+                }
+              }
+              statusmsg = "Selection filled with note at cursor";
+            }
+          }
+          status_change = 1; need_refresh++; key = 0;
+        }
+
         // Reverse Selection: Ctrl+Shift+R
         if ((kstate & KS_CTRL) && (kstate & KS_SHIFT) && key == SDLK_R) {
           if (selected) {


### PR DESCRIPTION
## Summary

Adds **Ctrl+Shift+F : Fill Selection with Note at Cursor** in the Pattern Editor. Listed on the skill's Paketti-port wishlist; matches Paketti's "replicate the source note across a selection" semantic.

## Behavior

- Source: the event at `(cur_edit_row, cur_edit_track)` — wherever the cursor is sitting.
- Target: every cell in the current selection (multi-track + multi-row OK).
- What gets copied: **note + instrument + length**.
- What stays untouched: **volume + effect + effect_data** — per-row creative decisions don't get stomped.
- Single `UNDO_SAVE()` so the entire fill is one Ctrl+Z.
- No selection → status message, no-op.
- Cursor row has no note → status message, no-op.

## Why those columns

`update_event(row, note, inst, vol, length, effect, effect_data)` accepts `-1` as "skip this column". The fill calls `update_event(j, src_note, src_inst, -1, src_length, -1, -1)`. Note + length form a complete note instance in zTracker (length is duration), and the instrument keeps the timbre consistent. Volume and effects are typically per-row choices the user wouldn't want overwritten.

## Files

- `src/CUI_Patterneditor.cpp` — handler placed alongside the other `Ctrl+Shift+*` selection ops (Reverse, Rotate, Double, Halve, Clone).
- `doc/help.txt` — new line in **Pattern Operations**.
- `doc/CHANGELOG.txt` — release note.

## Test plan

- [x] Builds clean on macOS arm64 (`zt.app`)
- [x] 9/9 unit suites pass (`ctest`)
- [ ] Manual: place a note at row 0, select rows 1-15 across track 0, Ctrl+Shift+F → all 16 rows show that note + inst.
- [ ] Manual: select multi-track range, Ctrl+Shift+F → fill spans all tracks.
- [ ] Manual: with no selection → "Fill: no selection" status, nothing changes.
- [ ] Manual: cursor on empty row → "Fill: cursor row has no note" status, nothing changes.
- [ ] Manual: Ctrl+Z after fill restores everything in one step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
