### PR TITLE
ListBox: defuse the OnSelect mousestate-clobber foot-gun

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,9 +185,9 @@ Failure mode if rule 5 is violated: shipped pages with non-interactive ASCII "sl
 
 1. **Pre-switch reset.** `if (!bMouseIsDown) mousestate = 0;` at the **top** of `mouseupdate` clears mousestate BEFORE the switch sees BUTTON_UP. Result: the up event never increments `act`, `Keys.getkey()` is never called, the up event sits forever in the FIFO blocking every subsequent input. **The reset must run AFTER the switch.**
 
-2. **Premature `ListBox::OnSelect(selected)` in a subclass override.** Base `ListBox::OnSelect` sets `mousestate = 0`. If a subclass override calls it during click handling (between BUTTON_DOWN and BUTTON_UP), mousestate gets cleared early — same freeze. **Don't call `ListBox::OnSelect` from a subclass; the BUTTON_UP_LEFT case clears mousestate itself.**
+2. **Premature `ListBox::OnSelect(selected)` in a subclass override.** Historically, base `ListBox::OnSelect` set `mousestate = 0`, and a subclass override calling it during click handling (between BUTTON_DOWN and BUTTON_UP) cleared mousestate early — same freeze pattern. **Defused as of PR #112: base `ListBox::OnSelect` is now a documented no-op**, so subclasses can safely call `ListBox::OnSelect(p)` from inside their override without freezing. The rule that survives: **never write `mousestate = 0` inside any `OnSelect` override either**; the BUTTON_UP_LEFT case in `mouseupdate` is the only place that should clear it.
 
-Symptom for the user: "click on widget freezes the UI; Cmd-Tab unfreezes it." The Cmd-Tab unfreeze is `SDL_EVENT_WINDOW_FOCUS_GAINED → Keys.flush()` (see `main.cpp::zt_handle_platform_window_event`).
+Symptom for the user (the historic version): "click on listbox freezes the UI; Cmd-Tab unfreezes it." The Cmd-Tab unfreeze is `SDL_EVENT_WINDOW_FOCUS_GAINED → Keys.flush()` (see `main.cpp::zt_handle_platform_window_event`).
 
 ### Widget-class fixes belong upstream
 

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,31 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_05_02 (ListBox: defuse the OnSelect mousestate-clobber foot-gun)
+-----------------------------------------------------------------------
+
+        * src/UserInterface.cpp ListBox::OnSelect is now a documented
+          no-op (base class). Previously it cleared mousestate=0,
+          which was the source of a recurring "click-on-listbox
+          freezes UI; Cmd-Tab unfreezes" bug whenever a subclass
+          override called ListBox::OnSelect from inside its own
+          handler (the natural "call super" pattern). The
+          mousestate clear belongs to ListBox::mouseupdate's
+          BUTTON_UP_LEFT case (which already does it) and the
+          post-switch defensive (also already does it). Removing
+          the third copy from OnSelect makes "calling super" safe
+          for any current or future ListBox subclass.
+        * SkinSelector::OnSelect: dropped its own redundant
+          this->mousestate = 0; same reasoning. The SkinSelector
+          freeze case (clicking the already-selected skin) is
+          fixed by this change.
+        ! CLAUDE.md updated: the gotcha now reads "defused" instead
+          of "active foot-gun." The forward rule is: never write
+          mousestate=0 inside any OnSelect override; the BUTTON_UP_LEFT
+          case is the only place.
+
+zt 2026_04_30 (CC Console + Shift+F2/F3 reshuffle)
+
 zt 2026_05_02 (Pattern Editor: Fill Selection with Note at Cursor)
 ------------------------------------------------------------------
 
@@ -64,8 +89,7 @@ zt 2026_05_02 (CC Console: fix file-switch slider value leak)
           leaked value as if it were file2's own. Fix: reset the
           entire widget pool's values to match the freshly-loaded
           file in load_selected(), in lockstep with the existing
-          last_values[] seed.zt 2026_04_30 (CC Console + Shift+F2/F3 reshuffle)
---------------------------------------------------
+          last_values[] seed.zt 2026_04_30 (CC Console + Shift+F2/F3 reshuffle)--------------------------------------------------
 
         + Shift+F3 is now the CC Console. It loads Paketti
           CCizer-format `.txt` files (one slot per line:

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -2658,9 +2658,23 @@ int ListBox::getCurrentItemIndex(void) {
 
 // ------------------------------------------------------------------------------------------------
 //
+// ListBox::OnSelect — base default. Intentionally a no-op.
 //
+// Subclasses override this to react to "user activated an item." Do
+// NOT set `mousestate = 0` here, and do NOT do it in subclass overrides
+// either: ListBox::mouseupdate already clears mousestate in the
+// BUTTON_UP_LEFT case (and again in the post-switch defensive). Clearing
+// it in OnSelect runs DURING BUTTON_DOWN_LEFT (line ~2142, where
+// OnSelect is called when the user re-clicks the focused item) — which
+// means the BUTTON_UP_LEFT branch then sees mousestate==0, `act++` is
+// gated off, the button-up event sits unconsumed in the Keys queue,
+// and every subsequent input freezes until SDL_EVENT_WINDOW_FOCUS_GAINED
+// triggers Keys.flush(). Cmd-Tab "unfreezing" the UI is the smoking-
+// gun signature.
+//
+// Subclasses that need to call into base from their own override can
+// safely write `ListBox::OnSelect(p);` -- this no-op is the contract.
 void ListBox::OnSelect(LBNode*) {
-    mousestate = 0;
 }
 
 
@@ -2818,8 +2832,11 @@ void SkinSelector::OnSelect(LBNode *selected)
         selected->checked = true;
         ListBox::OnSelect(selected);
     }
-    delete todel;    
-    this->mousestate = 0;
+    delete todel;
+    // Do NOT clear mousestate here -- ListBox::mouseupdate's
+    // BUTTON_UP_LEFT case clears it at the right moment. Clearing
+    // during BUTTON_DOWN-fired OnSelect freezes the UI. See the
+    // ListBox::OnSelect comment in this file.
 }
 void SkinSelector::OnSelectChange() {
 }


### PR DESCRIPTION
## Summary

Defuses the recurring "click-on-listbox freezes UI; Cmd-Tab unfreezes" foot-gun by removing the `mousestate = 0` clobber from `ListBox::OnSelect` (the base class) and from `SkinSelector::OnSelect`'s own redundant copy.

## Background

The bug pattern is documented in `CLAUDE.md` and was the subject of PR #65. Recap:

- `ListBox::mouseupdate` calls `OnSelect(p)` during `BUTTON_DOWN_LEFT` when the user re-clicks the focused item (line ~2142).
- The matching `BUTTON_UP_LEFT` case (~2166) gates `act++` on `if (mousestate)`. If `mousestate` got cleared between the two events, `act` stays 0, the up event sits unconsumed in the Keys FIFO, and every subsequent input freezes until `SDL_EVENT_WINDOW_FOCUS_GAINED` triggers `Keys.flush()`.
- `mousestate = 0` *belongs* in `mouseupdate`'s BUTTON_UP_LEFT branch (which already does it) and the post-switch defensive (which also already does it). Anywhere else, it's a freeze.

`ListBox::OnSelect` (base) had `mousestate = 0;` as its sole body. That's the bug — calling super from a subclass override clobbered mousestate during BUTTON_DOWN. The audit memory listed this as "latent foot-gun for any future ListBox subclass."

`SkinSelector::OnSelect` had its own `this->mousestate = 0;` at the end — the active-bug version: clicking an already-selected skin would freeze the UI until Cmd-Tab.

## Fix

- `ListBox::OnSelect(LBNode*)` → empty body, with a 12-line comment documenting the contract: "never set mousestate=0 in this override either; mouseupdate is the only place."
- `SkinSelector::OnSelect` → `this->mousestate = 0;` removed, with a brief comment pointing at the base-class explanation.
- The other 3 subclasses in `UserInterface.cpp` (`MidiOutDeviceSelector`, `MidiOutDeviceOpener`, `MidiInDeviceOpener`) each call `ListBox::OnSelect(selected)` from inside their override. After this fix, those calls are no-ops — they keep working but no longer clobber state.

## Files

- `src/UserInterface.cpp` — base + SkinSelector
- `CLAUDE.md` — gotcha section now reads "defused"; forward rule retained ("never write mousestate=0 inside any OnSelect override")
- `doc/CHANGELOG.txt` — release note

No call-site changes elsewhere; no API breakage.

## Test plan

- [x] Builds clean on macOS arm64 (`zt.app`)
- [x] 9/9 unit suites pass (`ctest`)
- [ ] Manual: F11 SkinSelector → click an already-selected skin entry → UI does not freeze (was the main reproducer).
- [ ] Manual: F12 SysConfig MIDI device lists → click already-selected → no freeze.
- [ ] Manual: any normal listbox click (Up/Down + Enter, drag-select) → behaves identically to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
