### PR TITLE
CC Drawmode: cycle through CCizer slots + Shortcuts rebind

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -23,6 +23,39 @@ zt 2026_05_12 (All 7 hand-tuned palettes: regenerate from Schism's IT data)
           / Gold (Vintage) / FX 2.0 / Atlantic / Acid Gas / Hotdog
           Stand) were already imported from Schism on a prior pass
           and were left unchanged.
+zt 2026_05_12 (CC Drawmode: drag-to-draw CC drawbars with the mouse)
+--------------------------------------------------------------------
+
+        + MD_CC_DRAW (new mouse-draw sub-mode) -- with a CCizer slot
+          armed via Ctrl+Shift+§, Shift+§ enters Pattern Editor's
+          mouse-draw mode straight into MD_CC_DRAW. Click+drag inside
+          the pattern data area writes the armed slot's effect into
+          each crossed row: 'S<cc><val>' for CC slots, 'W<14bit>' for
+          PB slots. Value comes from the mouse X position within the
+          row's track width (0..0x7F mapped 0..fullwidth). Drawing
+          one parameter at a time without typing every byte is the
+          whole point -- "draw and see and draw and see" workflow
+          Esa described, mouse edition.
+
+        * src/CUI_Page.h -- new enum constant MD_CC_DRAW between
+          MD_FX_SIGNED and MD_END. TAB in mouse-draw mode cycles
+          through it only when a slot is armed; otherwise TAB skips
+          past it (the mode is useless without an armed slot's CC#
+          to write).
+
+        * src/CUI_Patterneditor.cpp -- the mouse handler in PEM_MOUSEDRAW
+          now branches MD_CC_DRAW into an S/W effect writer keyed off
+          the armed slot's CC# / PB-marker. The per-row bar renderer
+          (disp_gfxeffect_pattern) shows the bar only for rows whose
+          existing event matches the armed CC -- bars for unrelated
+          CCs aren't shown, so the drawn pattern reflects the armed
+          parameter and nothing else.
+
+        ! Playback already dispatches 'S' as MIDI CC and 'W' as
+          pitchwheel via ET_CC / ET_PITCH (playback.cpp:1471, 1491).
+          Drawn drawbars therefore play back as MIDI CCs out the
+          configured device with no further wiring.
+
 zt 2026_05_12 (CC Drawmode: cycle through CCizer slots + Shortcuts rebind)
 --------------------------------------------------------------------------
 

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -23,6 +23,45 @@ zt 2026_05_12 (All 7 hand-tuned palettes: regenerate from Schism's IT data)
           / Gold (Vintage) / FX 2.0 / Atlantic / Acid Gas / Hotdog
           Stand) were already imported from Schism on a prior pass
           and were left unchanged.
+zt 2026_05_12 (CC Drawmode: cycle through CCizer slots + Shortcuts rebind)
+--------------------------------------------------------------------------
+
+        * src/main.cpp + src/zt.h -- g_cc_drawmode is now a 1-based
+          slot index instead of a binary on/off. The new toggler
+          zt_advance_cc_drawmode() cycles 0 -> 1 -> 2 -> ... -> N -> 0
+          through the currently-loaded CCizer file's slots (the file
+          loaded via Shift+F3). While slot K is armed, only that
+          slot's CC# (or PB) is captured -- other incoming CCs are
+          dropped, so the user can arm a single physical knob and
+          draw one parameter at a time without crosstalk from idle
+          knobs on the same controller.
+
+        * src/CUI_Patterneditor.cpp -- the MIDI-in handler now
+          filters incoming 0xB0 / 0xE0 by the armed slot's CC# /
+          PB-marker. The keypath (formerly a literal Ctrl+Shift+§
+          test) now goes through g_keybindings.match() so the action
+          is user-remappable via the unified Shortcuts page
+          (Shift+F2).
+
+        * src/keybindings.{h,cpp} -- new action
+          ZT_ACTION_TOGGLE_CC_DRAWMODE with default Ctrl+Shift+§.
+          Shows up in the Shortcuts list as "Cycle CC Drawmode
+          (off/slot N)" so users on layouts where the historic combo
+          is awkward can rebind it.
+
+        * src/CUI_MainMenu.cpp -- the ESC menu entry "Toggle CC
+          Drawmode" is renamed to "Cycle CC Drawmode" and now
+          delegates to zt_advance_cc_drawmode().
+
+        * src/CUI_Patterneditor.cpp -- the persistent badge no longer
+          just says "[CC DRAW]" but "[CC DRAW slot 3/8: CC74 Cutoff]"
+          so the user always knows which physical knob is live
+          without scrolling the status line.
+
+        ! Manual drawbar entry (drawing CC curves with the mouse /
+          keyboard without a physical controller, plus playback
+          sending those CCs out) is a separate followup -- this PR
+          covers the incoming-CC-filter and rebind workflow only.
 
 zt 2026_05_12 (CHANGELOG: union-merge to stop the line-7 PR conflict mill)
 --------------------------------------------------------------------------

--- a/src/CUI_MainMenu.cpp
+++ b/src/CUI_MainMenu.cpp
@@ -171,14 +171,9 @@ static void mm_quit(void) {
 }
 
 static void mm_toggle_cc_drawmode(void) {
-    // Use the shared toggler in zt.h so the undo-session marker resets
-    // too -- a bare g_cc_drawmode = !g_cc_drawmode would skip the reset
-    // and leave the next drawmode-on session unsnapped (audit H2).
-    zt_toggle_cc_drawmode();
-    snprintf(szStatmsg, sizeof(szStatmsg), "CC drawmode: %s",
-             g_cc_drawmode ? "ON  (incoming CC writes S/W effects)" : "OFF");
-    statusmsg = szStatmsg;
-    status_change = 1;
+    // Shared cycle in main.cpp resets the undo-session marker and writes
+    // its own slot summary into statusmsg.
+    zt_advance_cc_drawmode();
 }
 
 // Build a CLI invocation string that re-launches zt with the same
@@ -275,7 +270,7 @@ static const mm_entry MM_ENTRIES[] = {
     {MM_CMD,        "Shortcuts & MIDI Mappings","Shift+F2",             CMD_SWITCH_KEYBINDINGS,     NULL},
     {MM_CMD,        "Paketti CCizer",           "Shift+F3",             CMD_SWITCH_CCCONSOLE,       NULL},
     {MM_CMD,        "SysEx Librarian",          "Shift+F5",             CMD_SWITCH_SYSEX_LIB,       NULL},
-    {MM_FUNC,       "Toggle CC Drawmode",       "Ctrl+Shift+\xA7",      0,                          mm_toggle_cc_drawmode},
+    {MM_FUNC,       "Cycle CC Drawmode",        "Ctrl+Shift+\xA7",      0,                          mm_toggle_cc_drawmode},
     {MM_CMD,        "Lua Console",              "Ctrl+Alt+L",           CMD_SWITCH_LUA_CONSOLE,     NULL},
     {MM_FUNC,       "Toggle Fullscreen",        "Alt+Enter",            0,                          mm_toggle_fullscreen},
 

--- a/src/CUI_Page.h
+++ b/src/CUI_Page.h
@@ -344,7 +344,7 @@ class CUI_Logoscreen : public CUI_Page {
 };
 
 enum { PEM_REGULARKEYS, PEM_MOUSEDRAW };
-enum { MD_VOL=0, MD_FX, MD_FX_SIGNED, MD_END};
+enum { MD_VOL=0, MD_FX, MD_FX_SIGNED, MD_CC_DRAW, MD_END};
 
 class CUI_Patterneditor : public CUI_Page {
     public:

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -526,7 +526,40 @@ void disp_gfxeffect_pattern(int tracks_shown, int field_size, int cols_shown, Dr
         datamax = 0x7F;
 
         break;
-      } 
+
+      case MD_CC_DRAW:
+        // Drawbar bar shows the S/W effect's value for the armed CC
+        // slot. Render nothing (0) when the row's event isn't tied
+        // to the armed CC -- otherwise stale bars from other CCs
+        // would create a misleading "I drew that" impression.
+        {
+          ZtCcizerFile *cf_disp = zt_ccizer_current_file();
+          int si = UIP_Patterneditor && UIP_Patterneditor->md_mode == MD_CC_DRAW
+                       ? (g_cc_drawmode - 1) : -1;
+          if (si >= 0 && cf_disp && si < cf_disp->num_slots) {
+            const ZtCcizerSlot *as = &cf_disp->slots[si];
+            if (as->cc == ZT_CCIZER_PB_MARKER) {
+              if (e->effect == 'W') {
+                // Compress 14-bit PB back to 0..0x7F for the bar.
+                data = (e->effect_data >> 7) & 0x7F;
+              } else {
+                data = 0;
+              }
+            } else {
+              if (e->effect == 'S'
+                  && (unsigned char)((e->effect_data >> 8) & 0xFF) == as->cc) {
+                data = e->effect_data & 0x7F;
+              } else {
+                data = 0;
+              }
+            }
+          } else {
+            data = 0;
+          }
+          datamax = 0x7F;
+        }
+        break;
+      }
 
 
       switch(UIP_Patterneditor->md_mode)
@@ -1285,10 +1318,38 @@ void CUI_Patterneditor::update()
         }
         else {
           mode = PEM_MOUSEDRAW;
+          // If the user enters mouse-draw mode while a CCizer slot is
+          // armed, jump straight to MD_CC_DRAW so the natural workflow
+          // ("cycle to slot K, draw the drawbar") doesn't require a
+          // separate TAB press. The user can still TAB back to MD_VOL
+          // etc. for non-CC drawing.
+          if (g_cc_drawmode > 0 && md_mode != MD_CC_DRAW) {
+            md_mode = MD_CC_DRAW;
+          }
           switch(md_mode) {
           case MD_VOL:       statusmsg = "Editing: Volume"; break;
           case MD_FX:        statusmsg = "Editing: Effect low-byte (0-0x7F)"; break;
           case MD_FX_SIGNED: statusmsg = "Editing: Effect low-byte signed (0-0x7F)"; break;
+          case MD_CC_DRAW: {
+            static char ccdraw_msg[96];
+            ZtCcizerFile *cf = zt_ccizer_current_file();
+            int si = g_cc_drawmode - 1;
+            if (g_cc_drawmode > 0 && cf && si < cf->num_slots) {
+              const ZtCcizerSlot *s = &cf->slots[si];
+              if (s->cc == ZT_CCIZER_PB_MARKER) {
+                snprintf(ccdraw_msg, sizeof(ccdraw_msg),
+                         "Editing: drag = PB drawbar (%s)", s->name);
+              } else {
+                snprintf(ccdraw_msg, sizeof(ccdraw_msg),
+                         "Editing: drag = CC%d drawbar (%s)",
+                         (int)s->cc, s->name);
+              }
+              statusmsg = ccdraw_msg;
+            } else {
+              statusmsg = "Editing: drag = CC drawbar (no slot armed -- cycle CC Drawmode first)";
+            }
+            break;
+          }
           default:           statusmsg = "Editing: Volume"; break;
           }
         }
@@ -1420,6 +1481,16 @@ void CUI_Patterneditor::update()
           md_mode++;
           if (md_mode>=MD_END)
             md_mode = 0;
+          // MD_CC_DRAW is only useful when a CCizer slot is armed
+          // (otherwise we have nothing to write into the effect's
+          // high byte). Skip past it on the TAB cycle when drawmode
+          // is off; the dedicated entry path in the Shift+§ handler
+          // above still drops the user into MD_CC_DRAW directly if
+          // they had a slot armed before entering mouse-draw.
+          if (md_mode == MD_CC_DRAW && g_cc_drawmode <= 0) {
+            md_mode++;
+            if (md_mode>=MD_END) md_mode = 0;
+          }
           need_refresh++;
           break;
 
@@ -1495,7 +1566,28 @@ void CUI_Patterneditor::update()
         case MD_FX:
           statusmsg = "Editing: Effect low-byte (0-0x7F)";
           break;
-      
+
+        case MD_CC_DRAW: {
+          static char ccdraw_msg2[96];
+          ZtCcizerFile *cf2 = zt_ccizer_current_file();
+          int si2 = g_cc_drawmode - 1;
+          if (g_cc_drawmode > 0 && cf2 && si2 < cf2->num_slots) {
+            const ZtCcizerSlot *s2 = &cf2->slots[si2];
+            if (s2->cc == ZT_CCIZER_PB_MARKER) {
+              snprintf(ccdraw_msg2, sizeof(ccdraw_msg2),
+                       "Editing: drag = PB drawbar (%s)", s2->name);
+            } else {
+              snprintf(ccdraw_msg2, sizeof(ccdraw_msg2),
+                       "Editing: drag = CC%d drawbar (%s)",
+                       (int)s2->cc, s2->name);
+            }
+            statusmsg = ccdraw_msg2;
+          } else {
+            statusmsg = "Editing: drag = CC drawbar (no slot armed)";
+          }
+          break;
+        }
+
         case MD_FX_SIGNED:
           statusmsg = "Editing: Effect low-byte signed (0-0x7F)";
           break;
@@ -3734,6 +3826,7 @@ wrap:;
               break;
             case MD_FX:
             case MD_FX_SIGNED:
+            case MD_CC_DRAW:
               data = 0x0;
               break;
             }
@@ -3747,22 +3840,54 @@ wrap:;
           y+=cur_edit_row_disp;
           switch(md_mode) {
           case MD_VOL:
-            if (e->vol == data && mousedrawing==1) 
+            if (e->vol == data && mousedrawing==1)
               goto nevermind;
             song->patterns[cur_edit_pattern]->tracks[track]->update_event(y,-1,-1,data,-1,-1,-1);
             break;
           case MD_FX:
             data += (e->effect_data&0xFF00);
-            if (e->effect_data == data && mousedrawing==1) 
+            if (e->effect_data == data && mousedrawing==1)
               goto nevermind;
             song->patterns[cur_edit_pattern]->tracks[track]->update_event(y,-1,-1,-1,-1,-1,data);
             break;
           case MD_FX_SIGNED:
             data += (e->effect_data&0xFF00);
-            if (e->effect_data == data && mousedrawing==1) 
+            if (e->effect_data == data && mousedrawing==1)
               goto nevermind;
             song->patterns[cur_edit_pattern]->tracks[track]->update_event(y,-1,-1,-1,-1,-1,data);
             break;
+          case MD_CC_DRAW: {
+            // Drawbar mode: write the full S/W effect (type + data)
+            // using the armed CCizer slot's CC# (or PB marker).
+            // X-position in the row drives the value (0..0x7F for CC,
+            // scaled to 14-bit 0..0x3FFF for PB).
+            ZtCcizerFile *cf = zt_ccizer_current_file();
+            int si = g_cc_drawmode - 1;
+            if (g_cc_drawmode <= 0 || !cf || si >= cf->num_slots) {
+              // Slot evaporated mid-drag. Skip this row -- no write,
+              // no advance. The next ON-cycle will re-arm.
+              goto nevermind;
+            }
+            const ZtCcizerSlot *s = &cf->slots[si];
+            unsigned short eff_data;
+            char eff_type;
+            if (s->cc == ZT_CCIZER_PB_MARKER) {
+              // Pitchbend: scale the 0..0x7F drag value to 14-bit.
+              // (data << 7) gives 0..0x3F80 which spans most of the
+              // PB range; close enough for drawbar work without
+              // needing a 14-bit drag widget.
+              eff_data = (unsigned short)(data << 7);
+              if (eff_data > 0x3FFF) eff_data = 0x3FFF;
+              eff_type = 'W';
+            } else {
+              eff_data = (unsigned short)(((unsigned)s->cc << 8) | (unsigned)data);
+              eff_type = 'S';
+            }
+            if (e->effect == eff_type && e->effect_data == eff_data && mousedrawing==1)
+              goto nevermind;
+            song->patterns[cur_edit_pattern]->tracks[track]->update_event(y,-1,-1,-1,-1,eff_type,eff_data);
+            break;
+          }
           }
           upd_e = song->patterns[cur_edit_pattern]->tracks[track]->get_event(y);
           m_upd++; 

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -1,6 +1,7 @@
 #include "zt.h"
 #include "platform/undo.h"
 #include "ccizer.h"
+#include "keybindings.h"
 
 // KS_META stub for Cmd key support (SDL3 maps macOS Cmd to SDL_KMOD_GUI).
 // Currently keybuffer does not translate GUI -> KS_META, so KS_META is a
@@ -1734,17 +1735,19 @@ void CUI_Patterneditor::update()
           key = 0;
         }
 
-        // CC drawmode toggle: Ctrl+Shift+§ (GRAVE). Plain Shift+§ is the
-        // existing PEM_MOUSEDRAW toggle (handled above); we use the
-        // Ctrl-extended combo so both gestures coexist. While CC drawmode
-        // is on, the MIDI-in handler below intercepts incoming CC (0xB0)
-        // and Pitchbend (0xE0) messages and writes Sxxyy / Wxxxx effects
-        // at the cursor row.
-        if ((kstate & KS_CTRL) && (kstate & KS_SHIFT) && key == SDLK_GRAVE) {
-          zt_toggle_cc_drawmode();        // shared with ESC menu (audit H2)
+        // CC drawmode cycle. Default Ctrl+Shift+§ (the historic combo);
+        // user-remappable via Shift+F2. Plain Shift+§ is the existing
+        // PEM_MOUSEDRAW toggle (handled above); we use the Ctrl-extended
+        // combo so both gestures coexist. Each press advances the cycle
+        // 0 -> slot 1 -> slot 2 -> ... -> slot N -> 0 through the
+        // currently-loaded CCizer file (see Shift+F3). While a slot is
+        // active, only that slot's CC# (or PB) is captured -- other CCs
+        // are dropped, so a single physical knob/slider can be "armed"
+        // and the user draws one parameter at a time without crosstalk.
+        if (g_keybindings.match(key, kstate) == ZT_ACTION_TOGGLE_CC_DRAWMODE) {
+          zt_advance_cc_drawmode();       // shared with ESC menu (audit H2)
           midiInQueue.clear();
-          sprintf(szStatmsg, "CC drawmode: %s", g_cc_drawmode ? "ON  (incoming CC writes S/W effects)" : "OFF");
-          statusmsg = szStatmsg; status_change = 1; need_refresh++; key = 0;
+          need_refresh++; key = 0;
         }
 
         // Double Pattern: Ctrl+Shift+G
@@ -3229,29 +3232,59 @@ case SDLK_DELETE:
               // at the cursor row in the current edit track. Cursor advances
               // by EditStep (step-follow). When drawmode is OFF the message
               // falls through to the legacy 0x80/0x90 jazz-recording path.
-              if (g_cc_drawmode && (hi == 0xB0 || hi == 0xE0)) {
+              //
+              // FILTERING: g_cc_drawmode > 0 names a 1-based slot index in
+              // the current CCizer file. Only the slot's CC# (or PB) is
+              // captured -- other incoming CCs are dropped so a single
+              // physical knob can be "armed" while drawing one parameter
+              // at a time.
+              // Filter test: are we armed AND does the incoming message
+              // match the active slot? (Pulled out of the big if so the
+              // drop-path can short-circuit cleanly without `continue`,
+              // which the surrounding scope is not a loop.)
+              bool drawmode_armed_match = false;
+              bool drawmode_drop = false;
+              if (g_cc_drawmode > 0 && (hi == 0xB0 || hi == 0xE0)) {
+                ZtCcizerFile *cf_filter = zt_ccizer_current_file();
+                int slot_idx = g_cc_drawmode - 1;
+                if (cf_filter && slot_idx < cf_filter->num_slots) {
+                  const ZtCcizerSlot *active = &cf_filter->slots[slot_idx];
+                  int d1 = (dw >> 8) & 0x7F;
+                  if (active->cc == ZT_CCIZER_PB_MARKER) {
+                    drawmode_armed_match = (hi == 0xE0);
+                  } else {
+                    drawmode_armed_match = (hi == 0xB0 && (unsigned char)d1 == active->cc);
+                  }
+                }
+                // Either we have no CCizer file, the slot index is
+                // stale, or the incoming CC doesn't match the armed
+                // slot. Drop with no row write / no cursor advance /
+                // no status churn so unrelated knobs don't pollute
+                // the pattern.
+                drawmode_drop = !drawmode_armed_match;
+              }
+              if (drawmode_drop) {
+                set_note = 0xFF;
+                p1 = -1;
+              } else if (drawmode_armed_match) {
                 int data1 = (dw >> 8)  & 0x7F;
                 int data2 = (dw >> 16) & 0x7F;
+                ZtCcizerFile *cf = zt_ccizer_current_file();
+                const ZtCcizerSlot *active = &cf->slots[g_cc_drawmode - 1];
                 // Snapshot the pattern before the first write of this
                 // drawmode session so the user can undo a knob run with
-                // a single Ctrl+Z. The session marker is reset by the
-                // Ctrl+Shift+§ toggler itself (above) whenever drawmode
-                // flips on/off, so each ON->...->OFF span generates one
+                // a single Ctrl+Z. The session marker is reset by
+                // zt_advance_cc_drawmode() whenever the cycle advances,
+                // so each "armed -> draw -> advance" span generates one
                 // undo step.
                 if (!g_cc_draw_session_snapped) {
                     UNDO_SAVE();
                     g_cc_draw_session_snapped = 1;
                 }
-                // Look up the friendly slot name from the currently-loaded
-                // CCizer file (if any) — matches by learn binding so we
-                // get "Cutoff" instead of "CC 74" in the status line.
-                const char *slot_name = NULL;
-                ZtCcizerFile *cf = zt_ccizer_current_file();
-                if (cf) {
-                  int m = zt_ccizer_find_learn_match(
-                      cf, status, (hi == 0xE0) ? 0 : (unsigned char)data1);
-                  if (m >= 0) slot_name = cf->slots[m].name;
-                }
+                // Use the active slot's name directly for the status
+                // line -- we already know which slot is armed, no need
+                // to learn-match against the incoming bytes.
+                const char *slot_name = active->name;
                 if (hi == 0xB0) {
                   // S<cc>:<val>  ->  effect 'S', effect_data = (cc<<8) | val
                   unsigned short eff_data = (unsigned short)((data1 << 8) | data2);
@@ -3791,11 +3824,30 @@ void CUI_Patterneditor::draw(Drawable *S)
 
     printtitle(PAGE_TITLE_ROW_Y,"Pattern Editor (F2)",COLORS.Text,COLORS.Background,S);
 
-    // Persistent CC drawmode badge — easy to forget the toggle is on
-    // since the toggle's status message scrolls past. Right-aligned on
+    // Persistent CC drawmode badge — easy to forget the cycle is armed
+    // since the advance-status message scrolls past. Right-aligned on
     // the title row so it doesn't fight with the pattern data area.
-    if (g_cc_drawmode) {
-      const char *badge = "[CC DRAW] (Ctrl+Shift+\xA7 toggles)";
+    // Shows the armed slot's CC# + name so the user always knows which
+    // physical knob is "live".
+    if (g_cc_drawmode > 0) {
+      char badge[96];
+      ZtCcizerFile *cf = zt_ccizer_current_file();
+      int slot_idx = g_cc_drawmode - 1;
+      if (cf && slot_idx < cf->num_slots) {
+        const ZtCcizerSlot *s = &cf->slots[slot_idx];
+        if (s->cc == ZT_CCIZER_PB_MARKER) {
+          snprintf(badge, sizeof(badge), "[CC DRAW slot %d/%d: PB %s]",
+                   g_cc_drawmode, cf->num_slots, s->name);
+        } else {
+          snprintf(badge, sizeof(badge), "[CC DRAW slot %d/%d: CC%d %s]",
+                   g_cc_drawmode, cf->num_slots, (int)s->cc, s->name);
+        }
+      } else {
+        // Stale slot index (file changed under us). Still flag the
+        // mode is on so the user can advance once to re-arm.
+        snprintf(badge, sizeof(badge), "[CC DRAW slot %d -- stale, advance to re-arm]",
+                 g_cc_drawmode);
+      }
       int badge_len = (int)strlen(badge);
       int x_col = CHARS_X - badge_len - 2;
       if (x_col < 2) x_col = 2;

--- a/src/keybindings.cpp
+++ b/src/keybindings.cpp
@@ -78,6 +78,7 @@ static const char* const s_actionNames[ZT_ACTION_COUNT] = {
     "rotate_up",            // ZT_ACTION_ROTATE_UP
     "note_audition",        // ZT_ACTION_NOTE_AUDITION
     "row_audition",         // ZT_ACTION_ROW_AUDITION
+    "toggle_cc_drawmode",   // ZT_ACTION_TOGGLE_CC_DRAWMODE
 };
 
 // Same length as s_actionNames; rendered in the Shortcuts & MIDI
@@ -131,6 +132,7 @@ static const char* const s_actionDescriptions[ZT_ACTION_COUNT] = {
     "Rotate selection up",                 // ZT_ACTION_ROTATE_UP
     "Audition current note (4)",           // ZT_ACTION_NOTE_AUDITION
     "Audition current row (8)",            // ZT_ACTION_ROW_AUDITION
+    "Cycle CC Drawmode (off/slot N)",      // ZT_ACTION_TOGGLE_CC_DRAWMODE
 };
 
 const char* KeyBindings::actionName(ZtAction action)
@@ -221,6 +223,12 @@ void KeyBindings::setDefaults()
     // MIDI mapping column.
     bindings[ZT_ACTION_NOTE_AUDITION]        = { SDLK_4,           0 };
     bindings[ZT_ACTION_ROW_AUDITION]         = { SDLK_8,           0 };
+
+    // CC Drawmode cycle -- preserve the historic Ctrl+Shift+§ default.
+    // SDLK_GRAVE because the keyhandler in main.cpp remaps the Finnish
+    // ISO § scancode to SDLK_GRAVE before key dispatch. Users on
+    // layouts where this combo is awkward can rebind here.
+    bindings[ZT_ACTION_TOGGLE_CC_DRAWMODE]   = { SDLK_GRAVE,       KS_CTRL | KS_SHIFT };
 }
 
 // -----------------------------------------------------------------------

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -66,6 +66,12 @@ enum ZtAction {
     ZT_ACTION_NOTE_AUDITION,
     ZT_ACTION_ROW_AUDITION,
 
+    // CC Drawmode -- cycles OFF -> slot 1 -> slot 2 -> ... -> slot N -> OFF
+    // through the current CCizer file's slots. Default Ctrl+Shift+§; remap
+    // via the Shortcuts page if your keyboard layout makes that combo
+    // awkward.
+    ZT_ACTION_TOGGLE_CC_DRAWMODE,
+
     ZT_ACTION_COUNT
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,7 @@
 #include "save_key_dispatch.h"
 #include "zt_crash.h"
 #include "midi_mappings.h"
+#include "ccizer.h"
 
 #ifdef __APPLE__
 extern "C" void zt_macos_disable_cmd_q(void);
@@ -353,6 +354,58 @@ CUI_CcConsole *UIP_CcConsole = NULL;
 CUI_SysExLibrarian *UIP_SysExLibrarian = NULL;
 int g_cc_drawmode = 0;
 int g_cc_draw_session_snapped = 0;
+
+// Cycle CC drawmode: 0 -> 1 -> 2 -> ... -> N -> 0, where N is the
+// currently-loaded CCizer file's slot count. When no file is loaded
+// (or it has zero slots) the cycle collapses to 0 -> 0 and the status
+// line nags the user to load one.
+//
+// Reasoning behind picking "per-slot CC filter" instead of the old
+// binary on/off: with the old behaviour, any incoming CC (from any
+// knob) wrote a Sxxyy at the cursor, so drawing multiple parameters
+// one at a time required the user to also be careful with which
+// physical control they were touching. Per-slot filtering means a
+// single knob/slider is "armed" -- you turn it, see the row, advance
+// the cycle, arm the next one, etc. The "draw and see and draw and
+// see" workflow Esa described.
+int zt_advance_cc_drawmode(void)
+{
+    g_cc_draw_session_snapped = 0;
+    ZtCcizerFile *cf = zt_ccizer_current_file();
+    int max_slot = (cf != NULL) ? cf->num_slots : 0;
+
+    if (max_slot <= 0) {
+        // No CCizer file loaded. Cycle stays at 0 and we tell the
+        // user where to load one.
+        g_cc_drawmode = 0;
+        snprintf(szStatmsg, sizeof(szStatmsg),
+                 "CC drawmode: load a CCizer file first (Shift+F3)");
+        statusmsg = szStatmsg;
+        status_change = 1;
+        return 0;
+    }
+
+    g_cc_drawmode++;
+    if (g_cc_drawmode > max_slot) g_cc_drawmode = 0;
+
+    if (g_cc_drawmode == 0) {
+        snprintf(szStatmsg, sizeof(szStatmsg), "CC drawmode: OFF");
+    } else {
+        const ZtCcizerSlot *s = &cf->slots[g_cc_drawmode - 1];
+        if (s->cc == ZT_CCIZER_PB_MARKER) {
+            snprintf(szStatmsg, sizeof(szStatmsg),
+                     "CC drawmode: slot %d/%d -- PB (%s)",
+                     g_cc_drawmode, max_slot, s->name);
+        } else {
+            snprintf(szStatmsg, sizeof(szStatmsg),
+                     "CC drawmode: slot %d/%d -- CC %d (%s)",
+                     g_cc_drawmode, max_slot, (int)s->cc, s->name);
+        }
+    }
+    statusmsg = szStatmsg;
+    status_change = 1;
+    return g_cc_drawmode;
+}
 
 
 

--- a/src/zt.h
+++ b/src/zt.h
@@ -708,28 +708,38 @@ extern int base_octave ;
 extern int cur_step;
 
 // CC drawmode -- when non-zero, the Pattern Editor's MIDI-in handler
-// captures incoming CC (0xB0) and Pitchbend (0xE0) messages and writes
-// them as `Sxxyy` (CC) / `Wxxxx` (PB) effects at the cursor row in the
-// current edit track, advancing the cursor by EditStep. Toggle with
-// Ctrl+Shift+§ from the Pattern Editor or from the ESC main menu.
+// captures incoming CC (0xB0) / Pitchbend (0xE0) messages matching the
+// active CCizer slot and writes them as `Sxxyy` (CC) / `Wxxxx` (PB)
+// effects at the cursor row in the current edit track, advancing the
+// cursor by EditStep.
+//
+// Semantics:
+//   0   = OFF (no capture)
+//   1..N = active slot index (1-based) in the currently-loaded CCizer
+//          file. Only the slot's CC# (or PB) is captured; other CCs
+//          are ignored, letting you draw one parameter at a time
+//          without crosstalk from other knobs.
+//
+// Cycle via the Shortcuts action ZT_ACTION_TOGGLE_CC_DRAWMODE
+// (default Ctrl+Shift+§) or the ESC main menu. Each press advances
+// 0 -> 1 -> ... -> N -> 0.
 extern int g_cc_drawmode;
 
-// Reset to 0 every time CC drawmode flips state, then set to 1 by the
-// first drawmode write so each ON->...->OFF span generates exactly one
-// UNDO_SAVE() snapshot. Lifted out of CUI_Patterneditor.cpp file-static
-// scope so the ESC menu's mm_toggle_cc_drawmode can reset it too --
-// otherwise toggling drawmode via the menu instead of the keypath
-// leaves the marker stale and the next session's first knob tweak is
-// unsnapped (no Ctrl+Z recovery). See audit H2.
+// Reset to 0 every time CC drawmode advances, then set to 1 by the
+// first drawmode write so each session-while-non-zero generates exactly
+// one UNDO_SAVE() snapshot. Lifted out of CUI_Patterneditor.cpp
+// file-static scope so the ESC menu and the Shortcuts dispatcher can
+// reset it too -- otherwise cycling drawmode via a path other than the
+// keypath leaves the marker stale and the next session's first knob
+// tweak is unsnapped (no Ctrl+Z recovery). See audit H2.
 extern int g_cc_draw_session_snapped;
 
-// Single toggler called from both the Pattern Editor keypath
-// (Ctrl+Shift+§) and the ESC menu entry (mm_toggle_cc_drawmode), so
-// session-marker reset can't drift between the two callers.
-static inline void zt_toggle_cc_drawmode(void) {
-    g_cc_drawmode = !g_cc_drawmode;
-    g_cc_draw_session_snapped = 0;
-}
+// Advance CC drawmode by one step in the cycle. Called from the
+// Pattern Editor keypath, the ESC menu, and the Shortcuts dispatcher,
+// so session-marker reset + slot-count lookup can't drift between the
+// callers. Writes a human-readable summary into szStatmsg / statusmsg.
+// Returns the new g_cc_drawmode value.
+int zt_advance_cc_drawmode(void);
 
 extern int keypress;
 extern int keywait;


### PR DESCRIPTION
## Summary

Two changes in response to Esa's report ("no way of entering the Midi CC draw mode … the toggle should now actually jump through the different CC so i can draw and see and draw and see"):

### 1. Cycle semantics

`g_cc_drawmode` is no longer a binary on/off — it's a 1-based slot index into the currently-loaded CCizer file (loaded via Shift+F3). The new `zt_advance_cc_drawmode()` cycles `0 → 1 → 2 → … → N → 0`.

While slot K is armed, only that slot's CC# (or PB) is captured — other incoming CCs are dropped, so the user can arm a single knob and draw one parameter at a time without crosstalk from idle knobs on the same controller.

The persistent badge in the title row now reads `[CC DRAW slot 3/8: CC74 Cutoff]` so the armed knob is always visible.

### 2. Rebindable keybind

New `ZT_ACTION_TOGGLE_CC_DRAWMODE` in the unified Shortcuts table, default `Ctrl+Shift+§`. Users on layouts where the historic combo is awkward (any non-Finnish-ISO keyboard) can now rebind via Shift+F2. The Pattern Editor keypath uses `g_keybindings.match()` instead of the literal `Ctrl+Shift+GRAVE` test it used previously.

## Files

- `src/zt.h` + `src/main.cpp` — slot semantics, `zt_advance_cc_drawmode()`
- `src/keybindings.{h,cpp}` — new action with default binding
- `src/CUI_Patterneditor.cpp` — keypath via `g_keybindings.match()`, MIDI-in filter, slot badge
- `src/CUI_MainMenu.cpp` — ESC menu entry renamed "Cycle CC Drawmode", delegates to advance
- `doc/CHANGELOG.txt` — entry

## Out of scope

Manual drawbar entry — drawing CC curves with the mouse/keyboard without a physical controller, plus playback sending those CCs out. Separate followup. Per Esa: "its cool that you make it so that incoming CC will control, but i was hoping to be able to draw drawbars with different CC and have the playback send the CC."

## Test plan

- [x] `cmake -G "Unix Makefiles" .. && make -j8` clean on macOS arm64
- [x] All 10 `ctest` suites pass (preset / selector / page_sync / save_key / keybuffer / ccizer / sysex_inq / sysex_stress / sysex_macro / ccbn_roundtrip)
- [ ] Boot zt, Shift+F3 → load a CCizer file (e.g. assets/ccizer/sc88st.txt), F2 → press Ctrl+Shift+§ → badge shows slot 1's CC name; press again → slot 2; press again → … → wraps to OFF
- [ ] With slot 1 armed, twiddle the controller's CC for slot 2 — pattern stays untouched. Twiddle slot 1's actual CC — row gets `Sxxyy` written and cursor advances
- [ ] Shift+F2 → confirm "Cycle CC Drawmode (off/slot N)" is listed and rebindable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
