### PR TITLE
IEdit keyjazz when slider focused + Alt-P centering + Ctrl+C/V/P clipboard

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,43 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_05_14 (IEdit keyjazz + Alt-P centering + Ctrl+C/V/P clipboard)
+----------------------------------------------------------------------------
+
+        * src/CUI_InstEditor.cpp -- keyjazz audition (Q/W/E... and
+          Z/S/X/D/C...) now works when a non-name widget on the
+          Instrument Editor has focus (channel slider, MIDI device
+          listbox, etc.). The previous `editing_name` guard only
+          tested `ie->text_cursor < 24`, but that flag is sticky
+          across focus changes -- once the user clicked the name
+          field, every subsequent press on any other widget got
+          suppressed as "still editing name". Now also requires
+          `UI->cur_element == 0` (the InstEditor list's tabindex),
+          so once focus moves elsewhere keyjazz resumes.
+
+        * src/CUI_SongDuration.cpp -- Alt-P popup. "Song Duration"
+          title and "Total: m:ss" line are now centered against the
+          widget rect (this->x + this->xsize/2), not against the
+          whole screen. At default 640x480 the two centers happen
+          to coincide, but on higher-resolution displays or when
+          the widget is repositioned, the screen-center text could
+          fall outside the widget and be clipped by the right
+          border. User saw "Song Duration: tal: 0:03" (the leading
+          "To" of "Total" eaten by the widget frame).
+
+        + src/CUI_Patterneditor.cpp -- familiar Ctrl+C / Ctrl+V /
+          Ctrl+P clipboard shortcuts wired up alongside the legacy
+          Alt-keyed copy/paste:
+            * Ctrl+C  -- copy current selection to clipboard
+              (mirrors Alt+C).
+            * Ctrl+V  -- paste clipboard at the cursor in OVERWRITE
+              mode (mirrors Alt+O, which is what most users expect
+              from a "paste" shortcut today).
+            * Ctrl+P  -- paste clipboard repeatedly downward from
+              the cursor until the end of the pattern is reached
+              (overwrite fill). Useful for drum loops, ostinatos,
+              and stamping the same chord across the whole pattern.
+
 zt 2026_05_14 (CC Console: double-click reset + Ctrl+F2 drawmode cycle)
 ----------------------------------------------------------------------------
 

--- a/src/CUI_InstEditor.cpp
+++ b/src/CUI_InstEditor.cpp
@@ -299,7 +299,15 @@ void CUI_InstEditor::update() {
             scancode = Keys.getcode();
             kstate = Keys.getstate();
         }
-        const bool editing_name = (ie && ie->text_cursor < 24);
+        // `text_cursor < 24` only means "name field is in edit state". It
+        // does NOT mean the name field is currently focused -- ie's
+        // text_cursor stays whatever it was last set to even after the
+        // user Tabs to another widget (channel slider, midi-device list,
+        // etc.). So also gate on `cur_element == 0`, the tabindex of the
+        // InstEditor list itself, otherwise pressing Q on the channel
+        // slider sees text_cursor==0 and suppresses keyjazz.
+        const bool editing_name = (ie && ie->text_cursor < 24 &&
+                                   UI->cur_element == 0);
 
         switch(kstate) {
             case KS_CTRL:

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -2385,7 +2385,7 @@ void CUI_Patterneditor::update()
             break;
             
           case SDLK_N: /* Set length of first note to length of selection */
-            if (selected && 
+            if (selected &&
               (e = song->patterns[cur_edit_pattern]->tracks[select_track_start]->get_event(select_row_start))
               ) {
               j = (select_row_end+1 - select_row_start)*(96/song->tpb);
@@ -2396,7 +2396,34 @@ void CUI_Patterneditor::update()
             }
             break;
 
+          // Familiar Ctrl+C / Ctrl+V / Ctrl+P clipboard shortcuts in addition
+          // to the legacy Alt-keyed copy/paste below. Ctrl+P pastes the
+          // clipboard repeatedly downward from the cursor until the end of
+          // the pattern is reached (fill).
+          case SDLK_C:
+            if (selected) {
+              clipboard->copy();
+              SDL_Delay(50);
+              need_refresh++;
+            }
+            break;
 
+          case SDLK_V:
+            clipboard->paste(cur_edit_track, cur_edit_row, 1); // overwrite
+            need_refresh++;
+            break;
+
+          case SDLK_P:
+            if (clipboard->rows > 0) {
+              int target = cur_edit_row;
+              int limit  = song->patterns[cur_edit_pattern]->length;
+              while (target < limit) {
+                clipboard->paste(cur_edit_track, target, 1); // overwrite
+                target += clipboard->rows;
+              }
+              need_refresh++;
+            }
+            break;
 
           } ;
 

--- a/src/CUI_SongDuration.cpp
+++ b/src/CUI_SongDuration.cpp
@@ -146,12 +146,15 @@ void CUI_SongDuration::draw(Drawable *S) {
             printchar(col(this->x+this->xsize-1),row(i),146,COLORS.Lowlight,S);
         } 
         printline(col(this->x),row(this->y ),143,this->xsize,COLORS.Highlight,S);
-        print(col(this->x),row(this->y + 1),"    Song Duration",COLORS.Text,S);
+        const char *title = "Song Duration";
+        int title_x = this->x + (this->xsize - (int)strlen(title)) / 2;
+        print(col(title_x),row(this->y + 1),title,COLORS.Text,S);
         char str[50];
         int m = seconds/60;
         int s = seconds%60;
         sprintf(str,"Total: %d:%.2d",m,s);
-        print(col(textcenter(str)),row(this->y + 3),str,COLORS.Text,S);
+        int total_x = this->x + (this->xsize - (int)strlen(str)) / 2;
+        print(col(total_x),row(this->y + 3),str,COLORS.Text,S);
         UI->draw(S);
         S->unlock();
         need_refresh = 0;


### PR DESCRIPTION
## Summary

Three independent UX requests bundled per Esa's "single PR" ask.

User quotes:

> i notice that i cannot keyjazz while in for instance instrument editor -> channel slider. i would prefer and expect to be able to keyjazz.

> i accidentally press alt-p on widnows, it says "Song Duration: tal: 0:03" so the text is not properly centered.

> make ctrl-c, ctrl-v, ctrl-p actually do the work of copy, paste, paste continuously.

### 1. Keyjazz on Instrument Editor channel slider

**Root cause.** `CUI_InstEditor::update` guarded keyjazz with `editing_name = (ie && ie->text_cursor < 24)`. That flag is **sticky** across focus changes — once the user clicked into the name field, `text_cursor` stayed `0..23` even after they Tab'd to the channel slider, MIDI device list, or anywhere else. So the keyjazz dispatch (`Q/W/E.../Z/X/C...`) at the bottom of `update()` was suppressed forever.

**Fix.** Also require `UI->cur_element == 0` (InstEditor list's tabindex) before treating `text_cursor` as "editing". Tabbing off the name field resumes keyjazz immediately.

### 2. Alt-P "Song Duration" centering

**Root cause.** The popup used `textcenter(str)` which centers on whole-screen X. At default 640×480 the widget and screen centers happen to coincide; at higher resolutions or with a repositioned widget the screen-centered text falls past the widget's right edge and gets clipped by the border, eating leading chars of `Total` → `tal`.

**Fix.** Center both lines against the widget rect (`this->x + this->xsize/2`) instead of the whole screen.

### 3. Ctrl+C / Ctrl+V / Ctrl+P clipboard shortcuts

The legacy Alt-keyed bindings (`Alt+C`, `Alt+V` insert, `Alt+O` overwrite, `Alt+M` merge) still work. New bindings in the `kstate == KS_CTRL` block in `CUI_Patterneditor.cpp`:

- **Ctrl+C** — copy selection.
- **Ctrl+V** — paste at cursor in OVERWRITE mode (matches modern "paste" expectations).
- **Ctrl+P** — paste repeatedly downward from cursor until end of pattern (overwrite fill). Useful for drum loops, ostinatos, stamping a chord across a whole pattern.

## Test plan

- [x] `cmake --build` clean.
- [x] `ctest` — all 10 suites green.
- [ ] F3 → click into a name field → click channel slider → press Q → MIDI note plays.
- [ ] Alt-P → "Song Duration" and "Total: 0:03" both centered inside the popup widget at all supported resolutions.
- [ ] Select a region → Ctrl+C copies → move cursor → Ctrl+V overwrites at cursor → Ctrl+P fills downward to end of pattern.
- [ ] Existing Alt+C/V/O/M still work (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
