### PR TITLE
README: fix stale minimum-resolution claim (840x480)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Program behavior changes:
 
 - Default pattern size is 64 instead of 128.
 
-- Program doesn't allow the user to set a resolution lower than 1024x700 and will increase the X, Y or both of them if necessary.
+- Program doesn't allow the user to set a resolution lower than 840x480 and will increase the X, Y or both of them if necessary.
 
 - Play view draws as many channels as it can fit within the horizontal resolution, instead of a fixed number of them.
 


### PR DESCRIPTION
Corrects the last stale README claim: the minimum window resolution is **840x480** (zt.h `MINIMUM_SCREEN_WIDTH` / `MINIMUM_SCREEN_HEIGHT`), not `1024x700`. The old number also contradicted the README's own window-size/zoom table (which already cites 840x480).

Context: this is one of three README staleness fixes. The other two — the SDL3-linkage claim ("statically linked / no DLLs" → SDL3 is dynamically linked and bundled) and the post-load default page (Instrument Editor F3 → Pattern Editor F2) — already landed on master via the README autopush (commit 96a1f1c) before it was switched off. The autopush LaunchAgent has now been removed; README changes go through PRs from here.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)