### PR TITLE
F2 F2: "PianoKey" toggle for Ableton/Logic keyjazz layout

### DIFF
--- a/.claude/skills/ztrackerprime/recipes/keyjazz-piano-layout.md
+++ b/.claude/skills/ztrackerprime/recipes/keyjazz-piano-layout.md
@@ -6,18 +6,19 @@ label `PianoKey:`); conf key `keyjazz_piano`; test suite
 `tests/test_keyjazz_map.cpp` (12th CTest target).
 
 **Decisions taken (from the user, 2026-05-28):**
-- Z-row in piano mode = **match Logic exactly**: Z/X/C/V are NOT note keys
-  (Logic uses Z/X for octave shift, C/V for velocity). Only the home row +
-  the row above are notes in piano mode.
+- Z-row in piano mode = Z/X/C/V are NOT note keys. Per the user (2026-05-28):
+  **in piano mode Z and X are inert — they do NOT enter notes and do NOT
+  change the octave.** Only the home row + the row above are notes; the normal
+  zTracker octave controls still drive base_octave.
 - Upper range = **extend through L ; ' and O P** (white to F, black to D#).
 - Scope = **all note-entry pages** (Pattern + Instrument + Arpeggio editors).
 
-**Follow-up not in this PR:** the rest of Logic Musical Typing's *control*
-keys -- Z/X octave shift, C/V velocity, Tab sustain, 1/2 pitch bend, 3-8
-modulation. These collide with existing always-on pattern-editor editing keys
-and need their own collision-resolution + scoping decision; the note layout
-ships first. zTracker already has base_octave +/- and record-velocity, so some
-of those Logic controls map to existing features.
+**Follow-up not in this PR (and not committed to):** Logic Musical Typing's
+*control* keys -- C/V velocity, Tab sustain, 1/2 pitch bend, 3-8 modulation.
+These would collide with existing always-on pattern-editor editing keys and
+need their own collision-resolution + scoping decision. NOTE: Z/X octave-shift
+is explicitly NOT wanted (the user confirmed Z/X must not change octave in
+piano mode); zTracker keeps its own octave + record-velocity controls.
 
 ---
 

--- a/.claude/skills/ztrackerprime/recipes/keyjazz-piano-layout.md
+++ b/.claude/skills/ztrackerprime/recipes/keyjazz-piano-layout.md
@@ -13,12 +13,21 @@ label `PianoKey:`); conf key `keyjazz_piano`; test suite
 - Upper range = **extend through L ; ' and O P** (white to F, black to D#).
 - Scope = **all note-entry pages** (Pattern + Instrument + Arpeggio editors).
 
-**Follow-up not in this PR (and not committed to):** Logic Musical Typing's
-*control* keys -- C/V velocity, Tab sustain, 1/2 pitch bend, 3-8 modulation.
-These would collide with existing always-on pattern-editor editing keys and
-need their own collision-resolution + scoping decision. NOTE: Z/X octave-shift
-is explicitly NOT wanted (the user confirmed Z/X must not change octave in
-piano mode); zTracker keeps its own octave + record-velocity controls.
+**Transport controls (added 2026-05-28, note-column only in piano mode):**
+- Z / X = octave down / up (the existing `[` `]` octave keys keep working
+  everywhere too — Z/X are an *additional* control, scoped to the note column
+  so they don't shadow text/effect-column input).
+- C / V = decrease / increase a session `keyjazz_velocity` global (step 8,
+  clamp 1..127), shown in the status bar.
+- Notes entered in piano mode carry `keyjazz_velocity` into the volume column,
+  written regardless of the RecVeloc toggle.
+
+Implemented in the `T_NOTE` case of `CUI_Patterneditor.cpp` (so they're
+note-column-scoped); `keyjazz_velocity` lives in `main.cpp` / `zt.h` next to
+`base_octave`.
+
+**Still NOT done (not requested yet):** Tab sustain, 1/2 pitch bend, 3-8
+modulation.
 
 ---
 

--- a/.claude/skills/ztrackerprime/recipes/keyjazz-piano-layout.md
+++ b/.claude/skills/ztrackerprime/recipes/keyjazz-piano-layout.md
@@ -1,0 +1,230 @@
+# Recipe: F2-F2 "Piano (Ableton/Logic) keyjazz" checkbox
+
+**Status:** IMPLEMENTED (branch `esa/keyjazz-piano-layout`, 2026-05-28).
+Shared table `src/keyjazz_map.h`; checkbox in `CUI_PEParms.cpp` (element 10,
+label `PianoKey:`); conf key `keyjazz_piano`; test suite
+`tests/test_keyjazz_map.cpp` (12th CTest target).
+
+**Decisions taken (from the user, 2026-05-28):**
+- Z-row in piano mode = **match Logic exactly**: Z/X/C/V are NOT note keys
+  (Logic uses Z/X for octave shift, C/V for velocity). Only the home row +
+  the row above are notes in piano mode.
+- Upper range = **extend through L ; ' and O P** (white to F, black to D#).
+- Scope = **all note-entry pages** (Pattern + Instrument + Arpeggio editors).
+
+**Follow-up not in this PR:** the rest of Logic Musical Typing's *control*
+keys -- Z/X octave shift, C/V velocity, Tab sustain, 1/2 pitch bend, 3-8
+modulation. These collide with existing always-on pattern-editor editing keys
+and need their own collision-resolution + scoping decision; the note layout
+ships first. zTracker already has base_octave +/- and record-velocity, so some
+of those Logic controls map to existing features.
+
+---
+
+## Original design note follows.
+
+
+**Goal:** add a checkbox to the Pattern Editor Config (F2 F2) that switches the
+computer-keyboard note layout from the classic *tracker* layout to the *piano*
+layout used by Ableton Live / Logic / GarageBand Musical Typing — so a user who
+keyjazzes in those DAWs all day doesn't fumble when they come back to zTracker.
+
+---
+
+## The two layouts, precisely
+
+**Tracker layout (current, the only one today).** Two chromatic rows, each a
+full octave climbing left-to-right:
+
+```
+top row    Q 2 W 3 E R 5 T 6 Y 7 U I 9 O 0 P     = base_octave,    semitones 0..16
+bottom row Z S X D C V G B H N J M               = base_octave-1,  semitones 0..11
+```
+
+**Piano layout (the request — `awsedftgyhujk`).** The home row is the *white*
+keys, the row above holds the *black* keys, exactly mimicking a piano keyboard's
+geography — this is the Ableton/Logic mapping:
+
+```
+black     W E   T Y U     O P
+white    A S D F G H J K  L ;
+          C C# D D# E F F# G G# A A# B  C  ...
+```
+
+Decoded the way Esa wrote it: `a`=C `w`=C# `s`=D `e`=D# `d`=E `f`=F `t`=F#
+`g`=G `y`=G# `h`=A `u`=A# `j`=B `k`=C. That is `awsedftgyhujk`.
+
+The two are **mutually exclusive** — `S D G H J` (and friends) mean different
+notes in each. They cannot coexist on the same keys, which is exactly why a
+mode toggle (checkbox) is the right shape, not an additive binding.
+
+---
+
+## Why this is bigger than "swap a table" — the duplication problem
+
+The keyjazz layout is **hardcoded in four places today**, three as inline
+`switch(scancode)` blocks and one as an offset function:
+
+| # | File | Lines | Context |
+|---|------|-------|---------|
+| 1 | `src/CUI_Patterneditor.cpp` | 1756–1784 | mouse-draw-mode audition |
+| 2 | `src/CUI_Patterneditor.cpp` | 3408–3444 | T_NOTE cell direct entry |
+| 3 | `src/CUI_InstEditor.cpp` | 371–404 | instrument-list audition |
+| 4 | `src/CUI_Arpeggioeditor.cpp` | 144–179 | `ar_keyjazz_offset_for_scancode()` |
+
+Adding a second layout by editing four copies is exactly the foot-gun
+`CLAUDE.md` warns about ("extract the decision logic into a header… add tests").
+**So step 1 of the feature is a pure refactor that should ship even on its own:
+collapse all four onto one shared, SDL-free, unit-tested table — then the layout
+toggle is a one-line branch inside that single function.**
+
+Good news: all four already speak the **same coordinate convention** once you
+look closely. The arp function returns an *offset from `12*base_octave`*
+(top row 0..16, bottom row −12..−1). The Pattern/Inst switches compute
+`12*base_octave + N` for the top row and `12*(base_octave-1) + N` for the
+bottom — which is algebraically identical (`12*(base_octave-1)+N == 12*base_octave + (N-12)`).
+So a single function `int keyjazz_offset(scancode, layout)` returning offset-from-
+`12*base_octave` (or a sentinel for "not a note key") can feed all four callers
+unchanged in behavior.
+
+---
+
+## Proposed architecture
+
+### 1. New header `src/keyjazz_map.h` (SDL-free, testable)
+
+Mirrors the existing pattern of `preset_data.h` / `preset_selector.h` /
+`save_key_dispatch.h` — pure logic, no SDL, compiled into a CTest suite under
+`ZT_TEST_NO_SDL` against `tests/sdl_stub.h`.
+
+```cpp
+enum KeyjazzLayout { KJ_TRACKER = 0, KJ_PIANO = 1 };
+
+constexpr int KJ_NOT_A_NOTE = -127;   // matches arp's existing sentinel
+
+// Returns semitone offset from (12 * base_octave), or KJ_NOT_A_NOTE.
+// Callers do:  int n = 12*base_octave + off;  if (off == KJ_NOT_A_NOTE) skip;
+inline int keyjazz_offset(int scancode, KeyjazzLayout layout);
+```
+
+`KJ_TRACKER` reproduces the current table verbatim. `KJ_PIANO` is:
+
+```
+home  (white) A=0  S=2  D=4  F=5  G=7  H=9  J=11 K=12        (C..C)
+upper (black) W=1  E=3  T=6  Y=8  U=10  O=13  P=15           (C#,D#,F#,G#,A#, then C#,D#)
+extend(white) L=14 SEMICOLON=16                              (D, E)
+lower octave  Z=-12 X=-10 C=-8 V=-7 B=-5 N=-3 M=-1           (C..B, one octave down — optional)
+```
+
+The lower-octave Z-row in piano mode is a **design choice to confirm with Esa**
+(see "Open questions"). Ableton/Logic themselves reserve Z/X for *octave shift*,
+not notes — but zTracker shifts octave via `base_octave` +/- already, so the
+Z-row is free to double the playable range like the tracker layout does. Two
+options:
+  - **(a) Match Logic exactly:** Z-row unused for notes in piano mode (cleaner
+    muscle-memory transfer for DAW users; only one octave on the keyboard).
+  - **(b) zTracker bonus:** keep Z-row as the lower octave (two-octave span like
+    today). Recommended default — strictly more notes, no downside since zTracker
+    doesn't use Z/X for octave shift.
+
+### 2. Config flag — wire exactly like `centered_editing`
+
+The end-to-end path an existing checkbox follows (verified):
+
+- `src/conf.h` (~line 88): `int keyjazz_piano_layout;`
+- `src/conf.cpp` ctor (~244): `keyjazz_piano_layout = 0;`  // tracker by default
+- `src/conf.cpp` load (~360): `if (Config->get("keyjazz_piano")) keyjazz_piano_layout = getFlag("keyjazz_piano");`
+- `src/conf.cpp` save (~529): `Config->set("keyjazz_piano", keyjazz_piano_layout ? "yes" : "no");`
+
+Default **off** = zero behavior change for every existing user.
+
+### 3. The checkbox in `CUI_PEParms.cpp`
+
+The config panel already has 5 checkboxes (`Centered`, `StepEdit`, `RecVeloc`,
+`DrawMode`, `CCOver`) laid out on two rows at `y = +14` and `y = +18`. Add a
+sixth, e.g. label `"Piano keys:"`, next free UI element id (`10`), following the
+`cb_centered` recipe end-to-end:
+
+- declare `CheckBox *cb_keyjazz_piano;` in `CUI_Page.h` (class `CUI_PEParms`, ~387)
+- create in the ctor, `UI->add_element(cb_keyjazz_piano, 10)`,
+  `->value = &zt_config_globals.keyjazz_piano_layout;`
+- re-point `cb->value` in `enter()`
+- absorb `if (cb->changed) zt_config_globals.keyjazz_piano_layout = *(cb->value);` in `update()`
+- `print(...,"   Piano keys:",...)` label + position in `draw()`
+
+There's room on the `y = +18` row next to `CCOver`, or start a third row at
+`y = +22` if it reads cleaner. (Bump `need_refresh++` is handled by the widget;
+PEParms is a popup so the INVARIANT is already satisfied by `enter()`.)
+
+### 4. Each of the four callers becomes a one-liner
+
+Replace the inline `switch` / function body with:
+
+```cpp
+KeyjazzLayout layout = zt_config_globals.keyjazz_piano_layout ? KJ_PIANO : KJ_TRACKER;
+int off = keyjazz_offset(scancode, layout);
+if (off != KJ_NOT_A_NOTE) { int note = 12*base_octave + off; /* existing use */ }
+```
+
+In `CUI_Patterneditor.cpp:3408` the call sits *before* the existing "EDITING
+KEYS" cases (`1`→0x81, grave→0x82, period→0x80, `4`/`8` peek-play). Those special
+keys are **not** musical note keys and must survive in both layouts, so they stay
+as their own cases after the `keyjazz_offset` call returns the sentinel for them.
+
+---
+
+## The collision audit — the real risk, and what to check
+
+Piano mode recruits keys the tracker layout never used as notes: **A, K** (and
+**L, ;** if extending). Before shipping, confirm none of these already do
+something in the note-entry context:
+
+- In the `T_NOTE` scancode switch (`CUI_Patterneditor.cpp:3406+`) the only
+  non-note cases are `1`, GRAVE, PERIOD, `4`, `8` — **A/K/L/; are clear there.** ✓
+- Piano mode uses **no number keys at all** (black keys come from W/E/T/Y/U/O/P),
+  so the entire number row stays free — `4` and `8` peek-play keep working,
+  unlike tracker mode where they're wedged between note keys. A nice side benefit.
+- **Still to verify:** that `A` and `K` aren't bound as *global* Pattern Editor
+  commands elsewhere in `update()` (outside the T_NOTE column switch), and the
+  same for the Instrument Editor audition path (`CUI_InstEditor.cpp:371`). Grep
+  `SDL_SCANCODE_A` / `SDL_SCANCODE_K` across the editors. If either is a command,
+  decide precedence (in piano mode, note entry on the note column should win; the
+  command can keep working on non-note columns).
+
+---
+
+## Tests (new CTest suite `test_keyjazz_map`)
+
+Following the eight existing suites:
+- tracker layout reproduces the legacy table exactly for all ~29 keys + sentinel
+  for everything else (this is the regression guard for the refactor);
+- piano layout maps `awsedftgyhujk` → 0,1,2,3,4,5,6,7,8,9,10,11,12;
+- both share the same sentinel value and the same offset-from-`12*base_octave`
+  convention;
+- a couple of "this key means different notes in the two layouts" assertions
+  (e.g. `S` → 2 in piano, −11 in tracker) to lock the mutual exclusivity in.
+
+---
+
+## Suggested PR split (Manuel likes small, focused PRs)
+
+1. **Refactor only:** introduce `keyjazz_map.h` (tracker layout only) + the
+   `test_keyjazz_map` regression suite + repoint all four callers. Pure no-op,
+   provable by tests. Low risk, mergeable on its own.
+2. **Feature:** add `KJ_PIANO` to the header + its tests, the `keyjazz_piano`
+   conf key, and the F2-F2 checkbox. Update `doc/help.txt` and
+   `doc/CHANGELOG.txt`.
+
+---
+
+## Open questions for Esa
+
+1. **Z-row in piano mode** — option (a) match Logic (Z/X unused, one octave) or
+   (b) zTracker bonus lower octave (recommended)?
+2. **How far to extend upward** — stop at `K`=C, or carry on `L ; '` and
+   `O P [ ]` to give nearly two octaves on the home+upper rows?
+3. **Label wording** in the F2-F2 panel — `"Piano keys"`, `"DAW layout"`,
+   `"Ableton/Logic"`? Space is tight (the panel is character-grid).
+4. **Should Instrument Editor + Arpeggio Editor honor the same flag?** Almost
+   certainly yes (one global feel), and the shared header makes it free — worth
+   confirming there's no reason to scope it to the Pattern Editor only.

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,33 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_05_28 (Ableton/Logic piano keyjazz layout toggle in F2 F2)
+----------------------------------------------------------------------------
+
+        + New "PianoKey" checkbox in the F2 F2 Pattern Editor Options.
+          OFF (default) keeps the classic tracker keyjazz layout
+          (Q-row = upper octave, Z-row = lower octave). ON switches to
+          the Ableton Live / Logic "Musical Typing" layout: the home row
+          A S D F G H J K (L ; ') are the white keys and W E T Y U (O P)
+          are the black keys -- a b c... one piano octave climbing
+          rightward (a=C, w=C#, s=D, e=D#, d=E, ...). For users who
+          keyjazz in those DAWs and want the same feel in zTracker.
+          Z/X/C/V are deliberately left free in piano mode (Logic/Live
+          use them for octave-shift and velocity; zTracker keeps its own
+          base_octave controls).
+
+        + The layout applies to all note-entry paths -- Pattern Editor
+          cell entry + draw-mode audition, Instrument Editor audition,
+          and the Arpeggio Editor keyjazz slot -- and persists in zt.conf
+          as keyjazz_piano=yes/no. Default off = no change for existing
+          songs or muscle memory.
+
+        * Internal: the keyjazz keyboard->note layout, previously
+          hand-copied as four separate switch statements, is now a single
+          shared table (src/keyjazz_map.h) with a unit-test suite
+          (tests/test_keyjazz_map.cpp, the 12th CTest target) that
+          regression-guards the tracker layout byte-for-byte.
+
 zt 2026_05_25_2 (Linux: bundled libSDL3.so.0 found at runtime via rpath=$ORIGIN)
 ----------------------------------------------------------------------------
 

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -15,9 +15,10 @@ zt 2026_05_28 (Ableton/Logic piano keyjazz layout toggle in F2 F2)
           are the black keys -- a b c... one piano octave climbing
           rightward (a=C, w=C#, s=D, e=D#, d=E, ...). For users who
           keyjazz in those DAWs and want the same feel in zTracker.
-          Z/X/C/V are deliberately left free in piano mode (Logic/Live
-          use them for octave-shift and velocity; zTracker keeps its own
-          base_octave controls).
+          In piano mode Z and X are inert -- they do NOT enter notes and
+          do NOT change the octave; use zTracker's existing octave
+          controls. (The number row is also unused in piano mode, since
+          the black keys come from W/E/T/Y/U/O/P.)
 
         + The layout applies to all note-entry paths -- Pattern Editor
           cell entry + draw-mode audition, Instrument Editor audition,

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -15,16 +15,26 @@ zt 2026_05_28 (Ableton/Logic piano keyjazz layout toggle in F2 F2)
           are the black keys -- a b c... one piano octave climbing
           rightward (a=C, w=C#, s=D, e=D#, d=E, ...). For users who
           keyjazz in those DAWs and want the same feel in zTracker.
-          In piano mode Z and X are inert -- they do NOT enter notes and
-          do NOT change the octave; use zTracker's existing octave
-          controls. (The number row is also unused in piano mode, since
-          the black keys come from W/E/T/Y/U/O/P.)
+
+        + Logic / Ableton "Musical Typing" transport controls in piano
+          mode, on the note column:
+            Z / X  -- octave down / up (in addition to the [ ] keys,
+                      which keep working everywhere as before).
+            C / V  -- decrease / increase the keyjazz velocity. The new
+                      value is shown in the status bar ("KeyJazz
+                      velocity: NN") so you can see what notes will use
+                      going forward. Step is 8, clamped 1..127.
+          Notes played/entered in piano mode are written to the pattern
+          with that keyjazz velocity in the volume column (regardless of
+          the RecVeloc toggle). The number row is unused in piano mode
+          since the black keys come from W/E/T/Y/U/O/P.
 
         + The layout applies to all note-entry paths -- Pattern Editor
           cell entry + draw-mode audition, Instrument Editor audition,
           and the Arpeggio Editor keyjazz slot -- and persists in zt.conf
           as keyjazz_piano=yes/no. Default off = no change for existing
-          songs or muscle memory.
+          songs or muscle memory. (The Z/X octave + C/V velocity controls
+          are Pattern Editor note-column only.)
 
         * Internal: the keyjazz keyboard->note layout, previously
           hand-copied as four separate switch statements, is now a single

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -7,9 +7,11 @@
                Live / Logic "Musical Typing" layout instead: the home row
                A S D F G H J K (L ;) are the white keys and the row above
                W E T Y U (O P) are the black keys -- one piano octave
-               climbing rightward. The choice persists in zt.conf
-               (keyjazz_piano=) and applies to the Pattern, Instrument and
-               Arpeggio editors.
+               climbing rightward. In piano mode Z and X are inert --
+               they do NOT enter notes and do NOT change the octave (use
+               the normal octave controls). The choice persists in
+               zt.conf (keyjazz_piano=) and applies to the Pattern,
+               Instrument and Arpeggio editors.
  4/8         : peek play the current note/row
  Home/End    : Just try them
  PgUp/PgDn   : Up/down 16 rows

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -7,9 +7,11 @@
                Live / Logic "Musical Typing" layout instead: the home row
                A S D F G H J K (L ;) are the white keys and the row above
                W E T Y U (O P) are the black keys -- one piano octave
-               climbing rightward. In piano mode Z and X are inert --
-               they do NOT enter notes and do NOT change the octave (use
-               the normal octave controls). The choice persists in
+               climbing rightward. In piano mode, on the note column,
+               Z/X shift the octave down/up (the [ ] keys still work too)
+               and C/V decrease/increase the keyjazz velocity (shown in
+               the status bar); notes are written to the pattern with
+               that velocity in the volume column. The choice persists in
                zt.conf (keyjazz_piano=) and applies to the Pattern,
                Instrument and Arpeggio editors.
  4/8         : peek play the current note/row

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -1,6 +1,15 @@
 |L|%==|H|Pattern Editing|L|==%|U|
 
  Spacebar    : Turns Edit (or "Keyjazz") mode on or off
+ Keyjazz keys: Default is the classic tracker layout (Q-row = upper
+               octave, Z-row = lower octave). The "PianoKey" checkbox in
+               the F2 F2 Pattern Editor Options switches to the Ableton
+               Live / Logic "Musical Typing" layout instead: the home row
+               A S D F G H J K (L ;) are the white keys and the row above
+               W E T Y U (O P) are the black keys -- one piano octave
+               climbing rightward. The choice persists in zt.conf
+               (keyjazz_piano=) and applies to the Pattern, Instrument and
+               Arpeggio editors.
  4/8         : peek play the current note/row
  Home/End    : Just try them
  PgUp/PgDn   : Up/down 16 rows
@@ -118,7 +127,9 @@
                   to the line that documents it. Tab / Shift-Tab navigate
                   between section headers.
  F2             : Pattern editor - Pressing F2 again while in the pattern
-                  editing screen brings up the pattern settings.
+                  editing screen brings up the pattern settings, including
+                  the "PianoKey" toggle (tracker vs Ableton/Logic keyjazz
+                  layout).
  F3             : Instrument editor
  SHIFT-F2       : Shortcuts & MIDI Mappings (unified per-action grid:
                   Keyboard | MIDI1 | MIDI2 | MIDI3). Up/Dn/Lt/Rt move,

--- a/src/CUI_Arpeggioeditor.cpp
+++ b/src/CUI_Arpeggioeditor.cpp
@@ -123,6 +123,7 @@ static void format_ccval(unsigned char v, char buf[4]) {
 #include "preset_data.h"
 #include "preset_selector.h"
 #include "page_sync.h"
+#include "keyjazz_map.h"
 
 static int  ar_preset_index = 0;
 // Set by ArPresetSelector::OnSelect when Enter/Space lands on a preset.
@@ -142,40 +143,11 @@ static bool ar_preset_just_applied = false;
 // noteOff via the shared infrastructure.
 
 static int ar_keyjazz_offset_for_scancode(int sc) {
-    switch (sc) {
-        // Top row -- upper octave (12*base_octave + 0..16)
-        case SDL_SCANCODE_Q: return 0;
-        case SDL_SCANCODE_2: return 1;
-        case SDL_SCANCODE_W: return 2;
-        case SDL_SCANCODE_3: return 3;
-        case SDL_SCANCODE_E: return 4;
-        case SDL_SCANCODE_R: return 5;
-        case SDL_SCANCODE_5: return 6;
-        case SDL_SCANCODE_T: return 7;
-        case SDL_SCANCODE_6: return 8;
-        case SDL_SCANCODE_Y: return 9;
-        case SDL_SCANCODE_7: return 10;
-        case SDL_SCANCODE_U: return 11;
-        case SDL_SCANCODE_I: return 12;
-        case SDL_SCANCODE_9: return 13;
-        case SDL_SCANCODE_O: return 14;
-        case SDL_SCANCODE_0: return 15;
-        case SDL_SCANCODE_P: return 16;
-        // Bottom row -- lower octave (12*(base_octave-1) + 0..11)
-        case SDL_SCANCODE_Z: return -12;
-        case SDL_SCANCODE_S: return -11;
-        case SDL_SCANCODE_X: return -10;
-        case SDL_SCANCODE_D: return -9;
-        case SDL_SCANCODE_C: return -8;
-        case SDL_SCANCODE_V: return -7;
-        case SDL_SCANCODE_G: return -6;
-        case SDL_SCANCODE_B: return -5;
-        case SDL_SCANCODE_H: return -4;
-        case SDL_SCANCODE_N: return -3;
-        case SDL_SCANCODE_J: return -2;
-        case SDL_SCANCODE_M: return -1;
-    }
-    return -127;
+    // Delegates to the shared keyjazz table so the Arpeggio editor honors the
+    // same tracker-vs-piano layout toggle as the Pattern / Instrument editors.
+    // KJ_NOT_A_NOTE == -127, so the existing `off != -127` callers keep working.
+    KeyjazzLayout kjl = zt_config_globals.keyjazz_piano_layout ? KJ_PIANO : KJ_TRACKER;
+    return keyjazz_offset(sc, kjl);
 }
 
 // SDL scancode -> SDLK_* mapping for the keyjazz keys, so we can call
@@ -211,6 +183,13 @@ static int ar_keyjazz_keysym_for_scancode(int sc) {
         case SDL_SCANCODE_G: return SDLK_G;
         case SDL_SCANCODE_H: return SDLK_H;
         case SDL_SCANCODE_J: return SDLK_J;
+        // Extra keys recruited by the piano (Ableton/Logic) layout.
+        case SDL_SCANCODE_A:          return SDLK_A;
+        case SDL_SCANCODE_F:          return SDLK_F;
+        case SDL_SCANCODE_K:          return SDLK_K;
+        case SDL_SCANCODE_L:          return SDLK_L;
+        case SDL_SCANCODE_SEMICOLON:  return SDLK_SEMICOLON;
+        case SDL_SCANCODE_APOSTROPHE: return SDLK_APOSTROPHE;
     }
     return 0;
 }

--- a/src/CUI_InstEditor.cpp
+++ b/src/CUI_InstEditor.cpp
@@ -1,6 +1,7 @@
 #include "zt.h"
 #include "InstEditor.h"
 #include "Button.h"
+#include "keyjazz_map.h"
 
 
 void InitInstruments(void) {
@@ -367,43 +368,11 @@ void CUI_InstEditor::update() {
                         act++; break;
                 }
                 if (!editing_name) {
-                    switch(scancode) {
-                        case SDL_SCANCODE_Q: set_note = 12*base_octave;         break;
-                        case SDL_SCANCODE_2: set_note = (12*base_octave)+1;     break;
-                        case SDL_SCANCODE_W: set_note = (12*base_octave)+2;     break;
-                        case SDL_SCANCODE_3: set_note = (12*base_octave)+3;     break;
-                        case SDL_SCANCODE_E: set_note = (12*base_octave)+4;     break;
-                        case SDL_SCANCODE_R: set_note = (12*base_octave)+5;     break;
-                        case SDL_SCANCODE_5: set_note = (12*base_octave)+6;     break;
-                        case SDL_SCANCODE_T: set_note = (12*base_octave)+7;     break;
-                        case SDL_SCANCODE_6: set_note = (12*base_octave)+8;     break;
-                        case SDL_SCANCODE_Y: set_note = (12*base_octave)+9;     break;
-                        case SDL_SCANCODE_7: set_note = (12*base_octave)+10;    break;
-                        case SDL_SCANCODE_U: set_note = (12*base_octave)+11;    break;
-                        case SDL_SCANCODE_I: set_note = (12*base_octave)+12;    break;
-                        case SDL_SCANCODE_9: set_note = (12*base_octave)+1+12;  break;
-                        case SDL_SCANCODE_O: set_note = (12*base_octave)+2+12;  break;
-                        case SDL_SCANCODE_0: set_note = (12*base_octave)+3+12;  break;
-                        case SDL_SCANCODE_P: set_note = (12*base_octave)+4+12;  break;
-
-                        // <Manu> Repurpose these keys
-                        //case SDLK_LEFTBRACKET: set_note = (12*base_octave)+5+12;  break;
-                        //case SDLK_RIGHTBRACKET: set_note = (12*base_octave)+6+12;  break;
-
-                        case SDL_SCANCODE_Z: set_note = 12*(base_octave-1);     break;
-                        case SDL_SCANCODE_S: set_note = (12*(base_octave-1))+1; break;
-                        case SDL_SCANCODE_X: set_note = (12*(base_octave-1))+2; break;
-                        case SDL_SCANCODE_D: set_note =(12*(base_octave-1))+3;  break;
-                        case SDL_SCANCODE_C: set_note =(12*(base_octave-1))+4;  break;
-                        case SDL_SCANCODE_V: set_note = (12*(base_octave-1))+5; break;
-                        case SDL_SCANCODE_G: set_note = (12*(base_octave-1))+6; break;
-                        case SDL_SCANCODE_B: set_note = (12*(base_octave-1))+7; break;
-                        case SDL_SCANCODE_H: set_note = (12*(base_octave-1))+8; break;
-                        case SDL_SCANCODE_N: set_note = (12*(base_octave-1))+9; break;
-                        case SDL_SCANCODE_J: set_note = (12*(base_octave-1))+10;break;
-                        case SDL_SCANCODE_M: set_note = (12*(base_octave-1))+11;break;
-                        default: break;
-                    }
+                    // Shared keyjazz table (keyjazz_map.h): tracker vs piano
+                    // layout toggles in one place for every audition path.
+                    KeyjazzLayout kjl = zt_config_globals.keyjazz_piano_layout ? KJ_PIANO : KJ_TRACKER;
+                    int kjoff = keyjazz_offset(scancode, kjl);
+                    if (kjoff != KJ_NOT_A_NOTE) set_note = 12*base_octave + kjoff;
                 }
             break;
         }

--- a/src/CUI_PEParms.cpp
+++ b/src/CUI_PEParms.cpp
@@ -113,6 +113,15 @@ CUI_PEParms::CUI_PEParms(void) {
         cb_cc_draw_overwrite->y = (start_y / 8) + 18;
         cb_cc_draw_overwrite->xsize = 3;
         cb_cc_draw_overwrite->value = &zt_config_globals.cc_draw_overwrite;
+
+        // Keyjazz piano layout (Ableton Live / Logic). OFF = tracker layout.
+        cb_keyjazz_piano = new CheckBox;
+        UI->add_element(cb_keyjazz_piano, 10);
+        cb_keyjazz_piano->frame = 1;
+        cb_keyjazz_piano->x = (start_x / 8) + 17 + 32;
+        cb_keyjazz_piano->y = (start_y / 8) + 18;
+        cb_keyjazz_piano->xsize = 3;
+        cb_keyjazz_piano->value = &zt_config_globals.keyjazz_piano_layout;
 }
 
 void CUI_PEParms::enter(void) {
@@ -142,6 +151,8 @@ void CUI_PEParms::enter(void) {
     cb->value = &drawmode_val;
     cb = (CheckBox *)UI->get_element(9);
     cb->value = &zt_config_globals.cc_draw_overwrite;
+    cb = (CheckBox *)UI->get_element(10);
+    cb->value = &zt_config_globals.keyjazz_piano_layout;
 }
 
 void CUI_PEParms::leave(void) {
@@ -194,6 +205,10 @@ void CUI_PEParms::update() {
         UIP_Patterneditor->mode = (drawmode_val) ? PEM_MOUSEDRAW : PEM_REGULARKEYS;
         if (UIP_Patterneditor->mode == PEM_REGULARKEYS) midiInQueue.clear();
     }
+
+    cb = (CheckBox *)UI->get_element(10);
+    if (cb->changed)
+        zt_config_globals.keyjazz_piano_layout = *(cb->value);
 
     // Live drawing while the popup is open. With DrawMode on, forward
     // mouse activity to the pattern editor when the cursor is outside
@@ -254,6 +269,8 @@ void CUI_PEParms::draw(Drawable *S) {
     cb_drawmode->y = (start_y / 8) + 18;
     cb_cc_draw_overwrite->x = (start_x / 8) + 17 + 16;
     cb_cc_draw_overwrite->y = (start_y / 8) + 18;
+    cb_keyjazz_piano->x = (start_x / 8) + 17 + 32;
+    cb_keyjazz_piano->y = (start_y / 8) + 18;
 
 
     if (S->lock()==0) {
@@ -280,6 +297,9 @@ void CUI_PEParms::draw(Drawable *S) {
         // CC drawbar overwrite-protect toggle. Label width matches the
         // StepEdit / RecVeloc pattern on row 14.
         print(start_x + col(23),start_y + row(18),"CCOver:",COLORS.Text,S);
+        // Keyjazz piano-layout (Ableton/Logic) toggle, mirrors RecVeloc's
+        // column on row 14. Chip at col 49, label colon lands at col 47.
+        print(start_x + col(39),start_y + row(18),"PianoKey:",COLORS.Text,S);
         UI->full_refresh();
         UI->draw(S);
         S->unlock();

--- a/src/CUI_Page.h
+++ b/src/CUI_Page.h
@@ -396,6 +396,10 @@ class CUI_PEParms : public CUI_Page {
         // drawbars are protected from accidental overwrite.
         CheckBox *cb_cc_draw_overwrite ;
 
+        // Keyjazz layout toggle. OFF = classic tracker layout, ON = Ableton
+        // Live / Logic piano layout (home row = white keys). See keyjazz_map.h.
+        CheckBox *cb_keyjazz_piano ;
+
         ValueSlider *vs_speedup ;
 
         CUI_PEParms();

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -3386,7 +3386,41 @@ case SDLK_DELETE:
                       {
                         KeyjazzLayout kjl = zt_config_globals.keyjazz_piano_layout ? KJ_PIANO : KJ_TRACKER;
                         int kjoff = keyjazz_offset(scancode, kjl);
-                        if (kjoff != KJ_NOT_A_NOTE) set_note = 12*base_octave + kjoff;
+                        if (kjoff != KJ_NOT_A_NOTE) {
+                          set_note = 12*base_octave + kjoff;
+                        } else if (kjl == KJ_PIANO) {
+                          // Logic / Ableton "Musical Typing" transport controls,
+                          // scoped to the note column so they never shadow text
+                          // or effect-column input. The [ ] (and KP * /) octave
+                          // keys keep working everywhere regardless -- see the
+                          // switch(key) near the top of the handler; this only
+                          // ADDS Z/X as a second octave control in piano mode.
+                          switch (scancode) {
+                          case SDL_SCANCODE_Z:  // octave down
+                            if (base_octave > BASE_OCTAVE_MIN) base_octave--;
+                            sprintf(szStatmsg, "Octave: %d", base_octave);
+                            statusmsg = szStatmsg; status_change = 1; need_refresh++;
+                            break;
+                          case SDL_SCANCODE_X:  // octave up
+                            if (base_octave < BASE_OCTAVE_MAX) base_octave++;
+                            sprintf(szStatmsg, "Octave: %d", base_octave);
+                            statusmsg = szStatmsg; status_change = 1; need_refresh++;
+                            break;
+                          case SDL_SCANCODE_C:  // velocity down
+                            keyjazz_velocity -= KEYJAZZ_VELOCITY_STEP;
+                            if (keyjazz_velocity < 1) keyjazz_velocity = 1;
+                            sprintf(szStatmsg, "KeyJazz velocity: %d", keyjazz_velocity);
+                            statusmsg = szStatmsg; status_change = 1; need_refresh++;
+                            break;
+                          case SDL_SCANCODE_V:  // velocity up
+                            keyjazz_velocity += KEYJAZZ_VELOCITY_STEP;
+                            if (keyjazz_velocity > 127) keyjazz_velocity = 127;
+                            sprintf(szStatmsg, "KeyJazz velocity: %d", keyjazz_velocity);
+                            statusmsg = szStatmsg; status_change = 1; need_refresh++;
+                            break;
+                          default: break;
+                          }
+                        }
                       }
                       switch(scancode) {
                         /* EDITING KEYS */
@@ -3645,16 +3679,25 @@ case SDLK_DELETE:
               }
             }
             
+            // Piano (Ableton/Logic) keyjazz: a played note carries the current
+            // keyjazz velocity (set by C/V) into the volume column. It's written
+            // regardless of the RecVeloc toggle so the velocity is always
+            // "added" in piano mode, as requested.
+            if (zt_config_globals.keyjazz_piano_layout && set_note < 0x80 && p1 == -1)
+              p1 = (short int)keyjazz_velocity;
+            short int rec_vol =
+              (zt_config_globals.record_velocity || zt_config_globals.keyjazz_piano_layout) ? p1 : (short int)(-1);
+
             if (set_note != 0xFF) {
               if (key_jazz==0) {
                 if (noplay==0 ) {
                   if (set_note<0x80)
-                    song->patterns[cur_edit_pattern]->tracks[cur_edit_track]->update_event(cur_edit_row,set_note,cur_inst,zt_config_globals.record_velocity?p1:(-1),-1,-1,-1);
+                    song->patterns[cur_edit_pattern]->tracks[cur_edit_track]->update_event(cur_edit_row,set_note,cur_inst,rec_vol,-1,-1,-1);
                   else
-                    song->patterns[cur_edit_pattern]->tracks[cur_edit_track]->update_event(cur_edit_row,set_note,MAX_INSTS,zt_config_globals.record_velocity?p1:(-1),-1,-1,-1);
+                    song->patterns[cur_edit_pattern]->tracks[cur_edit_track]->update_event(cur_edit_row,set_note,MAX_INSTS,rec_vol,-1,-1,-1);
                 } else {
                   if ((e=song->patterns[cur_edit_pattern]->tracks[cur_edit_track]->get_event(cur_edit_row)))
-                    song->patterns[cur_edit_pattern]->tracks[cur_edit_track]->update_event(cur_edit_row,set_note,-1,zt_config_globals.record_velocity?p1:(-1),-1,-1,-1);
+                    song->patterns[cur_edit_pattern]->tracks[cur_edit_track]->update_event(cur_edit_row,set_note,-1,rec_vol,-1,-1,-1);
                 }
                 
                 step++;

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -2,6 +2,7 @@
 #include "platform/undo.h"
 #include "ccizer.h"
 #include "keybindings.h"
+#include "keyjazz_map.h"
 
 // KS_META stub for Cmd key support (SDL3 maps macOS Cmd to SDL_KMOD_GUI).
 // Currently keybuffer does not translate GUI -> KS_META, so KS_META is a
@@ -1752,37 +1753,10 @@ void CUI_Patterneditor::update()
         if (cur_inst >= 0 && cur_inst < MAX_INSTS &&
             song->instruments[cur_inst]) {
           int jazz_note = -1;
-          switch (scancode) {
-          case SDL_SCANCODE_Q: jazz_note = 12*base_octave;          break;
-          case SDL_SCANCODE_2: jazz_note = (12*base_octave)+1;      break;
-          case SDL_SCANCODE_W: jazz_note = (12*base_octave)+2;      break;
-          case SDL_SCANCODE_3: jazz_note = (12*base_octave)+3;      break;
-          case SDL_SCANCODE_E: jazz_note = (12*base_octave)+4;      break;
-          case SDL_SCANCODE_R: jazz_note = (12*base_octave)+5;      break;
-          case SDL_SCANCODE_5: jazz_note = (12*base_octave)+6;      break;
-          case SDL_SCANCODE_T: jazz_note = (12*base_octave)+7;      break;
-          case SDL_SCANCODE_6: jazz_note = (12*base_octave)+8;      break;
-          case SDL_SCANCODE_Y: jazz_note = (12*base_octave)+9;      break;
-          case SDL_SCANCODE_7: jazz_note = (12*base_octave)+10;     break;
-          case SDL_SCANCODE_U: jazz_note = (12*base_octave)+11;     break;
-          case SDL_SCANCODE_I: jazz_note = (12*base_octave)+12;     break;
-          case SDL_SCANCODE_9: jazz_note = (12*base_octave)+1+12;   break;
-          case SDL_SCANCODE_O: jazz_note = (12*base_octave)+2+12;   break;
-          case SDL_SCANCODE_0: jazz_note = (12*base_octave)+3+12;   break;
-          case SDL_SCANCODE_P: jazz_note = (12*base_octave)+4+12;   break;
-          case SDL_SCANCODE_Z: jazz_note = 12*(base_octave-1);      break;
-          case SDL_SCANCODE_S: jazz_note = (12*(base_octave-1))+1;  break;
-          case SDL_SCANCODE_X: jazz_note = (12*(base_octave-1))+2;  break;
-          case SDL_SCANCODE_D: jazz_note = (12*(base_octave-1))+3;  break;
-          case SDL_SCANCODE_C: jazz_note = (12*(base_octave-1))+4;  break;
-          case SDL_SCANCODE_V: jazz_note = (12*(base_octave-1))+5;  break;
-          case SDL_SCANCODE_G: jazz_note = (12*(base_octave-1))+6;  break;
-          case SDL_SCANCODE_B: jazz_note = (12*(base_octave-1))+7;  break;
-          case SDL_SCANCODE_H: jazz_note = (12*(base_octave-1))+8;  break;
-          case SDL_SCANCODE_N: jazz_note = (12*(base_octave-1))+9;  break;
-          case SDL_SCANCODE_J: jazz_note = (12*(base_octave-1))+10; break;
-          case SDL_SCANCODE_M: jazz_note = (12*(base_octave-1))+11; break;
-          default: break;
+          {
+            KeyjazzLayout kjl = zt_config_globals.keyjazz_piano_layout ? KJ_PIANO : KJ_TRACKER;
+            int kjoff = keyjazz_offset(scancode, kjl);
+            if (kjoff != KJ_NOT_A_NOTE) jazz_note = 12*base_octave + kjoff;
           }
           if (jazz_note >= 0 && jazz_note <= 0x7F &&
               !jazz_note_is_active((int)key)) {
@@ -3402,46 +3376,19 @@ case SDLK_DELETE:
                     default: break;
                     }
                     break;
-                    case T_NOTE: 
+                    case T_NOTE:
+                      // Musical note keys come from the shared keyjazz table
+                      // (keyjazz_map.h) so the tracker vs Ableton/Logic-piano
+                      // layout is one toggle, not four hand-copied switches.
+                      // Special / editing keys (Note Off, peek-play, ...) stay
+                      // in the switch below; they are never note keys in either
+                      // layout, so keyjazz_offset returns KJ_NOT_A_NOTE for them.
+                      {
+                        KeyjazzLayout kjl = zt_config_globals.keyjazz_piano_layout ? KJ_PIANO : KJ_TRACKER;
+                        int kjoff = keyjazz_offset(scancode, kjl);
+                        if (kjoff != KJ_NOT_A_NOTE) set_note = 12*base_octave + kjoff;
+                      }
                       switch(scancode) {
-                        /* TOP ROW */
-                      case SDL_SCANCODE_Q: set_note = 12*base_octave;         break;
-                      case SDL_SCANCODE_2: set_note = (12*base_octave)+1;     break;
-                      case SDL_SCANCODE_W: set_note = (12*base_octave)+2;     break;
-                      case SDL_SCANCODE_3: set_note = (12*base_octave)+3;     break;
-                      case SDL_SCANCODE_E: set_note = (12*base_octave)+4;     break;
-                      case SDL_SCANCODE_R: set_note = (12*base_octave)+5;     break;
-                      case SDL_SCANCODE_5: set_note = (12*base_octave)+6;     break;
-                      case SDL_SCANCODE_T: set_note = (12*base_octave)+7;     break;
-                      case SDL_SCANCODE_6: set_note = (12*base_octave)+8;     break;
-                      case SDL_SCANCODE_Y: set_note = (12*base_octave)+9;     break;
-                      case SDL_SCANCODE_7: set_note = (12*base_octave)+10;    break;
-                      case SDL_SCANCODE_U: set_note = (12*base_octave)+11;    break;
-                      case SDL_SCANCODE_I: set_note = (12*base_octave)+12;    break;
-                      case SDL_SCANCODE_9: set_note = (12*base_octave)+1+12;  break;
-                      case SDL_SCANCODE_O: set_note = (12*base_octave)+2+12;  break;
-                      case SDL_SCANCODE_0: set_note = (12*base_octave)+3+12;  break;
-                      case SDL_SCANCODE_P: set_note = (12*base_octave)+4+12;  break;
-                      
-                      
-                      // <Manu> Repurpose these keys
-                      //case SDLK_LEFTBRACKET: set_note = (12*base_octave)+5+12;  break;
-                      //case SDLK_RIGHTBRACKET: set_note = (12*base_octave)+6+12;  break;
-
-
-                        /* BOTTOM ROW */
-                      case SDL_SCANCODE_Z: set_note = 12*(base_octave-1);     break;
-                      case SDL_SCANCODE_S: set_note = (12*(base_octave-1))+1; break;
-                      case SDL_SCANCODE_X: set_note = (12*(base_octave-1))+2; break;
-                      case SDL_SCANCODE_D: set_note =(12*(base_octave-1))+3;  break;
-                      case SDL_SCANCODE_C: set_note =(12*(base_octave-1))+4;  break;
-                      case SDL_SCANCODE_V: set_note = (12*(base_octave-1))+5; break;
-                      case SDL_SCANCODE_G: set_note = (12*(base_octave-1))+6; break;
-                      case SDL_SCANCODE_B: set_note = (12*(base_octave-1))+7; break;
-                      case SDL_SCANCODE_H: set_note = (12*(base_octave-1))+8; break;
-                      case SDL_SCANCODE_N: set_note = (12*(base_octave-1))+9; break;
-                      case SDL_SCANCODE_J: set_note = (12*(base_octave-1))+10;break;
-                      case SDL_SCANCODE_M: set_note = (12*(base_octave-1))+11;break;
                         /* EDITING KEYS */
                         // Switch is on scancode (see line 2920); use
                         // SDL_SCANCODE_* here too. Mixing SDLK_* into a

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -254,6 +254,7 @@ ZTConf::ZTConf() {
     default_directory[0] = '\0';
     record_velocity = 1;
     cc_draw_overwrite = 0;  // default OFF: protect existing drawbars
+    keyjazz_piano_layout = 0;  // default OFF: classic tracker keyjazz layout
     post_load_page = POST_LOAD_PATTERN_EDIT;
     note_audition_step_mode = ZT_NAS_EDITSTEP;
     ccizer_folder[0] = '\0';
@@ -360,7 +361,8 @@ int ZTConf::load()
   centered_editing = getFlag("centered_edit");
   record_velocity = getFlag("record_velocity");
   if (Config->get("cc_draw_overwrite")) cc_draw_overwrite = getFlag("cc_draw_overwrite");
-  
+  if (Config->get("keyjazz_piano")) keyjazz_piano_layout = getFlag("keyjazz_piano");
+
   if(Config->get("default_directory"))                strcpy(default_directory, Config->get("default_directory"));
   if(Config->get("autoload_ztfile_filename"))         strcpy(autoload_ztfile_filename, Config->get("autoload_ztfile_filename"));
 
@@ -495,6 +497,11 @@ int ZTConf::save() {
         Config->set("cc_draw_overwrite","yes");
     else
         Config->set("cc_draw_overwrite","no");
+
+    if (keyjazz_piano_layout)
+        Config->set("keyjazz_piano","yes");
+    else
+        Config->set("keyjazz_piano","no");
 
     if (midi_in_sync)
         Config->set("midi_in_sync","yes");

--- a/src/conf.h
+++ b/src/conf.h
@@ -100,6 +100,10 @@ class ZTConf {
         // accidentally overwritten when you cycle to a new CC. When 1,
         // mouse-drag overwrites any prior effect on the row.
         int cc_draw_overwrite;
+        // 0 (default) = classic tracker keyjazz layout (Q-row + Z-row octaves).
+        // 1 = Ableton Live / Logic "Musical Typing" piano layout: home row is
+        // the white keys, the row above is the black keys. See keyjazz_map.h.
+        int keyjazz_piano_layout;
         int post_load_page;        // E_post_load_page — page to switch to after a successful load
         char window_icon[MAX_PATH + 1];
         // How far the cursor advances after the 4 / 8 audition keys

--- a/src/keyjazz_map.h
+++ b/src/keyjazz_map.h
@@ -1,0 +1,120 @@
+// keyjazz_map.h
+//
+// Single source of truth for the computer-keyboard -> note layout used by
+// every keyjazz / note-entry path in zTracker:
+//   * Pattern Editor cell entry          (CUI_Patterneditor.cpp, T_NOTE)
+//   * Pattern Editor draw-mode audition  (CUI_Patterneditor.cpp)
+//   * Instrument Editor audition         (CUI_InstEditor.cpp)
+//   * Arpeggio Editor keyjazz slot       (CUI_Arpeggioeditor.cpp)
+//
+// Before this header existed, the layout was hand-copied as four separate
+// switch statements. Adding a second layout meant editing four copies -- the
+// exact "fix the widget, not every caller" foot-gun CLAUDE.md warns about. Now
+// all four call keyjazz_offset() and the layout is one branch.
+//
+// The function returns a semitone OFFSET relative to (12 * base_octave). The
+// caller adds the base itself:
+//
+//     int off = keyjazz_offset(scancode, layout);
+//     if (off != KJ_NOT_A_NOTE) { int note = 12*base_octave + off; ... }
+//
+// Two layouts:
+//
+//   KJ_TRACKER  -- the classic Impulse / Fast Tracker two-row layout (default,
+//                  byte-for-byte what zTracker always did):
+//                    top row    Q 2 W 3 E R 5 T 6 Y 7 U I 9 O 0 P  ->   0..16
+//                    bottom row Z S X D C V G B H N J M            -> -12..-1
+//
+//   KJ_PIANO    -- the Ableton Live / Logic "Musical Typing" layout, so users
+//                  who keyjazz in those DAWs keep their muscle memory. The home
+//                  row is the white keys, the row above is the black keys -- one
+//                  piano octave climbing rightward, extended through ' :
+//                    white  A S D F G H J K L ; '  ->  0 2 4 5 7 9 11 12 14 16 17
+//                    black  W E   T Y U   O P      ->  1 3   6 8 10  13 15
+//                  i.e. exactly the "awsedftgyhujk" run the user asked for
+//                  (a=C w=C# s=D e=D# d=E f=F t=F# g=G y=G# h=A u=A# j=B k=C).
+//                  Z/X/C/V are deliberately NOT note keys here: in Logic/Live
+//                  they are octave-shift (Z/X) and velocity (C/V) controls.
+//                  zTracker keeps its own base_octave controls; those keys are
+//                  simply left free in piano mode.
+//
+// SDL-free in spirit: this header names SDL_SCANCODE_* tokens but does not
+// include SDL itself. Production translation units already include SDL; the
+// unit test (tests/test_keyjazz_map.cpp) pulls in the handful of SDL_SCANCODE_*
+// values it needs from tests/sdl_stub.h.
+
+#ifndef ZT_KEYJAZZ_MAP_H
+#define ZT_KEYJAZZ_MAP_H
+
+enum KeyjazzLayout { KJ_TRACKER = 0, KJ_PIANO = 1 };
+
+// Returned for any key that is not a musical note key in the given layout.
+// Matches the Arpeggio editor's historical -127 sentinel so behaviour is
+// identical after the callers are repointed at this function.
+static const int KJ_NOT_A_NOTE = -127;
+
+static inline int keyjazz_offset(int scancode, KeyjazzLayout layout) {
+    if (layout == KJ_PIANO) {
+        switch (scancode) {
+            // White keys -- home row (C D E F G A B C D E F)
+            case SDL_SCANCODE_A:          return 0;   // C
+            case SDL_SCANCODE_S:          return 2;   // D
+            case SDL_SCANCODE_D:          return 4;   // E
+            case SDL_SCANCODE_F:          return 5;   // F
+            case SDL_SCANCODE_G:          return 7;   // G
+            case SDL_SCANCODE_H:          return 9;   // A
+            case SDL_SCANCODE_J:          return 11;  // B
+            case SDL_SCANCODE_K:          return 12;  // C  (octave up)
+            case SDL_SCANCODE_L:          return 14;  // D
+            case SDL_SCANCODE_SEMICOLON:  return 16;  // E
+            case SDL_SCANCODE_APOSTROPHE: return 17;  // F
+            // Black keys -- upper row (C# D# . F# G# A# . C# D#)
+            case SDL_SCANCODE_W:          return 1;   // C#
+            case SDL_SCANCODE_E:          return 3;   // D#
+            case SDL_SCANCODE_T:          return 6;   // F#
+            case SDL_SCANCODE_Y:          return 8;   // G#
+            case SDL_SCANCODE_U:          return 10;  // A#
+            case SDL_SCANCODE_O:          return 13;  // C# (octave up)
+            case SDL_SCANCODE_P:          return 15;  // D#
+            default:                      return KJ_NOT_A_NOTE;
+        }
+    }
+
+    // KJ_TRACKER (default)
+    switch (scancode) {
+        // Top row -- upper octave (offsets 0..16 from 12*base_octave)
+        case SDL_SCANCODE_Q: return 0;
+        case SDL_SCANCODE_2: return 1;
+        case SDL_SCANCODE_W: return 2;
+        case SDL_SCANCODE_3: return 3;
+        case SDL_SCANCODE_E: return 4;
+        case SDL_SCANCODE_R: return 5;
+        case SDL_SCANCODE_5: return 6;
+        case SDL_SCANCODE_T: return 7;
+        case SDL_SCANCODE_6: return 8;
+        case SDL_SCANCODE_Y: return 9;
+        case SDL_SCANCODE_7: return 10;
+        case SDL_SCANCODE_U: return 11;
+        case SDL_SCANCODE_I: return 12;
+        case SDL_SCANCODE_9: return 13;
+        case SDL_SCANCODE_O: return 14;
+        case SDL_SCANCODE_0: return 15;
+        case SDL_SCANCODE_P: return 16;
+        // Bottom row -- lower octave (offsets -12..-1; 12*(base_octave-1)+N)
+        case SDL_SCANCODE_Z: return -12;
+        case SDL_SCANCODE_S: return -11;
+        case SDL_SCANCODE_X: return -10;
+        case SDL_SCANCODE_D: return -9;
+        case SDL_SCANCODE_C: return -8;
+        case SDL_SCANCODE_V: return -7;
+        case SDL_SCANCODE_G: return -6;
+        case SDL_SCANCODE_B: return -5;
+        case SDL_SCANCODE_H: return -4;
+        case SDL_SCANCODE_N: return -3;
+        case SDL_SCANCODE_J: return -2;
+        case SDL_SCANCODE_M: return -1;
+        default:             return KJ_NOT_A_NOTE;
+    }
+}
+
+#endif // ZT_KEYJAZZ_MAP_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -203,6 +203,7 @@ int cur_inst = 0;
 const char *col_desc[41];
 
 int base_octave = BASE_OCTAVE_DEFAULT ;
+int keyjazz_velocity = KEYJAZZ_VELOCITY_DEFAULT ;
 int cur_step = DEFAULT_CURSOR_STEP ;
 
 int keypress=0;

--- a/src/zt.h
+++ b/src/zt.h
@@ -147,6 +147,12 @@ static inline void zt_text_input_stop(void) {
 #define BASE_OCTAVE_MAX                 9
 #define BASE_OCTAVE_DEFAULT             4
 
+// Keyjazz velocity used by the Ableton/Logic piano keyjazz layout: C lowers,
+// V raises it (clamped 1..127) and it is written into the volume column of
+// notes entered in piano mode. Plain session global like base_octave.
+#define KEYJAZZ_VELOCITY_DEFAULT        100
+#define KEYJAZZ_VELOCITY_STEP           8
+
 #define DEFAULT_CURSOR_STEP             1
 
 #define EDIT_LOCK_TIMEOUT               800 // ms
@@ -707,6 +713,7 @@ extern int cur_edit_pattern;
 extern int cur_edit_track_disp;
 extern int cur_edit_column;
 extern int base_octave ;
+extern int keyjazz_velocity ;
 extern int cur_step;
 
 // CC drawmode -- when non-zero, the Pattern Editor's MIDI-in handler

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -132,3 +132,17 @@ add_executable(test_ccenv
 target_include_directories(test_ccenv PRIVATE "${CMAKE_SOURCE_DIR}/src")
 target_compile_features(test_ccenv PRIVATE cxx_std_17)
 add_test(NAME ccenv COMMAND test_ccenv)
+
+# Shared keyjazz note table (keyjazz_map.h). Regression-guards the tracker
+# layout byte-for-byte after the four-switch -> one-function refactor, and
+# locks in the Ableton/Logic piano layout + the two layouts' mutual exclusivity.
+# SDL-free: scancodes come from tests/sdl_stub.h.
+add_executable(test_keyjazz_map
+    test_keyjazz_map.cpp
+)
+target_include_directories(test_keyjazz_map PRIVATE
+    "${CMAKE_SOURCE_DIR}/src"
+    "${CMAKE_SOURCE_DIR}/tests"
+)
+target_compile_features(test_keyjazz_map PRIVATE cxx_std_17)
+add_test(NAME keyjazz_map COMMAND test_keyjazz_map)

--- a/tests/sdl_stub.h
+++ b/tests/sdl_stub.h
@@ -79,4 +79,46 @@ typedef uint16_t SDL_Keymod;
 #define SDLK_PAGEUP    ((unsigned int)0x40000056)
 #define SDLK_PAGEDOWN  ((unsigned int)0x40000057)
 
+// SDL3 physical scancodes (real values from SDL_scancode.h) — used by the
+// keyjazz_map test so the shared note table can be exercised SDL-free.
+#define SDL_SCANCODE_A 4
+#define SDL_SCANCODE_B 5
+#define SDL_SCANCODE_C 6
+#define SDL_SCANCODE_D 7
+#define SDL_SCANCODE_E 8
+#define SDL_SCANCODE_F 9
+#define SDL_SCANCODE_G 10
+#define SDL_SCANCODE_H 11
+#define SDL_SCANCODE_I 12
+#define SDL_SCANCODE_J 13
+#define SDL_SCANCODE_K 14
+#define SDL_SCANCODE_L 15
+#define SDL_SCANCODE_M 16
+#define SDL_SCANCODE_N 17
+#define SDL_SCANCODE_O 18
+#define SDL_SCANCODE_P 19
+#define SDL_SCANCODE_Q 20
+#define SDL_SCANCODE_R 21
+#define SDL_SCANCODE_S 22
+#define SDL_SCANCODE_T 23
+#define SDL_SCANCODE_U 24
+#define SDL_SCANCODE_V 25
+#define SDL_SCANCODE_W 26
+#define SDL_SCANCODE_X 27
+#define SDL_SCANCODE_Y 28
+#define SDL_SCANCODE_Z 29
+#define SDL_SCANCODE_1 30
+#define SDL_SCANCODE_2 31
+#define SDL_SCANCODE_3 32
+#define SDL_SCANCODE_4 33
+#define SDL_SCANCODE_5 34
+#define SDL_SCANCODE_6 35
+#define SDL_SCANCODE_7 36
+#define SDL_SCANCODE_8 37
+#define SDL_SCANCODE_9 38
+#define SDL_SCANCODE_0 39
+#define SDL_SCANCODE_SEMICOLON  51
+#define SDL_SCANCODE_APOSTROPHE 52
+#define SDL_SCANCODE_GRAVE      53
+
 #endif // ZT_SDL_STUB_H

--- a/tests/test_keyjazz_map.cpp
+++ b/tests/test_keyjazz_map.cpp
@@ -1,0 +1,138 @@
+// test_keyjazz_map.cpp -- tests for the shared keyjazz note table.
+//
+// keyjazz_map.h is the single source of truth for the computer-keyboard ->
+// note layout used by the Pattern Editor (cell entry + draw-mode audition),
+// the Instrument Editor, and the Arpeggio Editor. Two layouts:
+//
+//   KJ_TRACKER  classic Impulse/Fast Tracker two-row layout (default)
+//   KJ_PIANO    Ableton Live / Logic "Musical Typing" piano layout
+//
+// The KJ_TRACKER cases are the regression guard for the 2026-05 refactor that
+// collapsed four hand-copied switches into this one function: they must match
+// the legacy tables byte-for-byte. The KJ_PIANO cases lock in the requested
+// "awsedftgyhujk" run and the mutual-exclusivity of the two layouts.
+
+#include "sdl_stub.h"      // SDL_SCANCODE_* without linking SDL
+#include "keyjazz_map.h"
+
+#include <cstdio>
+
+static int g_failures = 0;
+static int g_total    = 0;
+
+#define CHECK_EQ(a, b) do {                                    \
+    ++g_total;                                                 \
+    auto _av = (a);                                            \
+    auto _bv = (b);                                            \
+    if (!(_av == _bv)) {                                       \
+        ++g_failures;                                          \
+        std::fprintf(stderr, "FAIL  %s:%d  %s == %s "          \
+                     "(got %lld vs %lld)\n",                   \
+                     __FILE__, __LINE__, #a, #b,               \
+                     (long long)_av, (long long)_bv);          \
+    }                                                          \
+} while (0)
+
+static int trk(int sc) { return keyjazz_offset(sc, KJ_TRACKER); }
+static int pno(int sc) { return keyjazz_offset(sc, KJ_PIANO);   }
+
+int main() {
+    // ---- Sentinel value contract -----------------------------------------
+    // The Arpeggio editor's callers test `off != -127`; keep it pinned.
+    CHECK_EQ(KJ_NOT_A_NOTE, -127);
+
+    // ---- KJ_TRACKER: top row (upper octave, offsets 0..16) ---------------
+    CHECK_EQ(trk(SDL_SCANCODE_Q), 0);
+    CHECK_EQ(trk(SDL_SCANCODE_2), 1);
+    CHECK_EQ(trk(SDL_SCANCODE_W), 2);
+    CHECK_EQ(trk(SDL_SCANCODE_3), 3);
+    CHECK_EQ(trk(SDL_SCANCODE_E), 4);
+    CHECK_EQ(trk(SDL_SCANCODE_R), 5);
+    CHECK_EQ(trk(SDL_SCANCODE_5), 6);
+    CHECK_EQ(trk(SDL_SCANCODE_T), 7);
+    CHECK_EQ(trk(SDL_SCANCODE_6), 8);
+    CHECK_EQ(trk(SDL_SCANCODE_Y), 9);
+    CHECK_EQ(trk(SDL_SCANCODE_7), 10);
+    CHECK_EQ(trk(SDL_SCANCODE_U), 11);
+    CHECK_EQ(trk(SDL_SCANCODE_I), 12);
+    CHECK_EQ(trk(SDL_SCANCODE_9), 13);
+    CHECK_EQ(trk(SDL_SCANCODE_O), 14);
+    CHECK_EQ(trk(SDL_SCANCODE_0), 15);
+    CHECK_EQ(trk(SDL_SCANCODE_P), 16);
+
+    // ---- KJ_TRACKER: bottom row (lower octave, offsets -12..-1) ----------
+    CHECK_EQ(trk(SDL_SCANCODE_Z), -12);
+    CHECK_EQ(trk(SDL_SCANCODE_S), -11);
+    CHECK_EQ(trk(SDL_SCANCODE_X), -10);
+    CHECK_EQ(trk(SDL_SCANCODE_D), -9);
+    CHECK_EQ(trk(SDL_SCANCODE_C), -8);
+    CHECK_EQ(trk(SDL_SCANCODE_V), -7);
+    CHECK_EQ(trk(SDL_SCANCODE_G), -6);
+    CHECK_EQ(trk(SDL_SCANCODE_B), -5);
+    CHECK_EQ(trk(SDL_SCANCODE_H), -4);
+    CHECK_EQ(trk(SDL_SCANCODE_N), -3);
+    CHECK_EQ(trk(SDL_SCANCODE_J), -2);
+    CHECK_EQ(trk(SDL_SCANCODE_M), -1);
+
+    // ---- KJ_TRACKER: keys with no note are sentinel ----------------------
+    CHECK_EQ(trk(SDL_SCANCODE_A), KJ_NOT_A_NOTE);  // unused in tracker layout
+    CHECK_EQ(trk(SDL_SCANCODE_K), KJ_NOT_A_NOTE);
+    CHECK_EQ(trk(SDL_SCANCODE_L), KJ_NOT_A_NOTE);
+    CHECK_EQ(trk(SDL_SCANCODE_F), KJ_NOT_A_NOTE);
+    CHECK_EQ(trk(SDL_SCANCODE_1), KJ_NOT_A_NOTE);  // Note Off lives in the editor switch
+    CHECK_EQ(trk(SDL_SCANCODE_4), KJ_NOT_A_NOTE);  // peek-play
+    CHECK_EQ(trk(SDL_SCANCODE_8), KJ_NOT_A_NOTE);  // peek-play row
+    CHECK_EQ(trk(SDL_SCANCODE_GRAVE), KJ_NOT_A_NOTE);
+
+    // ---- KJ_PIANO: the exact "awsedftgyhujk" run = chromatic C..C --------
+    CHECK_EQ(pno(SDL_SCANCODE_A), 0);   // C
+    CHECK_EQ(pno(SDL_SCANCODE_W), 1);   // C#
+    CHECK_EQ(pno(SDL_SCANCODE_S), 2);   // D
+    CHECK_EQ(pno(SDL_SCANCODE_E), 3);   // D#
+    CHECK_EQ(pno(SDL_SCANCODE_D), 4);   // E
+    CHECK_EQ(pno(SDL_SCANCODE_F), 5);   // F
+    CHECK_EQ(pno(SDL_SCANCODE_T), 6);   // F#
+    CHECK_EQ(pno(SDL_SCANCODE_G), 7);   // G
+    CHECK_EQ(pno(SDL_SCANCODE_Y), 8);   // G#
+    CHECK_EQ(pno(SDL_SCANCODE_H), 9);   // A
+    CHECK_EQ(pno(SDL_SCANCODE_U), 10);  // A#
+    CHECK_EQ(pno(SDL_SCANCODE_J), 11);  // B
+    CHECK_EQ(pno(SDL_SCANCODE_K), 12);  // C
+
+    // ---- KJ_PIANO: the extended upper keys (L ; ' and O P) ---------------
+    CHECK_EQ(pno(SDL_SCANCODE_O), 13);          // C#
+    CHECK_EQ(pno(SDL_SCANCODE_L), 14);          // D
+    CHECK_EQ(pno(SDL_SCANCODE_P), 15);          // D#
+    CHECK_EQ(pno(SDL_SCANCODE_SEMICOLON), 16);  // E
+    CHECK_EQ(pno(SDL_SCANCODE_APOSTROPHE), 17); // F
+
+    // ---- KJ_PIANO: Z/X/C/V are NOT notes (Logic reserves them) -----------
+    CHECK_EQ(pno(SDL_SCANCODE_Z), KJ_NOT_A_NOTE);  // octave shift in Logic/Live
+    CHECK_EQ(pno(SDL_SCANCODE_X), KJ_NOT_A_NOTE);
+    CHECK_EQ(pno(SDL_SCANCODE_C), KJ_NOT_A_NOTE);  // velocity in Logic/Live
+    CHECK_EQ(pno(SDL_SCANCODE_V), KJ_NOT_A_NOTE);
+    CHECK_EQ(pno(SDL_SCANCODE_B), KJ_NOT_A_NOTE);
+    CHECK_EQ(pno(SDL_SCANCODE_N), KJ_NOT_A_NOTE);
+    CHECK_EQ(pno(SDL_SCANCODE_M), KJ_NOT_A_NOTE);
+    CHECK_EQ(pno(SDL_SCANCODE_Q), KJ_NOT_A_NOTE);  // top row not used in piano
+    CHECK_EQ(pno(SDL_SCANCODE_R), KJ_NOT_A_NOTE);
+    CHECK_EQ(pno(SDL_SCANCODE_I), KJ_NOT_A_NOTE);
+    CHECK_EQ(pno(SDL_SCANCODE_2), KJ_NOT_A_NOTE);  // no number keys in piano
+
+    // ---- Mutual exclusivity: shared keys mean different notes ------------
+    // These are exactly why the two layouts cannot coexist on one keymap and
+    // why the feature is a mode toggle, not an additive binding.
+    CHECK_EQ(trk(SDL_SCANCODE_S), -11);  // tracker: C#-ish low
+    CHECK_EQ(pno(SDL_SCANCODE_S), 2);    // piano:   D
+    CHECK_EQ(trk(SDL_SCANCODE_W), 2);    // tracker: D (upper)
+    CHECK_EQ(pno(SDL_SCANCODE_W), 1);    // piano:   C#
+    CHECK_EQ(trk(SDL_SCANCODE_E), 4);    // tracker: E
+    CHECK_EQ(pno(SDL_SCANCODE_E), 3);    // piano:   D#
+
+    if (g_failures == 0)
+        std::printf("test_keyjazz_map: all %d checks passed\n", g_total);
+    else
+        std::fprintf(stderr, "test_keyjazz_map: %d/%d checks FAILED\n",
+                     g_failures, g_total);
+    return g_failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Adds a **PianoKey** checkbox to the Pattern Editor Options (press **F2 twice**) that switches the computer-keyboard note layout from the classic tracker layout to the **Ableton Live / Logic "Musical Typing"** layout, plus the Logic-style **Z/X octave** and **C/V velocity** transport controls. Users who keyjazz in those DAWs all day keep their muscle memory in zTracker.

```
tracker (default):  Q-row = upper octave, Z-row = lower octave
piano  (PianoKey):  home row  A S D F G H J K (L ; ')  = white keys
                    row above W E   T Y U   (O P)      = black keys
```

So `a`=C `w`=C# `s`=D `e`=D# `d`=E `f`=F `t`=F# `g`=G `y`=G# `h`=A `u`=A# `j`=B `k`=C — exactly the `awsedftgyhujk` run.

## Transport controls (piano mode, Pattern Editor note column)

- **Z / X** — octave down / up. The existing `[` `]` (and KP `*` `/`) octave keys keep working everywhere as before; Z/X are an **additional** control, scoped to the note column so they never shadow text/effect-column input.
- **C / V** — decrease / increase the keyjazz velocity (step 8, clamped 1..127). The new value is shown in the status bar (`KeyJazz velocity: NN`) so you can see what notes will use going forward.
- Notes played/entered in piano mode are **written to the pattern with that keyjazz velocity in the volume column**, regardless of the RecVeloc toggle.

## Root change / why it's a refactor too

The keyjazz keyboard→note layout was **hand-copied as four separate `switch` statements** — Pattern Editor cell entry, Pattern Editor draw-mode audition, Instrument Editor audition, and the Arpeggio Editor offset helper. Adding a second layout to four copies is the exact "fix the widget, not every caller" foot-gun `CLAUDE.md` warns about. This collapses all four onto **one shared, SDL-free, unit-tested table** (`src/keyjazz_map.h`); the layout is a single branch inside `keyjazz_offset()`.

## What's wired

- `src/keyjazz_map.h` — `KJ_TRACKER` / `KJ_PIANO` tables + `keyjazz_offset(scancode, layout)`.
- `conf` — `keyjazz_piano=yes/no` persists in `zt.conf`, **default off** (no change for existing users).
- `keyjazz_velocity` session global in `main.cpp` / `zt.h` (next to `base_octave`); `KEYJAZZ_VELOCITY_DEFAULT=100`, `KEYJAZZ_VELOCITY_STEP=8`.
- `CUI_PEParms` — `PianoKey` checkbox (element 10), bottom row next to DrawMode/CCOver.
- Z/X/C/V handled in the `T_NOTE` case (note-column-scoped); velocity flows into both the recorded event and the audition noteOn.
- Layout applies to all note-entry paths: Pattern + Instrument + Arpeggio editors.
- `tests/test_keyjazz_map.cpp` — **12th CTest target**, regression-guards the tracker layout byte-for-byte and locks in the piano layout + the two layouts' mutual exclusivity.
- `doc/help.txt` + `doc/CHANGELOG.txt` updated.

## Not in this PR

Tab sustain, 1/2 pitch bend, 3–8 modulation (the remaining Logic Musical-Typing controls) — not requested yet.

## Test plan

- [x] Clean build (macOS, Unix Makefiles)
- [x] `ctest` — 12/12 pass (was 11)
- [x] F2 F2 panel renders the PianoKey checkbox aligned in the bottom row
- [ ] Manual (maintainer / author): toggle PianoKey on, confirm `a w s e d f t g y h u j k` enters C C# D … , that Z/X shift octave, and C/V change the velocity written to the volume column

🤖 Generated with [Claude Code](https://claude.com/claude-code)
