### PR TITLE
CC Console: double-click reset + Ctrl+F2 drawmode cycle

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,37 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_05_14 (CC Console: double-click reset + Ctrl+F2 drawmode cycle)
+----------------------------------------------------------------------------
+
+        + src/Sliders.{h,cpp} -- ValueSlider gains a double-click-
+          to-reset facility. New members:
+            * int dblclick_default  -- sentinel -1 disables; in range
+              [min,max] enables. Caller sets this to the slot's
+              natural rest value.
+            * unsigned int last_click_ms -- timestamp of last left-
+              click on this widget (SDL_GetTicks).
+          A second MOUSE_BUTTON_DOWN_LEFT within 500 ms on the same
+          widget snaps value to dblclick_default and bumps `changed`,
+          short-circuiting the drag-to-position path so the snapped
+          value isn't immediately overridden by the click's mouse-X.
+
+        + src/CUI_CcConsole.cpp::position_sliders -- each visible
+          slot now sets dblclick_default = slot_default(s), i.e.
+          8192 (center) for pitchbend slots and 0 for CC slots.
+          Double-clicking a PB slider snaps it back to center and
+          fires the corresponding MIDI Pitch Wheel via the existing
+          absorb_slider_changes -> send_slot path.
+
+        + src/CUI_Patterneditor.cpp -- Ctrl+F2 is now an alternate
+          CC-drawmode-cycle shortcut, parallel to the existing
+          Ctrl+Shift+§/`. Each press advances 0 -> 1 -> ... -> N -> 0
+          through the currently-loaded CCizer file. Useful when the
+          §/grave key is awkward to reach with two modifiers held
+          (laptop keyboards, non-Finnish layouts). Plain F2 stays
+          the page-switch; Alt+F2 stays the track-1 mute toggle;
+          Ctrl+F2 was otherwise unbound.
+
 zt 2026_05_14 (Windows: Ctrl+Shift+` fix + keyjazz audition in mouse-draw)
 ----------------------------------------------------------------------------
 

--- a/src/CUI_CcConsole.cpp
+++ b/src/CUI_CcConsole.cpp
@@ -418,6 +418,7 @@ void CUI_CcConsole::position_sliders(int grid_max_rows) {
         vs->min = 0;
         vs->max = slot_max(s);
         vs->value = s->value;
+        vs->dblclick_default = slot_default(s);
         // Force a paint every frame: UserInterface::draw skips elements
         // with need_redraw==0, but the page-level slot grid blanks the
         // surrounding text on every frame and a sibling slider's drag

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -1477,6 +1477,19 @@ void CUI_Patterneditor::update()
       need_refresh++; key = 0;
     }
 
+    // Ctrl+F2 is an alternate CC-drawmode-cycle shortcut. Same advance as
+    // Ctrl+Shift+§/` -- useful on platforms / layouts where the §/grave
+    // key is awkward to reach with two modifiers held (Windows non-
+    // Finnish layouts, laptop keyboards without a dedicated § key).
+    // Plain F2 stays the global Pattern Editor page-switch; Alt+F2 stays
+    // the track-1 mute toggle below; Ctrl+F2 is otherwise unbound.
+    if ((kstate & KS_CTRL) && !(kstate & KS_SHIFT) && !KS_HAS_ALT(kstate) &&
+        key == SDLK_F2) {
+      zt_advance_cc_drawmode();
+      midiInQueue.clear();
+      need_refresh++; key = 0;
+    }
+
     if (kstate == KS_SHIFT) {
 
       switch(key)

--- a/src/Sliders.cpp
+++ b/src/Sliders.cpp
@@ -16,6 +16,8 @@ ValueSlider::ValueSlider(int fset)
     focus = fset;
     from_input = 0;
     input_value = 0;
+    dblclick_default = -1;
+    last_click_ms = 0;
 }
 
 
@@ -34,6 +36,26 @@ int ValueSlider::mouseupdate(int cur_element)
         switch(key) {
             case ((unsigned int)((SDL_EVENT_MOUSE_BUTTON_DOWN << 8) | SDL_BUTTON_LEFT)):
                 if (checkclick(col(this->x),row(this->y),col(this->x+this->xsize),row(this->y+1))) {
+                    // Double-click reset: a second left-down within 500 ms
+                    // on the same widget snaps value to dblclick_default
+                    // (e.g. PB center 8192, CC zero) and short-circuits
+                    // the drag-to-position path so the snapped value isn't
+                    // immediately overridden by the click's mouse-X.
+                    unsigned int now = SDL_GetTicks();
+                    if (dblclick_default >= min && dblclick_default <= max &&
+                        last_click_ms != 0 && (now - last_click_ms) < 500) {
+                        if (value != dblclick_default) {
+                            value = dblclick_default;
+                            changed++;
+                            need_refresh++;
+                            need_redraw++;
+                        }
+                        last_click_ms = 0;
+                        Keys.getkey();
+                        fixmouse++;
+                        return this->ID;
+                    }
+                    last_click_ms = now;
                     mousestate = 1;
                     act++;
                     newclick=0; // unset click to focus

--- a/src/Sliders.h
+++ b/src/Sliders.h
@@ -20,6 +20,12 @@ class ValueSlider : public UserInterfaceElement {
         int input_value; // raw typed number from the popup, preserved BEFORE clamping
                          // so callers can see the user's literal input even if it falls
                          // outside [min,max]. Only valid when from_input == 1.
+        // Double-click-to-reset. If dblclick_default is in [min,max], a second
+        // left-click within DBLCLICK_MS on the same widget snaps value to
+        // dblclick_default and bumps `changed`. Sentinel -1 disables. Used by
+        // CC Console to center pitchbend (8192) / zero CCs on a quick re-click.
+        int dblclick_default;
+        unsigned int last_click_ms;
         explicit ValueSlider(int fset = 0);
         virtual ~ValueSlider() = default ;
         int mouseupdate(int cur_element);


### PR DESCRIPTION
## Summary

Two CC Console / Pattern Editor UX additions reported by Esa.

User quotes:

> if i click on pitchbend, doubleclick, while in shift-f3, it should reset it to default. but for some reason, doesnt.

> make it so that if we are in drawmode, ctrl-f2 will result in cycling through the drawmode CCs.

### 1. Double-click reset on CC Console sliders

**Root cause.** `ValueSlider` had no concept of "default value", and no double-click detection. The CC Console's `slot_default()` helper already returned 8192 (center) for pitchbend / 0 for CC, but it was only used internally — never wired to a UI gesture.

**Fix.** Extend `ValueSlider` with:
- `int dblclick_default` — sentinel `-1` disables; in range `[min,max]` enables.
- `unsigned int last_click_ms` — `SDL_GetTicks` timestamp of last left-down.

On `MOUSE_BUTTON_DOWN_LEFT` within 500 ms of the previous left-down on the same widget, `value` snaps to `dblclick_default` and `changed++` fires. We short-circuit the drag-to-position path on that frame so the snapped value isn't immediately overridden by the click's mouse-X.

`CUI_CcConsole::position_sliders` now sets `dblclick_default = slot_default(s)` for every visible slot. Double-click a PB slider → value snaps to 8192 → `absorb_slider_changes` copies it back to the slot → `send_slot` fires the MIDI Pitch Wheel out.

### 2. Ctrl+F2 alternate CC-drawmode-cycle shortcut

The existing `Ctrl+Shift+§/grave` is awkward on layouts that don't expose `§` as a single keypress, and on laptop keyboards where grave requires Fn. `Ctrl+F2` was unbound (plain `F2` = page-switch, `Alt+F2` = track-1 mute).

**Fix.** In `CUI_Patterneditor.cpp`'s COMMON KEYS block, add a parallel branch that fires `zt_advance_cc_drawmode()` on `Ctrl+F2` (with Shift and Alt explicitly NOT held). Same advance semantics: each press cycles `0 → 1 → ... → N → 0` through the currently-loaded CCizer file.

## Test plan

- [x] `cmake --build` clean.
- [x] `ctest` — all 10 suites green.
- [ ] Shift+F3 → load `sc88st.txt` → find a PB slot → drag slider away from center → double-click the slider → snaps to 8192 + audible MIDI Pitch Wheel "center" out.
- [ ] F2 Pattern Editor → load a CCizer file in Shift+F3 first → return to F2 → Ctrl+F2 cycles through CC drawmode slots, with status bar showing `CC drawmode: slot K/N -- CC# (Name)`.
- [ ] Plain F2 still page-switches; Alt+F2 still mutes track 1; Ctrl+Shift+grave still cycles (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
