### PR TITLE
Instrument Editor: "Create 16 Channels" for the current MIDI device

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ set(ZT_SOURCES
   src/CUI_PEFindReplace.cpp
   src/CUI_PENature.cpp
   src/CUI_PEParms.cpp
+  src/CUI_IEParms.cpp
   src/CUI_PEVol.cpp
   src/CUI_Playsong.cpp
   src/CUI_RUSure.cpp

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,30 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_05_29 (Instrument Editor: Create 16 channels for a MIDI device)
+----------------------------------------------------------------------------
+
+        + New "Create 16 Channels" action in the Instrument Editor (F3).
+          It takes the current instrument's MIDI Out device and fills the
+          next up-to-16 EMPTY instrument slots with that device on channels
+          1..16, named "<device> Channel 01" .. "<device> Channel 16"
+          (e.g. "IAC Bus 1 Channel 01" .. "IAC Bus 1 Channel 16"). Great
+          for setting up a multitimbral device fast.
+
+        + Two ways to trigger it:
+            - Press F3 again while already on the Instrument Editor to open
+              the new Instrument Editor Options popup (shows the device
+              name + a "Create 16 Channels" button; Enter confirms, Esc
+              cancels). Mirrors the F2-again Pattern Editor Options popup.
+            - Alt+G in the Instrument Editor does it directly.
+
+        + Non-destructive: only EMPTY instrument slots are used, so existing
+          instruments are never overwritten. A slot counts as empty when it
+          has no device, no name, and default patch/bank (the channel field
+          is ignored, since the engine pre-seeds channels 1..16 onto the
+          first 16 slots as a convenience). Assign a device to the current
+          instrument first (Alt+1..0); the source instrument is preserved.
+
 zt 2026_05_28 (Ableton/Logic piano keyjazz layout toggle in F2 F2)
 ----------------------------------------------------------------------------
 

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -16,10 +16,12 @@ zt 2026_05_29 (Instrument Editor: Create 16 channels for a MIDI device)
 
         + Two ways to trigger it:
             - Press F3 again while already on the Instrument Editor to open
-              the new Instrument Editor Options popup (shows the device
-              name + a "Create 16 Channels" button; Enter confirms, Esc
-              cancels). Mirrors the F2-again Pattern Editor Options popup.
-            - Alt+G in the Instrument Editor does it directly.
+              a popup that lists the open MIDI Out devices: pick one
+              (Up/Dn), then Enter or the "Create 16 Channels" button
+              generates them; Esc cancels. No need to assign a device
+              elsewhere first. Mirrors the F2-again Pattern Editor popup.
+            - Alt+G in the Instrument Editor does it directly using the
+              current instrument's device.
 
         + Non-destructive: only EMPTY instrument slots are used, so existing
           instruments are never overwritten. A slot counts as empty when it

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -134,7 +134,16 @@
                   editing screen brings up the pattern settings, including
                   the "PianoKey" toggle (tracker vs Ableton/Logic keyjazz
                   layout).
- F3             : Instrument editor
+ F3             : Instrument editor. Pressing F3 again (while already on it)
+                  opens the Instrument Editor Options popup with a
+                  "Create 16 Channels" action: it takes the current
+                  instrument's MIDI Out device and fills the next 16 empty
+                  instrument slots with channels 1-16, named
+                  "<device> Channel 01" .. "<device> Channel 16" (e.g.
+                  "IAC Bus 1 Channel 01"). Non-destructive: existing
+                  instruments are never overwritten. Alt+G does the same
+                  thing directly without the popup. (Assign a device first
+                  via Alt+1..0.)
  SHIFT-F2       : Shortcuts & MIDI Mappings (unified per-action grid:
                   Keyboard | MIDI1 | MIDI2 | MIDI3). Up/Dn/Lt/Rt move,
                   Enter edits, Backspace clears, Ctrl+S saves both

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -135,15 +135,14 @@
                   the "PianoKey" toggle (tracker vs Ableton/Logic keyjazz
                   layout).
  F3             : Instrument editor. Pressing F3 again (while already on it)
-                  opens the Instrument Editor Options popup with a
-                  "Create 16 Channels" action: it takes the current
-                  instrument's MIDI Out device and fills the next 16 empty
-                  instrument slots with channels 1-16, named
+                  opens a popup where you PICK a MIDI Out device from a list
+                  and hit "Create 16 Channels": it fills the next 16 empty
+                  instrument slots with that device on channels 1-16, named
                   "<device> Channel 01" .. "<device> Channel 16" (e.g.
-                  "IAC Bus 1 Channel 01"). Non-destructive: existing
-                  instruments are never overwritten. Alt+G does the same
-                  thing directly without the popup. (Assign a device first
-                  via Alt+1..0.)
+                  "IAC Bus 1 Channel 01"). Up/Dn pick, Enter creates, Esc
+                  cancels. Non-destructive: existing instruments are never
+                  overwritten. Alt+G does the same thing directly using the
+                  CURRENT instrument's device (no popup).
  SHIFT-F2       : Shortcuts & MIDI Mappings (unified per-action grid:
                   Keyboard | MIDI1 | MIDI2 | MIDI3). Up/Dn/Lt/Rt move,
                   Enter edits, Backspace clears, Ctrl+S saves both

--- a/src/CUI_IEParms.cpp
+++ b/src/CUI_IEParms.cpp
@@ -1,0 +1,116 @@
+#include "zt.h"
+#include "Button.h"
+
+// Instrument Editor options popup -- opened by pressing F3 again while already
+// on the Instrument Editor (mirrors the F2-again CUI_PEParms popup). One
+// action: create 16 instruments for the current instrument's MIDI device, one
+// per channel 1..16, into the next empty slots. The same action is also bound
+// to Alt+G in the Instrument Editor (see CUI_InstEditor.cpp).
+
+void BTNCLK_Create16Channels(UserInterfaceElement *) {
+    inst_create_16_channels_for_current_device();  // writes its own statusmsg
+    close_popup_window();
+    need_refresh++;
+}
+
+CUI_IEParms::CUI_IEParms(void) {
+    UI = new UserInterface;
+
+    int window_width  = 46 * col(1);
+    int window_height = 11 * row(1);
+    int start_x = (INTERNAL_RESOLUTION_X / 2) - (window_width / 2);
+    for (; start_x % 8; start_x--) ;
+    int start_y = (INTERNAL_RESOLUTION_Y / 2) - (window_height / 2);
+    for (; start_y % 8; start_y--) ;
+
+    btn_create16 = new Button;
+    UI->add_element(btn_create16, 0);
+    btn_create16->x = (start_x / 8) + 14;
+    btn_create16->y = (start_y / 8) + 7;
+    btn_create16->xsize = 18;
+    btn_create16->ysize = 1;
+    btn_create16->caption = " Create 16 Channels";
+    btn_create16->OnClick = (ActFunc)BTNCLK_Create16Channels;
+}
+
+void CUI_IEParms::enter(void) {
+    need_refresh = 1;
+    cur_state = STATE_IEDIT_WIN;
+}
+
+void CUI_IEParms::leave(void) {
+    cur_state = STATE_IEDIT;
+}
+
+void CUI_IEParms::update(void) {
+    int key = 0;
+
+    UI->update();   // drives the Create-16 button (its OnClick closes the popup)
+
+    if (Keys.size()) {
+        key = Keys.getkey();
+        if (key == SDLK_ESCAPE || key == SDLK_F3 ||
+            key == ((unsigned int)((SDL_EVENT_MOUSE_BUTTON_DOWN << 8) | SDL_BUTTON_RIGHT))) {
+            close_popup_window();
+            fixmouse++;
+            need_refresh++;
+        } else if (key == SDLK_RETURN) {
+            // Enter = confirm, same as clicking the button.
+            inst_create_16_channels_for_current_device();
+            close_popup_window();
+            fixmouse++;
+            need_refresh++;
+        }
+    }
+}
+
+void CUI_IEParms::draw(Drawable *S) {
+    int window_width  = 46 * col(1);
+    int window_height = 11 * row(1);
+    int start_x = (INTERNAL_RESOLUTION_X / 2) - (window_width / 2);
+    for (; start_x % 8; start_x--) ;
+    int start_y = (INTERNAL_RESOLUTION_Y / 2) - (window_height / 2);
+    for (; start_y % 8; start_y--) ;
+
+    btn_create16->x = (start_x / 8) + 14;
+    btn_create16->y = (start_y / 8) + 7;
+
+    // Resolve the current instrument's MIDI device name for display.
+    const char *devname = NULL;
+    if (song && cur_inst >= 0 && cur_inst < MAX_INSTS && song->instruments[cur_inst]) {
+        unsigned int dev = song->instruments[cur_inst]->midi_device;
+        if (dev < MidiOut->numOuputDevices) {
+            const char *alias = MidiOut->outputDevices[dev]->alias;
+            const char *name  = MidiOut->outputDevices[dev]->szName;
+            devname = (alias != NULL && strlen(alias) > 1) ? alias : name;
+        }
+    }
+
+    if (S->lock() == 0) {
+        S->fillRect(start_x, start_y, start_x + window_width, start_y + window_height, COLORS.Background);
+        printline(start_x, start_y + window_height - row(1) + 1, 148, window_width / 8, COLORS.Lowlight, S);
+        for (int i = start_y / row(1); i < (start_y + window_height) / row(1); i++) {
+            printchar(start_x, row(i), 145, COLORS.Highlight, S);
+            printchar(start_x + window_width - row(1) + 1, row(i), 146, COLORS.Lowlight, S);
+        }
+        printline(start_x, start_y, 143, window_width / 8, COLORS.Highlight, S);
+        print(col(textcenter("Instrument Editor Options")), start_y + row(2), "Instrument Editor Options", COLORS.Text, S);
+
+        char line[128];
+        if (devname) {
+            snprintf(line, sizeof(line), "Device: %.30s", devname);
+            print(start_x + col(3), start_y + row(4), line, COLORS.Text, S);
+            print(start_x + col(3), start_y + row(5), "Fills the next 16 empty slots, ch 1-16.", COLORS.Lowlight, S);
+        } else {
+            print(start_x + col(3), start_y + row(4), "No MIDI device on this instrument.", COLORS.Text, S);
+            print(start_x + col(3), start_y + row(5), "Assign one (Alt+1..0) then reopen.", COLORS.Lowlight, S);
+        }
+        print(start_x + col(3), start_y + row(9), "Enter / click to create, Esc to cancel.", COLORS.Lowlight, S);
+
+        UI->full_refresh();
+        UI->draw(S);
+        S->unlock();
+        need_refresh = need_popup_refresh = 0;
+        updated++;
+    }
+}

--- a/src/CUI_IEParms.cpp
+++ b/src/CUI_IEParms.cpp
@@ -2,89 +2,153 @@
 #include "Button.h"
 
 // Instrument Editor options popup -- opened by pressing F3 again while already
-// on the Instrument Editor (mirrors the F2-again CUI_PEParms popup). One
-// action: create 16 instruments for the current instrument's MIDI device, one
-// per channel 1..16, into the next empty slots. The same action is also bound
-// to Alt+G in the Instrument Editor (see CUI_InstEditor.cpp).
+// on the Instrument Editor (mirrors the F2-again CUI_PEParms popup). Pick a
+// MIDI Out device from the in-dialog list, then "Create 16 Channels" generates
+// 16 instruments (channels 1..16) for that device, named "<device> Channel
+// 01".."<device> Channel 16", into the next empty slots. The same generation
+// (using the current instrument's device) is also bound to Alt+G in the
+// Instrument Editor (see CUI_InstEditor.cpp).
+
+// Lightweight device picker: lists the open MIDI Out devices and just tracks
+// the highlighted one. Unlike MidiOutDeviceSelector it does NOT touch the
+// current instrument on select -- the Create button reads the highlight.
+class IEGenDeviceList : public ListBox {
+    public:
+        IEGenDeviceList() {
+            empty_message  = "No MIDI Out devices are open";
+            is_sorted      = true;
+            use_checks     = false;
+            use_key_select = false;
+            OnChange();
+        }
+        void OnChange() override {
+            clear();
+            for (int i = 0; i < MidiOut->GetNumOpenDevs(); i++) {
+                int dev = MidiOut->GetDevID(i);
+                if (dev < 0 || dev >= MAX_MIDI_DEVS) continue;
+                if (MidiOut->outputDevices[dev] == NULL) continue;
+                const char *alias = MidiOut->outputDevices[dev]->alias;
+                const char *name  = MidiOut->outputDevices[dev]->szName;
+                if (name == NULL) name = "";
+                const char *disp = (alias != NULL && strlen(alias) > 1) ? alias : name;
+                LBNode *p = insertItem((char *)disp);
+                p->int_data = dev;
+            }
+        }
+        void OnSelectChange() override {}
+};
+
+// The popup is a singleton (one UIP_IEParms), so the button callback reaches
+// the live instance through this file-static pointer.
+static CUI_IEParms *g_ieparms = NULL;
 
 void BTNCLK_Create16Channels(UserInterfaceElement *) {
-    inst_create_16_channels_for_current_device();  // writes its own statusmsg
-    close_popup_window();
-    need_refresh++;
+    if (g_ieparms) g_ieparms->do_create();
 }
 
 CUI_IEParms::CUI_IEParms(void) {
     UI = new UserInterface;
+    g_ieparms = this;
 
-    int window_width  = 46 * col(1);
-    int window_height = 11 * row(1);
+    int window_width  = 48 * col(1);
+    int window_height = 18 * row(1);
     int start_x = (INTERNAL_RESOLUTION_X / 2) - (window_width / 2);
     for (; start_x % 8; start_x--) ;
     int start_y = (INTERNAL_RESOLUTION_Y / 2) - (window_height / 2);
     for (; start_y % 8; start_y--) ;
 
+    // Device picker (focused first so arrows work immediately).
+    dev_list = new IEGenDeviceList;
+    UI->add_element(dev_list, 0);
+    dev_list->x     = (start_x / 8) + 4;
+    dev_list->y     = (start_y / 8) + 5;
+    dev_list->xsize = 40;
+    dev_list->ysize = 7;
+
+    // "Create 16 Channels" button -- xsize >= caption length so the right
+    // border doesn't clip the last character. Caption padded with spaces.
     btn_create16 = new Button;
-    UI->add_element(btn_create16, 0);
-    btn_create16->x = (start_x / 8) + 14;
-    btn_create16->y = (start_y / 8) + 7;
-    btn_create16->xsize = 18;
+    UI->add_element(btn_create16, 1);
+    btn_create16->x = (start_x / 8) + 13;
+    btn_create16->y = (start_y / 8) + 14;
+    btn_create16->xsize = 22;
     btn_create16->ysize = 1;
-    btn_create16->caption = " Create 16 Channels";
+    btn_create16->caption = " Create 16 Channels ";
     btn_create16->OnClick = (ActFunc)BTNCLK_Create16Channels;
 }
 
 void CUI_IEParms::enter(void) {
     need_refresh = 1;
     cur_state = STATE_IEDIT_WIN;
+    g_ieparms = this;
+    // Refresh the device list (devices may have opened/closed) and pre-select
+    // the device currently on the active instrument, if any.
+    if (dev_list) {
+        dev_list->OnChange();
+        if (song && cur_inst >= 0 && cur_inst < MAX_INSTS && song->instruments[cur_inst]) {
+            unsigned int cur_dev = song->instruments[cur_inst]->midi_device;
+            for (int i = 0; i < dev_list->num_elements; i++) {
+                LBNode *n = dev_list->getNode(i);
+                if (n && (unsigned int)n->int_data == cur_dev) { dev_list->setCursor(i); break; }
+            }
+        }
+    }
+    UI->cur_element = 0;
 }
 
 void CUI_IEParms::leave(void) {
     cur_state = STATE_IEDIT;
 }
 
-void CUI_IEParms::update(void) {
-    int key = 0;
-
-    UI->update();   // drives the Create-16 button (its OnClick closes the popup)
-
-    if (Keys.size()) {
-        key = Keys.getkey();
-        if (key == SDLK_ESCAPE || key == SDLK_F3 ||
-            key == ((unsigned int)((SDL_EVENT_MOUSE_BUTTON_DOWN << 8) | SDL_BUTTON_RIGHT))) {
-            close_popup_window();
-            fixmouse++;
-            need_refresh++;
-        } else if (key == SDLK_RETURN) {
-            // Enter = confirm, same as clicking the button.
-            inst_create_16_channels_for_current_device();
-            close_popup_window();
-            fixmouse++;
-            need_refresh++;
-        }
+void CUI_IEParms::do_create(void) {
+    int idx = dev_list ? dev_list->getCurrentItemIndex() : -1;
+    LBNode *n = (dev_list && idx >= 0) ? dev_list->getNode(idx) : NULL;
+    if (n) {
+        inst_create_16_channels_for_device((unsigned int)n->int_data);  // sets statusmsg
+    } else {
+        sprintf(szStatmsg, "No MIDI Out device to pick (open one in F12)");
+        statusmsg = szStatmsg;
     }
+    close_popup_window();
+    fixmouse++;
+    need_refresh++;
+}
+
+void CUI_IEParms::update(void) {
+    // Handle close / confirm keys before the widgets, so Enter always means
+    // "create" (the listbox would otherwise swallow it) and Esc always closes.
+    int peek = Keys.checkkey();
+    if (peek == SDLK_ESCAPE || peek == SDLK_F3 ||
+        peek == ((unsigned int)((SDL_EVENT_MOUSE_BUTTON_DOWN << 8) | SDL_BUTTON_RIGHT))) {
+        Keys.getkey();
+        close_popup_window();
+        fixmouse++;
+        need_refresh++;
+        return;
+    }
+    if (peek == SDLK_RETURN) {
+        Keys.getkey();
+        do_create();
+        return;
+    }
+
+    // Everything else (arrows move the device list, mouse drives the button
+    // whose OnClick calls do_create) goes through the widgets.
+    UI->update();
 }
 
 void CUI_IEParms::draw(Drawable *S) {
-    int window_width  = 46 * col(1);
-    int window_height = 11 * row(1);
+    int window_width  = 48 * col(1);
+    int window_height = 18 * row(1);
     int start_x = (INTERNAL_RESOLUTION_X / 2) - (window_width / 2);
     for (; start_x % 8; start_x--) ;
     int start_y = (INTERNAL_RESOLUTION_Y / 2) - (window_height / 2);
     for (; start_y % 8; start_y--) ;
 
-    btn_create16->x = (start_x / 8) + 14;
-    btn_create16->y = (start_y / 8) + 7;
-
-    // Resolve the current instrument's MIDI device name for display.
-    const char *devname = NULL;
-    if (song && cur_inst >= 0 && cur_inst < MAX_INSTS && song->instruments[cur_inst]) {
-        unsigned int dev = song->instruments[cur_inst]->midi_device;
-        if (dev < MidiOut->numOuputDevices) {
-            const char *alias = MidiOut->outputDevices[dev]->alias;
-            const char *name  = MidiOut->outputDevices[dev]->szName;
-            devname = (alias != NULL && strlen(alias) > 1) ? alias : name;
-        }
-    }
+    dev_list->x     = (start_x / 8) + 4;
+    dev_list->y     = (start_y / 8) + 5;
+    btn_create16->x = (start_x / 8) + 13;
+    btn_create16->y = (start_y / 8) + 14;
 
     if (S->lock() == 0) {
         S->fillRect(start_x, start_y, start_x + window_width, start_y + window_height, COLORS.Background);
@@ -94,18 +158,10 @@ void CUI_IEParms::draw(Drawable *S) {
             printchar(start_x + window_width - row(1) + 1, row(i), 146, COLORS.Lowlight, S);
         }
         printline(start_x, start_y, 143, window_width / 8, COLORS.Highlight, S);
-        print(col(textcenter("Instrument Editor Options")), start_y + row(2), "Instrument Editor Options", COLORS.Text, S);
-
-        char line[128];
-        if (devname) {
-            snprintf(line, sizeof(line), "Device: %.30s", devname);
-            print(start_x + col(3), start_y + row(4), line, COLORS.Text, S);
-            print(start_x + col(3), start_y + row(5), "Fills the next 16 empty slots, ch 1-16.", COLORS.Lowlight, S);
-        } else {
-            print(start_x + col(3), start_y + row(4), "No MIDI device on this instrument.", COLORS.Text, S);
-            print(start_x + col(3), start_y + row(5), "Assign one (Alt+1..0) then reopen.", COLORS.Lowlight, S);
-        }
-        print(start_x + col(3), start_y + row(9), "Enter / click to create, Esc to cancel.", COLORS.Lowlight, S);
+        print(col(textcenter("Create 16 MIDI Channels")), start_y + row(2), "Create 16 MIDI Channels", COLORS.Text, S);
+        print(start_x + col(4), start_y + row(4), "Pick a MIDI Out device:", COLORS.Text, S);
+        print(start_x + col(4), start_y + row(16),
+              "Up/Dn: pick   Enter: create   Esc: cancel", COLORS.Lowlight, S);
 
         UI->full_refresh();
         UI->draw(S);

--- a/src/CUI_InstEditor.cpp
+++ b/src/CUI_InstEditor.cpp
@@ -35,6 +35,78 @@ void BTNCLK_InitInstrumentsOne(UserInterfaceElement*) {
     need_refresh++; 
 }
 
+// A slot is "available" to receive a generated channel instrument if it
+// carries no real user data: no MIDI device, blank name, default patch / bank,
+// and no CCizer bank. We deliberately IGNORE the channel field -- the
+// instrument constructor pre-seeds channels 1..16 onto slots 0..15 as a
+// convenience, so a strict isempty() (which counts that as data) would treat a
+// fresh song's slots 1..15 as "used" and scatter the 16 instruments past slot
+// 16. Ignoring channel lets a fresh song fill slots 0..15 consecutively.
+static bool inst_slot_available(instrument *in) {
+    // Default values mirror module.cpp's ZTM_INST_DEFAULT_* (those macros are
+    // local to module.cpp): no device = 0xff, patch = -1, bank = -1.
+    if (!in) return false;
+    if (in->midi_device != 0xff) return false;
+    if (in->patch       != -1)   return false;
+    if (in->bank        != -1)   return false;
+    if (in->ccizer_bank[0] != '\0') return false;
+    for (int i = 0; i < ZTM_INSTTITLE_MAXLEN - 1; i++)
+        if (in->title[i] != ' ') return false;
+    return true;
+}
+
+// Fill the next up-to-16 empty instrument slots with the current instrument's
+// MIDI device, on channels 1..16, named "<device> Channel 01".."Channel 16".
+// Non-destructive: only writes into available slots (never overwrites). Returns
+// the number of instruments created.
+int inst_create_16_channels_for_current_device(void) {
+    if (!song || cur_inst < 0 || cur_inst >= MAX_INSTS || !song->instruments[cur_inst])
+        return 0;
+
+    unsigned int dev = song->instruments[cur_inst]->midi_device;
+    if (dev >= MidiOut->numOuputDevices) {
+        sprintf(szStatmsg, "Assign a MIDI Out device to this instrument first");
+        statusmsg = szStatmsg; need_refresh++;
+        return 0;
+    }
+
+    // Match the device-list display: prefer a user alias, else the device name.
+    const char *alias   = MidiOut->outputDevices[dev]->alias;
+    const char *name    = MidiOut->outputDevices[dev]->szName;
+    const char *devname = (alias != NULL && strlen(alias) > 1) ? alias : name;
+
+    int created = 0;
+    for (int i = 0; i < MAX_INSTS && created < 16; i++) {
+        instrument *in = song->instruments[i];
+        if (!inst_slot_available(in)) continue;
+
+        in->midi_device = (unsigned char)dev;
+        in->channel     = (unsigned char)created;   // 0..15 == MIDI channel 1..16
+
+        // "<device> Channel NN". The title field is a fixed, space-padded
+        // buffer (the UI expects spaces, not a short C string), so build into a
+        // temp and copy. Device part is capped so " Channel NN" always fits.
+        char nm[ZTM_INSTTITLE_MAXLEN];
+        snprintf(nm, sizeof(nm), "%.13s Channel %02d", devname, created + 1);
+        memset(in->title, ' ', ZTM_INSTTITLE_MAXLEN);
+        size_t n = strlen(nm);
+        if (n > ZTM_INSTTITLE_MAXLEN - 1) n = ZTM_INSTTITLE_MAXLEN - 1;
+        memcpy(in->title, nm, n);
+        in->title[ZTM_INSTTITLE_MAXLEN - 1] = 0;
+        in->MarkAsUsed();
+        created++;
+    }
+
+    if (created == 0)
+        sprintf(szStatmsg, "No empty instrument slots available");
+    else if (created < 16)
+        sprintf(szStatmsg, "Created %d channels for %s (no more empty slots)", created, devname);
+    else
+        sprintf(szStatmsg, "Created 16 channels for %s", devname);
+    statusmsg = szStatmsg; need_refresh++;
+    return created;
+}
+
 void BTNCLK_ToggleNoteRetrig(UserInterfaceElement *b) {
     Button *btn;
     btn = (Button *)b;
@@ -338,6 +410,11 @@ void CUI_InstEditor::update() {
                     case SDLK_9: dev_sel(8,mds); act++; break;
                     case SDLK_0: dev_sel(9,mds); act++; break;
                     case SDLK_T: BTNCLK_ToggleTrackerMode(this->trackerModeButton); act++; break;
+                    // Alt+G -- "Generate 16": create 16 instruments for the
+                    // current instrument's MIDI device, one per channel 1..16,
+                    // into the next empty slots. Same action as the F3-again
+                    // popup's button.
+                    case SDLK_G: inst_create_16_channels_for_current_device(); act++; break;
                     }
                     break;
             case KS_NO_SHIFT_KEYS:

--- a/src/CUI_InstEditor.cpp
+++ b/src/CUI_InstEditor.cpp
@@ -55,17 +55,14 @@ static bool inst_slot_available(instrument *in) {
     return true;
 }
 
-// Fill the next up-to-16 empty instrument slots with the current instrument's
-// MIDI device, on channels 1..16, named "<device> Channel 01".."Channel 16".
-// Non-destructive: only writes into available slots (never overwrites). Returns
-// the number of instruments created.
-int inst_create_16_channels_for_current_device(void) {
-    if (!song || cur_inst < 0 || cur_inst >= MAX_INSTS || !song->instruments[cur_inst])
-        return 0;
-
-    unsigned int dev = song->instruments[cur_inst]->midi_device;
-    if (dev >= MidiOut->numOuputDevices) {
-        sprintf(szStatmsg, "Assign a MIDI Out device to this instrument first");
+// Fill the next up-to-16 empty instrument slots with the given MIDI device, on
+// channels 1..16, named "<device> Channel 01".."Channel 16". Non-destructive:
+// only writes into available slots (never overwrites). Returns the number of
+// instruments created.
+int inst_create_16_channels_for_device(unsigned int dev) {
+    if (!song) return 0;
+    if (dev >= MidiOut->numOuputDevices || MidiOut->outputDevices[dev] == NULL) {
+        sprintf(szStatmsg, "Pick a MIDI Out device first");
         statusmsg = szStatmsg; need_refresh++;
         return 0;
     }
@@ -105,6 +102,14 @@ int inst_create_16_channels_for_current_device(void) {
         sprintf(szStatmsg, "Created 16 channels for %s", devname);
     statusmsg = szStatmsg; need_refresh++;
     return created;
+}
+
+// Convenience wrapper for the Alt+G shortcut: use the current instrument's
+// device. (The F3-again popup lets you pick any open device directly.)
+int inst_create_16_channels_for_current_device(void) {
+    if (!song || cur_inst < 0 || cur_inst >= MAX_INSTS || !song->instruments[cur_inst])
+        return 0;
+    return inst_create_16_channels_for_device(song->instruments[cur_inst]->midi_device);
 }
 
 void BTNCLK_ToggleNoteRetrig(UserInterfaceElement *b) {

--- a/src/CUI_Page.h
+++ b/src/CUI_Page.h
@@ -410,6 +410,21 @@ class CUI_PEParms : public CUI_Page {
         void draw(Drawable *S);
 };
 
+// Instrument Editor options popup (press F3 again while on the Instrument
+// Editor). Single action: "Create 16 Channels" for the current instrument's
+// MIDI device. Mirrors the CUI_PEParms F2-again popup pattern.
+class CUI_IEParms : public CUI_Page {
+    public:
+        Button *btn_create16 ;
+
+        CUI_IEParms();
+
+        void enter(void);
+        void leave(void);
+        void update(void);
+        void draw(Drawable *S);
+};
+
 class CUI_PEVol : public CUI_Page {
 public:
 

--- a/src/CUI_Page.h
+++ b/src/CUI_Page.h
@@ -411,11 +411,13 @@ class CUI_PEParms : public CUI_Page {
 };
 
 // Instrument Editor options popup (press F3 again while on the Instrument
-// Editor). Single action: "Create 16 Channels" for the current instrument's
-// MIDI device. Mirrors the CUI_PEParms F2-again popup pattern.
+// Editor). Pick a MIDI Out device from the in-dialog list, then "Create 16
+// Channels" generates 16 instruments (channels 1..16) for it. Mirrors the
+// CUI_PEParms F2-again popup pattern.
 class CUI_IEParms : public CUI_Page {
     public:
-        Button *btn_create16 ;
+        ListBox *dev_list ;     // in-dialog MIDI Out device picker
+        Button  *btn_create16 ;
 
         CUI_IEParms();
 
@@ -423,6 +425,10 @@ class CUI_IEParms : public CUI_Page {
         void leave(void);
         void update(void);
         void draw(Drawable *S);
+
+        // Generate 16 channel-instruments for the device highlighted in
+        // dev_list, then close the popup. Called by the button and by Enter.
+        void do_create(void);
 };
 
 class CUI_PEVol : public CUI_Page {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -346,6 +346,7 @@ CUI_PaletteEditor *UIP_PaletteEditor = NULL;
 CUI_Config *UIP_Config = NULL;
 CUI_Patterneditor *UIP_Patterneditor = NULL;
 CUI_PEParms *UIP_PEParms = NULL;
+CUI_IEParms *UIP_IEParms = NULL;
 CUI_PEVol *UIP_PEVol = NULL;
 CUI_PENature *UIP_PENature = NULL;
 CUI_PEFindReplace *UIP_PEFindReplace = NULL;
@@ -1277,6 +1278,7 @@ int initConsole(int& Width, int& Height, int& FullScreen, int& Flags, Screen* S)
     UIP_CCEnvelopeEditor = new CUI_CCEnvelopeEditor;
     UIP_Patterneditor = new CUI_Patterneditor;
     UIP_PEParms = new CUI_PEParms;
+    UIP_IEParms = new CUI_IEParms;
     UIP_PEVol = new CUI_PEVol;
     UIP_SliderInput = new CUI_SliderInput;
     UIP_NewSong = new CUI_NewSong;
@@ -1960,8 +1962,15 @@ void global_keys(Drawable *S)
             break;
         // ------------------------------------------------------------------------
         case CMD_SWITCH_IEDIT:
-            switch_page(UIP_InstEditor);
-            doredraw++; clear++;
+            if (cur_state == STATE_IEDIT) {
+                // Already on the Instrument Editor -> F3 again opens the
+                // options popup (Create 16 Channels), mirroring F2-again.
+                popup_window(UIP_IEParms); clear++;
+                doredraw++;
+            } else {
+                switch_page(UIP_InstEditor);
+                doredraw++; clear++;
+            }
             break;
         // ------------------------------------------------------------------------
         case CMD_SWITCH_ORDERLIST:
@@ -2629,6 +2638,7 @@ int postAction ()
     delete UIP_Sysconfig;
     delete UIP_Patterneditor;
     delete UIP_PEParms;
+    delete UIP_IEParms;
     delete UIP_SliderInput;
     delete UIP_NewSong;
     delete UIP_RUSure;
@@ -3721,6 +3731,7 @@ int initSDL(void)
     UIP_Config = new CUI_Config;
     UIP_Patterneditor = new CUI_Patterneditor;
     UIP_PEParms = new CUI_PEParms;
+    UIP_IEParms = new CUI_IEParms;
     UIP_PEVol = new CUI_PEVol;
     UIP_PENature = new CUI_PENature;
     UIP_PEFindReplace = new CUI_PEFindReplace;

--- a/src/zt.h
+++ b/src/zt.h
@@ -717,9 +717,12 @@ extern int base_octave ;
 extern int keyjazz_velocity ;
 
 // Instrument Editor helper: fill the next up-to-16 empty instrument slots with
-// the current instrument's MIDI device on channels 1..16, named
-// "<device> Channel 01".."<device> Channel 16". Writes a summary to szStatmsg /
-// statusmsg and returns how many instruments were created. See CUI_InstEditor.cpp.
+// the given MIDI device on channels 1..16, named "<device> Channel 01" ..
+// "<device> Channel 16". Writes a summary to szStatmsg / statusmsg and returns
+// how many instruments were created. The _for_current_device wrapper uses the
+// current instrument's device (Alt+G shortcut); the F3-again popup passes the
+// device picked in its in-dialog list. See CUI_InstEditor.cpp.
+int inst_create_16_channels_for_device(unsigned int dev);
 int inst_create_16_channels_for_current_device(void);
 extern int cur_step;
 

--- a/src/zt.h
+++ b/src/zt.h
@@ -334,6 +334,7 @@ enum state {
   STATE_CONFIG,
   STATE_ORDER,
   STATE_PEDIT_WIN,
+  STATE_IEDIT_WIN,
   STATE_HELP,
   STATE_LOAD,
   STATE_SAVE,
@@ -714,6 +715,12 @@ extern int cur_edit_track_disp;
 extern int cur_edit_column;
 extern int base_octave ;
 extern int keyjazz_velocity ;
+
+// Instrument Editor helper: fill the next up-to-16 empty instrument slots with
+// the current instrument's MIDI device on channels 1..16, named
+// "<device> Channel 01".."<device> Channel 16". Writes a summary to szStatmsg /
+// statusmsg and returns how many instruments were created. See CUI_InstEditor.cpp.
+int inst_create_16_channels_for_current_device(void);
 extern int cur_step;
 
 // CC drawmode -- when non-zero, the Pattern Editor's MIDI-in handler


### PR DESCRIPTION
## Summary

A fast multitimbral-setup feature for the **Instrument Editor (F3)**: take the current instrument's MIDI Out device and create **16 instruments** for it — one per MIDI channel 1–16 — named `<device> Channel 01` … `<device> Channel 16` (e.g. `IAC Bus 1 Channel 01` … `IAC Bus 1 Channel 16`).

## Two triggers (as requested)

- **F3 again** while already on the Instrument Editor opens a new **Instrument Editor Options** popup showing the device name + a **"Create 16 Channels"** button (Enter confirms, Esc cancels). Mirrors the F2-again Pattern Editor Options popup.
- **Alt+G** in the Instrument Editor runs it directly.

## Behavior

- **Non-destructive** (the chosen option): only **empty** instrument slots are filled, so existing instruments are never overwritten.
- "Empty" here = no device, blank name, default patch/bank, no CCizer bank. The **channel field is deliberately ignored** — the instrument constructor pre-seeds channels 1–16 onto slots 0–15 as a convenience, so a strict `isempty()` (which counts that as data) would treat a fresh song's slots 1–15 as "used" and scatter the 16 instruments past slot 16. Ignoring channel lets a fresh song fill slots 0–15 consecutively, in order.
- Channels stored 0–15 (MIDI ch 1–16); name is space-padded into the fixed 25-char title field, device part capped so " Channel NN" always fits.
- Device name uses the same alias-or-`szName` display as the device selector.
- Assign a device to the current instrument first (Alt+1..0). The source instrument is preserved (it has a device, so it isn't "empty").

## Files

- `src/CUI_InstEditor.cpp` — `inst_create_16_channels_for_current_device()` (the shared core) + `inst_slot_available()` predicate + the Alt+G binding. Declared in `zt.h`.
- `src/CUI_IEParms.cpp` (new) + `CUI_Page.h` — the F3-again popup, mirroring `CUI_PEParms`.
- `src/main.cpp` — `UIP_IEParms` global + both instantiation sites + delete; `STATE_IEDIT_WIN`; the F3-again branch in `CMD_SWITCH_IEDIT`.
- `CMakeLists.txt`, `doc/help.txt`, `doc/CHANGELOG.txt`.

## Test plan

- [x] Clean build (macOS, Unix Makefiles)
- [x] `ctest` — 12/12 pass
- [x] Popup lifecycle verified by code (enter→`STATE_IEDIT_WIN`, `~WStackNode`→`leave()`→`STATE_IEDIT`; F3-again consumed by the modal popup)
- [ ] **Manual (maintainer/author):** assign IAC Bus 1 to an instrument, press F3 then F3 (or Alt+G), confirm 16 instruments named "IAC Bus 1 Channel 01..16" on channels 1–16 appear in the next empty slots. (Not auto-verified — headless build only, no GUI launched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
