### PR TITLE
Alt-P / Ctrl-P rebind: duplicate-pattern + paste-continuously + Song Duration

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,23 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_05_25 (Alt-P / Ctrl-P rebind for pattern duplicate + paste-continuously)
+----------------------------------------------------------------------------
+
+        * Ctrl-P now opens the Song Duration popup (was Alt-P).
+
+        * Alt-P, on the Pattern Editor (F2), is paste-continuously:
+          repeatedly overwrite-paste the clipboard downward from the
+          cursor until the end of the pattern. This is the behaviour
+          Ctrl-P used to have inside F2; freeing Ctrl-P up for the
+          global Song Duration shortcut.
+
+        * Alt-P, on every other page (F11 Order List, F3 Instrument
+          Editor, F4/Shift+F4 macro/arp editors, etc.), duplicates the
+          current pattern into the next empty pattern slot and switches
+          cur_edit_pattern to it. Status: "Duplicated pattern N to M".
+          Reach it from F11 if you're on F2 (where Alt-P is fill).
+
 zt 2026_05_18 (CC Envelopes per-instrument, CCizer-aware)
 ----------------------------------------------------------------------------
 

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -59,9 +59,10 @@
  ALT-D  : Select one beat (press multiple times to select next beats)
 
  CTRL-C : Copy the selected block to the clipboard.
- CTRL-P : Copy pattern, paste to next empty pattern,
-          and jump to new pattern
  CTRL-V : Paste the contents of the clipboard to the cursor location.
+ ALT-P  : Paste continuously - repeatedly overwrite-paste the
+          clipboard downward from the cursor until the end of
+          the current pattern.
  CTRL-O : Overwrite paste
  CTRL-M : Merge paste the contents of the clipboard with the contents
           of the location you're pasting to.
@@ -173,7 +174,10 @@
  ALT-F12        : About
  CTRL-S         : Save Song
  CTRL-ALT-N     : New Song
- ALT-P          : Song Duration
+ CTRL-P         : Song Duration
+ ALT-P          : Duplicate current pattern to next empty pattern
+                  slot and switch to it. (On Pattern Editor F2,
+                  Alt-P is paste-continuously instead - see above.)
  CTRL-Q         : Quit (CTRL-ALT-Q also works)
 
 

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -2396,10 +2396,11 @@ void CUI_Patterneditor::update()
             }
             break;
 
-          // Familiar Ctrl+C / Ctrl+V / Ctrl+P clipboard shortcuts in addition
-          // to the legacy Alt-keyed copy/paste below. Ctrl+P pastes the
-          // clipboard repeatedly downward from the cursor until the end of
-          // the pattern is reached (fill).
+          // Familiar Ctrl+C / Ctrl+V clipboard shortcuts in addition to
+          // the legacy Alt-keyed copy/paste below. Ctrl-P used to do
+          // paste-continuously here; that moved to Alt-P (see the
+          // KS_HAS_ALT block below) so Ctrl-P can serve as the global
+          // Song Duration shortcut (see main.cpp global_keys).
           case SDLK_C:
             if (selected) {
               clipboard->copy();
@@ -2411,18 +2412,6 @@ void CUI_Patterneditor::update()
           case SDLK_V:
             clipboard->paste(cur_edit_track, cur_edit_row, 1); // overwrite
             need_refresh++;
-            break;
-
-          case SDLK_P:
-            if (clipboard->rows > 0) {
-              int target = cur_edit_row;
-              int limit  = song->patterns[cur_edit_pattern]->length;
-              while (target < limit) {
-                clipboard->paste(cur_edit_track, target, 1); // overwrite
-                target += clipboard->rows;
-              }
-              need_refresh++;
-            }
             break;
 
           } ;
@@ -2464,36 +2453,24 @@ void CUI_Patterneditor::update()
             }
             break;
 
-          case SDLK_P: // copy to new pattern
-            // select all of current pattern
-            {
-              
-              selected = 1;
-              select_row_start = 0;
-              select_row_end = song->patterns[cur_edit_pattern]->length-1;
-              select_track_start = 0;
-              select_track_end = MAX_TRACKS-1;
-              
-              // copy to clipboard
-              CClipboard tempcb;
-              tempcb.copy(); SDL_Delay(50);
-              
-              x = cur_edit_pattern+1;
-              while(x<256 && !song->patterns[x]->isempty()) x++;
-              if (x<256) {
-                sprintf(szStatmsg,"Copied pattern %d to %d",cur_edit_pattern,x);
-                statusmsg = szStatmsg;
-                song->patterns[x]->resize(song->patterns[cur_edit_pattern]->length);
-                cur_edit_pattern = x;
-                tempcb.paste(0,0,0); // insert
-              } else {
-                statusmsg = "Could not find empty pattern for paste";
+          case SDLK_P:
+            // Alt-P = paste continuously: repeatedly overwrite-paste
+            // the clipboard downward from the cursor until the end of
+            // the pattern is reached. Used to be Ctrl-P; moved here so
+            // Ctrl-P could become the global Song Duration shortcut.
+            // The "duplicate pattern to next empty slot" routine that
+            // used to live on Alt-P (Pattern Editor only) was promoted
+            // to a global Alt-P binding for every page EXCEPT the
+            // Pattern Editor (see main.cpp global_keys).
+            if (clipboard->rows > 0) {
+              int target = cur_edit_row;
+              int limit  = song->patterns[cur_edit_pattern]->length;
+              while (target < limit) {
+                clipboard->paste(cur_edit_track, target, 1); // overwrite
+                target += clipboard->rows;
               }
+              need_refresh++;
             }
-            // paste pattern and unselect
-            selected = 0;
-            need_refresh++;
-            
             break;
             
           case SDLK_GRAVE: 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1585,9 +1585,61 @@ void global_keys(Drawable *S)
                     clear++;
                 }
                 break;
-            case SDLK_P: // song duration
-                if (kstate & KS_ALT) {
+            case SDLK_P:
+                // Ctrl-P = Song Duration popup. Moved here from Alt-P so
+                // Alt-P is free for two new pattern-management bindings:
+                //   * On F2 Pattern Editor: Alt-P = paste-continuously
+                //     (fill clipboard downward to end of pattern). The
+                //     page handler implements this; the global handler
+                //     skips Alt-P when cur_state == STATE_PEDIT.
+                //   * Everywhere else: Alt-P = duplicate current pattern
+                //     into the next empty pattern slot and switch
+                //     cur_edit_pattern to it. Reachable from F11 Order
+                //     List / F3 Instrument Editor / any other page.
+                if ((kstate & KS_CTRL) && !KS_HAS_ALT(kstate) && !(kstate & KS_SHIFT)) {
                     popup_window(UIP_SongDuration);
+                    key = Keys.getkey();
+                    clear++;
+                    break;
+                }
+                if (KS_HAS_ALT(kstate) && !(kstate & KS_CTRL) && !(kstate & KS_SHIFT)
+                    && cur_state != STATE_PEDIT) {
+                    // Duplicate current pattern to next empty slot.
+                    // Save selection globals: CClipboard::copy() reads
+                    // them, and the pattern editor's own selection must
+                    // survive an Alt-P fired from another page.
+                    int saved_selected         = selected;
+                    int saved_select_row_start = select_row_start;
+                    int saved_select_row_end   = select_row_end;
+                    int saved_select_trk_start = select_track_start;
+                    int saved_select_trk_end   = select_track_end;
+                    int src_pat                = cur_edit_pattern;
+                    selected           = 1;
+                    select_row_start   = 0;
+                    select_row_end     = song->patterns[src_pat]->length - 1;
+                    select_track_start = 0;
+                    select_track_end   = MAX_TRACKS - 1;
+                    CClipboard tempcb;
+                    tempcb.copy();
+                    SDL_Delay(50);
+                    int x = src_pat + 1;
+                    while (x < 256 && !song->patterns[x]->isempty()) x++;
+                    if (x < 256) {
+                        song->patterns[x]->resize(song->patterns[src_pat]->length);
+                        cur_edit_pattern = x;
+                        tempcb.paste(0, 0, 0); // insert
+                        sprintf(szStatmsg, "Duplicated pattern %d to %d", src_pat, x);
+                        statusmsg = szStatmsg;
+                    } else {
+                        statusmsg = "Could not find empty pattern for duplicate";
+                    }
+                    selected           = saved_selected;
+                    select_row_start   = saved_select_row_start;
+                    select_row_end     = saved_select_row_end;
+                    select_track_start = saved_select_trk_start;
+                    select_track_end   = saved_select_trk_end;
+                    status_change = 1;
+                    need_refresh++;
                     key = Keys.getkey();
                     clear++;
                 }


### PR DESCRIPTION
## Summary

Three-way rebind so Alt-P / Ctrl-P actually carry their weight:

- **Ctrl-P** -> opens the **Song Duration** popup (was Alt-P).
- **Alt-P on F2 Pattern Editor** -> **paste continuously** (the fill-down behaviour Ctrl-P used to have inside F2).
- **Alt-P on every other page** -> **duplicate current pattern to next empty slot** and switch `cur_edit_pattern` to it. Reachable from F11 Order List, F3 Instrument Editor, F4 / Shift+F4 macro+arp editors -- any page except `STATE_PEDIT`.

User request, verbatim:

> "make alt-P work on order list, but be paste continuously on F2 view."
> "im fine with CTRL-P being the one for song duration. and ALT-P being in pattern the paste continuously and elsewhere duplicate pattern to new slot, select new slot."

## Root cause of the dead code

`global_keys()` runs before `ActivePage->update()` (`main.cpp:3287` vs `main.cpp:3336`) and consumes Alt-P via `Keys.getkey()`. Before this PR Alt-P was globally bound to the Song Duration popup at `main.cpp:1588`, which meant the page-level Alt-P branch at `CUI_Patterneditor.cpp:2467` (a "copy current pattern to next empty slot" routine) was unreachable. That routine is hoisted into `global_keys()` here and the Pattern Editor's Alt-P becomes the fill instead.

## Fix

- `src/main.cpp` `global_keys`, `case SDLK_P`:
  - Ctrl-P (no Alt/Shift) -> Song Duration popup.
  - Alt-P (no Ctrl/Shift) when `cur_state != STATE_PEDIT` -> duplicate routine. Saves+restores the pattern editor's selection globals (`selected`, `select_row_*`, `select_track_*`) around the temp `CClipboard` copy/paste so the F2 selection survives an Alt-P fired from F11.
- `src/CUI_Patterneditor.cpp`:
  - Old Ctrl-P fill case removed (now lives in global handler conceptually -- the fill is on Alt-P).
  - Old Alt-P "copy-to-new-pattern" case replaced with paste-continuously fill body.
- `doc/help.txt` updated (line ~62 and ~176).
- `doc/CHANGELOG.txt` new section.

## Test plan

- [x] Clean `cmake --build build -j8` -- green.
- [x] `ctest --test-dir build --output-on-failure` -- 11/11 pass.
- [ ] Launch zt.app, F2, Ctrl-P -> Song Duration popup opens.
- [ ] F2 with a clipboard, Alt-P -> clipboard fills downward to end of pattern.
- [ ] F11 (Order List), Alt-P -> "Duplicated pattern N to M" in status; cur_edit_pattern advances to M; F2 returns showing the duplicate.
- [ ] F11 Alt-P doesn't trash the F2 selection (selection globals saved/restored).
- [ ] Alt-P from F3 / F4 / Shift+F4 / Shift+F3 / Shift+F5 / F12 -> same duplicate behaviour.

(Manual checklist items 3-7 are for Esa to verify; the binary launches and the global flow path was traced statically.)
