### PR TITLE
Windows: Ctrl+Shift+` fires CC drawmode cycle + keyjazz audition in mouse-draw

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,32 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_05_14 (Windows: Ctrl+Shift+` fix + keyjazz audition in mouse-draw)
+----------------------------------------------------------------------------
+
+        * src/main.cpp::keyhandler -- non-Apple branch now remaps
+          SDL_SCANCODE_GRAVE -> SDLK_GRAVE explicitly, matching the
+          existing macOS branch. SDL3 layout-transforms the backtick
+          key under Shift to SDLK_TILDE (~) on Windows + US/Finnish
+          layouts, so Ctrl+Shift+` never produced SDLK_GRAVE and the
+          CC drawmode cycle in the Pattern Editor never fired. The
+          NONUSBACKSLASH/INTERNATIONAL1..3 remap that already lived
+          here only triggered for Finnish ISO § via non-grave
+          scancodes; physical backtick fell through unmapped under
+          modifiers. With this fix Ctrl+Shift+` cycles CCizer slots
+          on Windows the same way Ctrl+Shift+§ does on EU Finnish.
+
+        + src/CUI_Patterneditor.cpp -- keyjazz audition is now
+          available while the Pattern Editor is in PEM_MOUSEDRAW
+          mode (the mode you enter with Shift+§ / Shift+`). Q/2/W/3/
+          E/... and Z/S/X/D/C/... play notes on the current
+          instrument's MIDI channel using the current base octave,
+          same key map as the regular T_NOTE column. The note-off is
+          handled by the existing central key-up path in main.cpp::
+          keyhandler -- no pattern mutation, no row advance, pure
+          audition. Lets you hear what you're drawing CC drawbars
+          against without leaving mouse-draw.
+
 zt 2026_05_14 (CI: bundle CCizer banks + SysEx examples in release artifacts)
 ----------------------------------------------------------------------------
 

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -1711,11 +1711,68 @@ void CUI_Patterneditor::update()
           need_refresh++;
           break;
         } ;
+
+        // Keyjazz audition in mouse-draw mode. Mouse draws drawbars, the
+        // keyboard is otherwise idle here — let the user hear notes while
+        // drawing. noteOff fires automatically from the central key-up
+        // path in main.cpp::keyhandler via jazz_clear_state.
+        if (cur_inst >= 0 && cur_inst < MAX_INSTS &&
+            song->instruments[cur_inst]) {
+          int jazz_note = -1;
+          switch (scancode) {
+          case SDL_SCANCODE_Q: jazz_note = 12*base_octave;          break;
+          case SDL_SCANCODE_2: jazz_note = (12*base_octave)+1;      break;
+          case SDL_SCANCODE_W: jazz_note = (12*base_octave)+2;      break;
+          case SDL_SCANCODE_3: jazz_note = (12*base_octave)+3;      break;
+          case SDL_SCANCODE_E: jazz_note = (12*base_octave)+4;      break;
+          case SDL_SCANCODE_R: jazz_note = (12*base_octave)+5;      break;
+          case SDL_SCANCODE_5: jazz_note = (12*base_octave)+6;      break;
+          case SDL_SCANCODE_T: jazz_note = (12*base_octave)+7;      break;
+          case SDL_SCANCODE_6: jazz_note = (12*base_octave)+8;      break;
+          case SDL_SCANCODE_Y: jazz_note = (12*base_octave)+9;      break;
+          case SDL_SCANCODE_7: jazz_note = (12*base_octave)+10;     break;
+          case SDL_SCANCODE_U: jazz_note = (12*base_octave)+11;     break;
+          case SDL_SCANCODE_I: jazz_note = (12*base_octave)+12;     break;
+          case SDL_SCANCODE_9: jazz_note = (12*base_octave)+1+12;   break;
+          case SDL_SCANCODE_O: jazz_note = (12*base_octave)+2+12;   break;
+          case SDL_SCANCODE_0: jazz_note = (12*base_octave)+3+12;   break;
+          case SDL_SCANCODE_P: jazz_note = (12*base_octave)+4+12;   break;
+          case SDL_SCANCODE_Z: jazz_note = 12*(base_octave-1);      break;
+          case SDL_SCANCODE_S: jazz_note = (12*(base_octave-1))+1;  break;
+          case SDL_SCANCODE_X: jazz_note = (12*(base_octave-1))+2;  break;
+          case SDL_SCANCODE_D: jazz_note = (12*(base_octave-1))+3;  break;
+          case SDL_SCANCODE_C: jazz_note = (12*(base_octave-1))+4;  break;
+          case SDL_SCANCODE_V: jazz_note = (12*(base_octave-1))+5;  break;
+          case SDL_SCANCODE_G: jazz_note = (12*(base_octave-1))+6;  break;
+          case SDL_SCANCODE_B: jazz_note = (12*(base_octave-1))+7;  break;
+          case SDL_SCANCODE_H: jazz_note = (12*(base_octave-1))+8;  break;
+          case SDL_SCANCODE_N: jazz_note = (12*(base_octave-1))+9;  break;
+          case SDL_SCANCODE_J: jazz_note = (12*(base_octave-1))+10; break;
+          case SDL_SCANCODE_M: jazz_note = (12*(base_octave-1))+11; break;
+          default: break;
+          }
+          if (jazz_note >= 0 && jazz_note <= 0x7F &&
+              !jazz_note_is_active((int)key)) {
+            int played = jazz_note + song->instruments[cur_inst]->transpose;
+            if (played > 0x7F) played = 0x7F;
+            if (played < 0)    played = 0;
+            unsigned char vel = song->instruments[cur_inst]->default_volume;
+            if (song->instruments[cur_inst]->global_volume != 0x7F && vel > 0) {
+              vel = (unsigned char)((vel * song->instruments[cur_inst]->global_volume) / 0x7F);
+            }
+            MidiOut->noteOn(song->instruments[cur_inst]->midi_device,
+                            (unsigned char)played,
+                            song->instruments[cur_inst]->channel,
+                            vel, MAX_TRACKS, 0);
+            jazz_set_state((int)key, (unsigned char)played,
+                           song->instruments[cur_inst]->channel);
+          }
+        }
       }
-      
-      
-      
-      
+
+
+
+
       
       
       if (cur_edit_row_disp >= song->patterns[cur_edit_pattern]->length - PATTERN_EDIT_ROWS) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2652,6 +2652,14 @@ void keyhandler(SDL_KeyboardEvent *e) {
         e->scancode == SDL_SCANCODE_NONUSHASH) {
       id = SDLK_GRAVE;
     }
+    // Windows + US (and Finnish) layouts: SDL3 layout-transforms the
+    // backtick key under Shift to SDLK_TILDE (~), so Ctrl+Shift+` never
+    // produces SDLK_GRAVE and the CC drawmode cycle in Pattern Editor
+    // never fires. Force GRAVE on every physical-grave event regardless
+    // of modifier. Matches the macOS branch below.
+    else if (e->scancode == SDL_SCANCODE_GRAVE) {
+      id = SDLK_GRAVE;
+    }
 #else
     // macOS Finnish ISO (verified via ZT_KEYDEBUG):
     //  * The top-left §-key reports scancode=SDL_SCANCODE_GRAVE with a


### PR DESCRIPTION
## Summary

Two related Pattern Editor fixes for Windows 32-bit XP users.

User quotes:

> ctrl-shift-§ does nothing on windows xp.

> while im in draw mode, i would like to be able to trigger midi notes and hear them. i cannot.

### 1. Ctrl+Shift+backtick fires CC drawmode cycle on Windows

**Root cause.** SDL3 layout-transforms the backtick key under Shift to `SDLK_TILDE` (`~`) on Windows + US/Finnish layouts, so the Pattern Editor's

```cpp
if ((kstate & KS_CTRL) && (kstate & KS_SHIFT) && key == SDLK_GRAVE)
```

never matched. The non-Apple branch of `keyhandler()` only remapped `NONUSBACKSLASH` / `INTERNATIONAL1..3` / `NONUSHASH` → `SDLK_GRAVE` for Finnish ISO §; physical `SDL_SCANCODE_GRAVE` was left to SDL3's layout-aware default.

**Fix.** Add explicit `SDL_SCANCODE_GRAVE` → `SDLK_GRAVE` remap in the non-Apple branch of `keyhandler()`, matching the macOS branch one block down. Now on every platform, the physical backtick/§ key produces `SDLK_GRAVE` regardless of Shift state.

### 2. Keyjazz audition inside mouse-draw mode

`PEM_MOUSEDRAW` previously consumed only mouse events + arrows + TAB. Keyboard letters were dead. The T_NOTE column's `Q/2/W/3/E...` keymap that drives keyjazz audition in `PEM_REGULARKEYS` was unreachable from drawmode.

**Fix.** Add a scancode-based jazz keymap in `PEM_MOUSEDRAW`'s `KS_NO_SHIFT_KEYS` branch:

- `MidiOut->noteOn` + `jazz_set_state` on press.
- Note-off is handled automatically by the central key-up handler in `main.cpp::keyhandler` (lines 2747–2764) via `jazz_clear_state` — no extra wiring needed.
- No pattern mutation, no row advance. Pure audition.

Result: while drawing CC drawbars with the mouse, you can hear what you're drawing them against by holding `Q/W/E/...` for the upper octave or `Z/X/C/...` for the lower.

## Test plan

- [x] `cmake --build` clean on macOS.
- [x] `ctest --output-on-failure` — all 10 suites green.
- [ ] Windows XP MinGW CI build green (this PR's CI run).
- [ ] Manual on Windows XP: Shift+\` enters mousedraw → `Q` plays note via MIDI Out; release → noteOff fires.
- [ ] Manual on Windows XP: Ctrl+Shift+\` cycles CC drawmode slot indicator.
- [ ] Manual on macOS / Finnish: existing Ctrl+Shift+§ behaviour preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
