### PR TITLE
Linux: rpath=$ORIGIN so bundled libSDL3.so.0 is found at runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,20 @@ endif()
 target_include_directories(zt PRIVATE src extlibs/libpng extlibs/zlib extlibs/lua)
 target_link_libraries(zt PRIVATE lua_static zt_zlib_static)
 
+# Linux release artifacts bundle libSDL3.so.0 next to the binary (Ubuntu 24.04
+# apt has no libsdl3-dev yet). Without $ORIGIN in the rpath, the dynamic linker
+# won't look beside the binary and `./zt` fails with
+#   "error while loading shared libraries: libSDL3.so.0: cannot open shared
+#    object file: No such file or directory"
+# even though the .so is sitting right there. macOS uses .app bundles; Windows
+# searches the exe directory for DLLs natively. Linux is the only platform
+# that needs this.
+if(UNIX AND NOT APPLE)
+  set_target_properties(zt PROPERTIES
+    BUILD_RPATH   "$ORIGIN"
+    INSTALL_RPATH "$ORIGIN")
+endif()
+
 if(MSVC)
   target_compile_options(zt PRIVATE /W3 /MP /wd4103)
 else()

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,17 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt (unreleased)
+----------------------------------------------------------------------------
+
+        * Linux: set rpath to $ORIGIN on the zt binary so the bundled
+          libSDL3.so.0 (shipped next to the binary in the release
+          artifact, because Ubuntu 24.04 apt has no libsdl3-dev) is
+          found at runtime. Previously running ./zt from the unpacked
+          tarball failed with "error while loading shared libraries:
+          libSDL3.so.0: cannot open shared object file" unless the
+          user knew to set LD_LIBRARY_PATH=. first.
+
 zt 2026_05_25 (Alt-P / Ctrl-P rebind for pattern duplicate + paste-continuously)
 ----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Linux release artifacts bundle `libSDL3.so.0` next to the `zt` binary (Ubuntu 24.04 apt has no `libsdl3-dev` yet, so CI builds SDL3 from source and copies the `.so` into the artifact directory — see `.github/workflows/build.yml:155-157`). But the `zt` binary has no rpath, so the dynamic linker never looks beside the binary and `./zt` from the unpacked tarball fails with:

```
./zt: error while loading shared libraries: libSDL3.so.0:
cannot open shared object file: No such file or directory
```

even though the `.so` is sitting right there. Users had to know to `LD_LIBRARY_PATH=. ./zt` or `patchelf --set-rpath '$ORIGIN' zt`.

## Fix

Set `BUILD_RPATH` and `INSTALL_RPATH` to `$ORIGIN` on the `zt` target on Linux only.

- macOS uses `.app` bundles → not affected.
- Windows searches the exe directory for DLLs natively → not affected.
- Linux is the only platform that needs the rpath hint.

## Test plan

- [x] CMake reconfigures clean on macOS (no-op on this branch since gated by `UNIX AND NOT APPLE`).
- [ ] Linux CI green.
- [ ] Download Linux artifact, untar, run `./zt` from the unpacked directory — should launch without `LD_LIBRARY_PATH`.
- [ ] `readelf -d build/Program/zt | grep -E 'RPATH|RUNPATH'` shows `$ORIGIN` in the Linux build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)