### PR TITLE
CI: bundle CCizer banks + SysEx examples in release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,8 @@ jobs:
           cp zt.conf                 dist/ztrackerprime-linux-x86_64/
           cp -R skins                dist/ztrackerprime-linux-x86_64/
           cp -R doc                  dist/ztrackerprime-linux-x86_64/
+          cp -R assets/ccizer        dist/ztrackerprime-linux-x86_64/
+          cp -R assets/syx           dist/ztrackerprime-linux-x86_64/
           # Ship libSDL3.so.0 next to the binary so the artifact is self-
           # contained -- the system apt does not yet provide SDL3.
           cp -a sdl3-prefix/lib/libSDL3.so*  dist/ztrackerprime-linux-x86_64/ || true
@@ -441,6 +443,8 @@ jobs:
           cp zt.conf                             dist/ztrackerprime-windows-x86-xp/
           cp -R skins                            dist/ztrackerprime-windows-x86-xp/
           cp -R doc                              dist/ztrackerprime-windows-x86-xp/
+          cp -R assets/ccizer                    dist/ztrackerprime-windows-x86-xp/
+          cp -R assets/syx                       dist/ztrackerprime-windows-x86-xp/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -541,6 +545,8 @@ jobs:
           Copy-Item zt.conf                    $dest
           Copy-Item skins -Recurse             $dest
           Copy-Item doc   -Recurse             $dest
+          Copy-Item assets\ccizer -Recurse     $dest
+          Copy-Item assets\syx    -Recurse     $dest
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,19 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_05_14 (CI: bundle CCizer banks + SysEx examples in release artifacts)
+----------------------------------------------------------------------------
+
+        * .github/workflows/build.yml -- Linux, Windows XP (MinGW),
+          and Windows x64 (MSVC) "Stage release" steps now copy
+          assets/ccizer and assets/syx into the staged directory.
+          Without this, downloaded Linux/Windows releases shipped
+          without sc88st.txt, microfreak.txt, etc., leaving the
+          Shift+F3 CC Console and Shift+F5 SysEx Librarian empty
+          out of the box. macOS was already fine because the .app
+          bundle carries assets/ccizer + assets/syx in Resources/
+          via the CMake POST_BUILD step.
+
 zt 2026_05_13 (CC Drawmode: ghost bars + Overwrite Previous Drawbars toggle)
 ----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Linux, Windows XP (MinGW), and Windows x64 (MSVC) release artifacts have been shipping **without** the bundled CCizer banks (`sc88st.txt`, `microfreak.txt`, `minilogue.txt`, `Prophet6.txt`, `deepmind6.txt`, `waldorf_blofeld.txt`, `tb03.txt`, `se02.txt`, `pro800.txt`, `polyend_performance_mode.txt`, `polyend_synth_mode.txt`, `monologue.txt`, `midi_control_example.txt`) and **without** `assets/syx/request_universal_inquiry.syx`.

User report (verbatim):

> when using windows32bit xp ztracker, is, that the SC88st.txt is not there. and there are no examples. so it is pretty wack. i am on an empty windows and i dont have access to the textfile. why did you not bake them inside ztrackerprime?

On a fresh Windows install, Shift+F3 CC Console and Shift+F5 SysEx Librarian both came up empty.

## Root cause

`CMakeLists.txt` already copies `assets/ccizer` and `assets/syx` next to the binary via a `POST_BUILD` step (lines 381–386 for `.app`, 400–403 for non-macOS). That works for local builds.

But the CI **Stage release** steps in `.github/workflows/build.yml` only ever copied `zt.conf + skins + doc` into the staged release directory, ignoring everything CMake put next to the binary. So the uploaded artifact was missing the CCizer + SysEx folders.

macOS was unaffected: the CMake POST_BUILD writes into `Resources/ccizer` + `Resources/syx` inside the `.app` bundle, and macOS staging copies the whole `.app`.

## Fix

Add `cp -R assets/ccizer` and `cp -R assets/syx` (and the PowerShell equivalent for the x64 MSVC job) to the three affected Stage release steps:

- Linux x86_64
- Windows x86 XP (MinGW cross from Ubuntu)
- Windows x64 (MSVC on windows-latest)

## Test plan

- [x] Build green locally (CMake POST_BUILD already proven on master).
- [ ] Next CI run on this branch produces Linux + Windows XP + Windows x64 artifacts that contain a top-level `ccizer/` directory with `sc88st.txt` and a top-level `syx/` directory with `request_universal_inquiry.syx`.
- [ ] Download the Windows XP artifact on a fresh Windows machine, launch `zt.exe`, hit Shift+F3 — sc88st should be listed and selectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)