### PR TITLE
CC Drawmode: drag-to-draw CC drawbars with the mouse (MD_CC_DRAW)

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,39 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_05_12 (CC Drawmode: drag-to-draw CC drawbars with the mouse)
+--------------------------------------------------------------------
+
+        + MD_CC_DRAW (new mouse-draw sub-mode) -- with a CCizer slot
+          armed via Ctrl+Shift+§, Shift+§ enters Pattern Editor's
+          mouse-draw mode straight into MD_CC_DRAW. Click+drag inside
+          the pattern data area writes the armed slot's effect into
+          each crossed row: 'S<cc><val>' for CC slots, 'W<14bit>' for
+          PB slots. Value comes from the mouse X position within the
+          row's track width (0..0x7F mapped 0..fullwidth). Drawing
+          one parameter at a time without typing every byte is the
+          whole point -- "draw and see and draw and see" workflow
+          Esa described, mouse edition.
+
+        * src/CUI_Page.h -- new enum constant MD_CC_DRAW between
+          MD_FX_SIGNED and MD_END. TAB in mouse-draw mode cycles
+          through it only when a slot is armed; otherwise TAB skips
+          past it (the mode is useless without an armed slot's CC#
+          to write).
+
+        * src/CUI_Patterneditor.cpp -- the mouse handler in PEM_MOUSEDRAW
+          now branches MD_CC_DRAW into an S/W effect writer keyed off
+          the armed slot's CC# / PB-marker. The per-row bar renderer
+          (disp_gfxeffect_pattern) shows the bar only for rows whose
+          existing event matches the armed CC -- bars for unrelated
+          CCs aren't shown, so the drawn pattern reflects the armed
+          parameter and nothing else.
+
+        ! Playback already dispatches 'S' as MIDI CC and 'W' as
+          pitchwheel via ET_CC / ET_PITCH (playback.cpp:1471, 1491).
+          Drawn drawbars therefore play back as MIDI CCs out the
+          configured device with no further wiring.
+
 zt 2026_05_12 (CC Drawmode: cycle through CCizer slots + Shortcuts rebind)
 --------------------------------------------------------------------------
 

--- a/src/CUI_Page.h
+++ b/src/CUI_Page.h
@@ -344,7 +344,7 @@ class CUI_Logoscreen : public CUI_Page {
 };
 
 enum { PEM_REGULARKEYS, PEM_MOUSEDRAW };
-enum { MD_VOL=0, MD_FX, MD_FX_SIGNED, MD_END};
+enum { MD_VOL=0, MD_FX, MD_FX_SIGNED, MD_CC_DRAW, MD_END};
 
 class CUI_Patterneditor : public CUI_Page {
     public:

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -526,7 +526,40 @@ void disp_gfxeffect_pattern(int tracks_shown, int field_size, int cols_shown, Dr
         datamax = 0x7F;
 
         break;
-      } 
+
+      case MD_CC_DRAW:
+        // Drawbar bar shows the S/W effect's value for the armed CC
+        // slot. Render nothing (0) when the row's event isn't tied
+        // to the armed CC -- otherwise stale bars from other CCs
+        // would create a misleading "I drew that" impression.
+        {
+          ZtCcizerFile *cf_disp = zt_ccizer_current_file();
+          int si = UIP_Patterneditor && UIP_Patterneditor->md_mode == MD_CC_DRAW
+                       ? (g_cc_drawmode - 1) : -1;
+          if (si >= 0 && cf_disp && si < cf_disp->num_slots) {
+            const ZtCcizerSlot *as = &cf_disp->slots[si];
+            if (as->cc == ZT_CCIZER_PB_MARKER) {
+              if (e->effect == 'W') {
+                // Compress 14-bit PB back to 0..0x7F for the bar.
+                data = (e->effect_data >> 7) & 0x7F;
+              } else {
+                data = 0;
+              }
+            } else {
+              if (e->effect == 'S'
+                  && (unsigned char)((e->effect_data >> 8) & 0xFF) == as->cc) {
+                data = e->effect_data & 0x7F;
+              } else {
+                data = 0;
+              }
+            }
+          } else {
+            data = 0;
+          }
+          datamax = 0x7F;
+        }
+        break;
+      }
 
 
       switch(UIP_Patterneditor->md_mode)
@@ -1285,10 +1318,38 @@ void CUI_Patterneditor::update()
         }
         else {
           mode = PEM_MOUSEDRAW;
+          // If the user enters mouse-draw mode while a CCizer slot is
+          // armed, jump straight to MD_CC_DRAW so the natural workflow
+          // ("cycle to slot K, draw the drawbar") doesn't require a
+          // separate TAB press. The user can still TAB back to MD_VOL
+          // etc. for non-CC drawing.
+          if (g_cc_drawmode > 0 && md_mode != MD_CC_DRAW) {
+            md_mode = MD_CC_DRAW;
+          }
           switch(md_mode) {
           case MD_VOL:       statusmsg = "Editing: Volume"; break;
           case MD_FX:        statusmsg = "Editing: Effect low-byte (0-0x7F)"; break;
           case MD_FX_SIGNED: statusmsg = "Editing: Effect low-byte signed (0-0x7F)"; break;
+          case MD_CC_DRAW: {
+            static char ccdraw_msg[96];
+            ZtCcizerFile *cf = zt_ccizer_current_file();
+            int si = g_cc_drawmode - 1;
+            if (g_cc_drawmode > 0 && cf && si < cf->num_slots) {
+              const ZtCcizerSlot *s = &cf->slots[si];
+              if (s->cc == ZT_CCIZER_PB_MARKER) {
+                snprintf(ccdraw_msg, sizeof(ccdraw_msg),
+                         "Editing: drag = PB drawbar (%s)", s->name);
+              } else {
+                snprintf(ccdraw_msg, sizeof(ccdraw_msg),
+                         "Editing: drag = CC%d drawbar (%s)",
+                         (int)s->cc, s->name);
+              }
+              statusmsg = ccdraw_msg;
+            } else {
+              statusmsg = "Editing: drag = CC drawbar (no slot armed -- cycle CC Drawmode first)";
+            }
+            break;
+          }
           default:           statusmsg = "Editing: Volume"; break;
           }
         }
@@ -1420,6 +1481,16 @@ void CUI_Patterneditor::update()
           md_mode++;
           if (md_mode>=MD_END)
             md_mode = 0;
+          // MD_CC_DRAW is only useful when a CCizer slot is armed
+          // (otherwise we have nothing to write into the effect's
+          // high byte). Skip past it on the TAB cycle when drawmode
+          // is off; the dedicated entry path in the Shift+§ handler
+          // above still drops the user into MD_CC_DRAW directly if
+          // they had a slot armed before entering mouse-draw.
+          if (md_mode == MD_CC_DRAW && g_cc_drawmode <= 0) {
+            md_mode++;
+            if (md_mode>=MD_END) md_mode = 0;
+          }
           need_refresh++;
           break;
 
@@ -1495,7 +1566,28 @@ void CUI_Patterneditor::update()
         case MD_FX:
           statusmsg = "Editing: Effect low-byte (0-0x7F)";
           break;
-      
+
+        case MD_CC_DRAW: {
+          static char ccdraw_msg2[96];
+          ZtCcizerFile *cf2 = zt_ccizer_current_file();
+          int si2 = g_cc_drawmode - 1;
+          if (g_cc_drawmode > 0 && cf2 && si2 < cf2->num_slots) {
+            const ZtCcizerSlot *s2 = &cf2->slots[si2];
+            if (s2->cc == ZT_CCIZER_PB_MARKER) {
+              snprintf(ccdraw_msg2, sizeof(ccdraw_msg2),
+                       "Editing: drag = PB drawbar (%s)", s2->name);
+            } else {
+              snprintf(ccdraw_msg2, sizeof(ccdraw_msg2),
+                       "Editing: drag = CC%d drawbar (%s)",
+                       (int)s2->cc, s2->name);
+            }
+            statusmsg = ccdraw_msg2;
+          } else {
+            statusmsg = "Editing: drag = CC drawbar (no slot armed)";
+          }
+          break;
+        }
+
         case MD_FX_SIGNED:
           statusmsg = "Editing: Effect low-byte signed (0-0x7F)";
           break;
@@ -3734,6 +3826,7 @@ wrap:;
               break;
             case MD_FX:
             case MD_FX_SIGNED:
+            case MD_CC_DRAW:
               data = 0x0;
               break;
             }
@@ -3747,22 +3840,54 @@ wrap:;
           y+=cur_edit_row_disp;
           switch(md_mode) {
           case MD_VOL:
-            if (e->vol == data && mousedrawing==1) 
+            if (e->vol == data && mousedrawing==1)
               goto nevermind;
             song->patterns[cur_edit_pattern]->tracks[track]->update_event(y,-1,-1,data,-1,-1,-1);
             break;
           case MD_FX:
             data += (e->effect_data&0xFF00);
-            if (e->effect_data == data && mousedrawing==1) 
+            if (e->effect_data == data && mousedrawing==1)
               goto nevermind;
             song->patterns[cur_edit_pattern]->tracks[track]->update_event(y,-1,-1,-1,-1,-1,data);
             break;
           case MD_FX_SIGNED:
             data += (e->effect_data&0xFF00);
-            if (e->effect_data == data && mousedrawing==1) 
+            if (e->effect_data == data && mousedrawing==1)
               goto nevermind;
             song->patterns[cur_edit_pattern]->tracks[track]->update_event(y,-1,-1,-1,-1,-1,data);
             break;
+          case MD_CC_DRAW: {
+            // Drawbar mode: write the full S/W effect (type + data)
+            // using the armed CCizer slot's CC# (or PB marker).
+            // X-position in the row drives the value (0..0x7F for CC,
+            // scaled to 14-bit 0..0x3FFF for PB).
+            ZtCcizerFile *cf = zt_ccizer_current_file();
+            int si = g_cc_drawmode - 1;
+            if (g_cc_drawmode <= 0 || !cf || si >= cf->num_slots) {
+              // Slot evaporated mid-drag. Skip this row -- no write,
+              // no advance. The next ON-cycle will re-arm.
+              goto nevermind;
+            }
+            const ZtCcizerSlot *s = &cf->slots[si];
+            unsigned short eff_data;
+            char eff_type;
+            if (s->cc == ZT_CCIZER_PB_MARKER) {
+              // Pitchbend: scale the 0..0x7F drag value to 14-bit.
+              // (data << 7) gives 0..0x3F80 which spans most of the
+              // PB range; close enough for drawbar work without
+              // needing a 14-bit drag widget.
+              eff_data = (unsigned short)(data << 7);
+              if (eff_data > 0x3FFF) eff_data = 0x3FFF;
+              eff_type = 'W';
+            } else {
+              eff_data = (unsigned short)(((unsigned)s->cc << 8) | (unsigned)data);
+              eff_type = 'S';
+            }
+            if (e->effect == eff_type && e->effect_data == eff_data && mousedrawing==1)
+              goto nevermind;
+            song->patterns[cur_edit_pattern]->tracks[track]->update_event(y,-1,-1,-1,-1,eff_type,eff_data);
+            break;
+          }
           }
           upd_e = song->patterns[cur_edit_pattern]->tracks[track]->get_event(y);
           m_upd++; 


### PR DESCRIPTION
## Summary

Per Esa: *"its cool that you make it so that incoming CC will control, but i was hoping to be able to draw drawbars with different CC and have the playback send the CC."*

Playback already sends `S` as MIDI CC and `W` as pitchwheel (`playback.cpp:1471` and `:1491` → `ET_CC` / `ET_PITCH`), so the missing piece was the **editor-side drawing**. This PR adds a new mouse-draw sub-mode `MD_CC_DRAW` that writes the armed CCizer slot's effect into each row crossed by a click+drag inside the pattern data area.

## Workflow

1. `Shift+F3` → load a CCizer file (e.g. `assets/ccizer/sc88st.txt`).
2. `F2` → Pattern Editor.
3. `Ctrl+Shift+§` (or rebind via `Shift+F2`) → cycle CC Drawmode to slot K. Badge shows `[CC DRAW slot 3/8: CC74 Cutoff]`.
4. `Shift+§` → enter mouse-draw mode. Jumps straight into `MD_CC_DRAW` because slot is armed.
5. Click+drag inside the pattern → each crossed row gets `S<cc><val>` (CC slot) or `W<14bit>` (PB slot). Value from mouse X position scaled to 0..0x7F.
6. F5 / F6 / F7 plays back, and the configured MIDI device receives CCs in real time.

## Details

- `MD_CC_DRAW` slots into the existing `PEM_MOUSEDRAW` enum between `MD_FX_SIGNED` and `MD_END` (`CUI_Page.h`).
- `TAB` cycles through `MD_VOL → MD_FX → MD_FX_SIGNED → MD_CC_DRAW → back`, but skips `MD_CC_DRAW` when no slot is armed (it'd be useless without a CC# to put in the effect's high byte). Entering `Shift+§` with a slot armed jumps straight into `MD_CC_DRAW` so the user doesn't have to TAB.
- The per-row bar renderer (`disp_gfxeffect_pattern`) shows the bar **only for rows whose existing event matches the armed CC**. So if you drew CC74 earlier and now armed CC71, the old CC74 rows show no bar while you're armed on CC71 — the bars reflect the currently armed parameter only.
- PB slots scale the 0..0x7F drag value to 14-bit (`val << 7`) so pitchwheel covers most of the range. Close enough for drawbar work without needing a 14-bit drag widget.

## Stacking

Stacked on top of **#123** (slot cycle + filter) because it relies on `g_cc_drawmode`'s new slot-index semantics and `zt_ccizer_current_file()` lookups. Merge #123 first, then this rebases cleanly.

## Test plan

- [x] `make -j8` clean on macOS arm64
- [x] All 10 `ctest` suites pass (`preset` / `selector` / `page_sync` / `save_key` / `keybuffer` / `ccizer` / `sysex_inq` / `sysex_stress` / `sysex_macro` / `ccbn_roundtrip`)
- [ ] In-app: load a CCizer file, cycle to a CC slot, Shift+§, drag → rows get `S<cc><val>`; release; click another row at a different Y → that row updates too; bars match the drawn values
- [ ] Hit F5 → MIDI Out shows CCs streaming live with the drawn shape
- [ ] Arm a PB slot → drag writes `W<14bit>`; playback emits pitchwheel
- [ ] Disarm (cycle to OFF) → entering Shift+§ falls back to MD_VOL as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
