### PR TITLE
Samples PR A: sample pool + .zt SMPL/SMIX persistence + WAV loader (foundation, silent)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,8 @@ set(ZT_SOURCES
   src/OutputDevices.cpp
   src/platform.cpp
   src/playback.cpp
+  src/sample.cpp
+  src/sample_load.cpp
   src/skins.cpp
   src/zlib_wrapper.cpp
   src/ztfile-io.cpp

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -197,6 +197,38 @@ zt 2026_05_31 (Pattern Editor keymap: Ctrl-D select, Ctrl-Shift-P duration)
           global "Load Song" rather than the documented "select whole
           track / pattern" block function -- the global handler shadows
           the page binding. Left as-is for now.
+zt 2026_05_29 (Sample playback foundation: pool + .zt persistence + WAV loader)
+----------------------------------------------------------------------------
+
+        ! PR A of the optional sample-playback work. This lays the
+          foundation only -- it adds storage, file persistence and a WAV
+          loader, but NO audio engine yet, so nothing here makes sound.
+          The SampleOutputDevice voice mixer that plays the pool lands in
+          PR B. See doc/sample-playback-design.md for the full plan.
+
+        + New song-level PCM sample pool (zt_sample, src/sample.{h,cpp}):
+          interleaved S16 frames, loop points, root note, finetune, rate.
+          A song carries up to 100 samples; instruments optionally link to
+          one via a new instrument.sample_index field (-1 = MIDI-only, the
+          default).
+
+        + .zt persistence via two new OPTIONAL chunks:
+            - SMPL: one chunk per occupied sample slot (carries the PCM).
+            - SMIX: per-instrument sample-pool links (CCBN-style parallel
+              chunk; the instrument record format is untouched).
+          Both are skipped by older zTracker (and by this build when the
+          pool is empty), so MIDI-only songs save byte-identically and
+          load cleanly in either direction -- fully backward+forward
+          compatible, the same contract as the CCBN chunk.
+
+        + WAV loader (src/sample_load.{h,cpp}): SDL_LoadWAV +
+          SDL_ConvertAudioSamples to interleaved S16 mono/stereo (>2-channel
+          sources are downmixed to stereo).
+
+        + Two new unit-test suites: test_sample_chunk (SDL-free SMPL/SMIX
+          round-trip + the zt_sample data model) and test_sample_load
+          (SDL-linked WAV loader, fed in-memory WAVs -- no fixtures).
+          ctest is now 14 suites.
 
 zt 2026_05_29 (Instrument Editor: Create 16 channels for a MIDI device)
 ----------------------------------------------------------------------------

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -84,6 +84,10 @@ instrument::instrument(int p)
 
   ccizer_bank[0] = '\0';
 
+  // No sample linked by default -- instruments are MIDI-only until a
+  // sample is explicitly assigned.
+  sample_index = -1;
+
   // CC envelope slots default to "unused" (cc=0xFF, num_nodes=0).
   // The Shift+F6 editor populates them on demand.
   for (int e = 0; e < ZTM_INST_MAX_ENVELOPES; e++) {
@@ -791,6 +795,11 @@ void zt_module::init(void)
     for(i=0;i<ZTM_MAX_INSTS;i++)
         instruments[i] = new instrument(i);
 
+    // Sample pool starts empty -- slots are allocated lazily on WAV load
+    // or .zt SMPL-chunk load.
+    for(i=0;i<ZTM_MAX_SAMPLES;i++)
+        samples[i] = NULL;
+
     for(i=0;i<ZTM_MAX_TRACKS;i++)
         track_mute[i] = 0;
 
@@ -837,6 +846,13 @@ void zt_module::de_init(void) {
         if (this->instruments[i])
             delete this->instruments[i];
         this->instruments[i] = NULL;
+    }
+
+    // delete samples (frees each sample's PCM via ~zt_sample)
+    for(i=0;i<ZTM_MAX_SAMPLES;i++) {
+        if (this->samples[i])
+            delete this->samples[i];
+        this->samples[i] = NULL;
     }
 
     // delete songmessage

--- a/src/module.h
+++ b/src/module.h
@@ -44,6 +44,7 @@
 #include <fstream>
 
 #include "platform.h"
+#include "sample.h"
 
 
 class CDataBuf ;
@@ -184,6 +185,13 @@ public:
   // when the instrument plays a note (pattern + keyjazz both). Persisted
   // in the optional INSE chunk; old zTracker skips it.
   inst_envelope envelopes[ZTM_INST_MAX_ENVELOPES];
+
+  // Optional link into the song's sample pool (module::samples[]). -1 = no
+  // sample (pure MIDI instrument, the default). >=0 = index of the sample
+  // this instrument plays when routed to the sample-output device. Persisted
+  // in the optional SMIX chunk (CCBN-style parallel chunk); old zTracker
+  // skips it and loads the instrument as MIDI-only (forward-compat).
+  signed short int sample_index;
 
 } ;
 
@@ -369,6 +377,11 @@ class zt_module
         
         pattern *patterns[ZTM_MAX_PATTERNS];
         instrument *instruments[ZTM_MAX_INSTS];
+        // Song-level PCM sample pool. NULL slot = empty. Instruments link in
+        // via instrument::sample_index. Persisted via the optional SMPL
+        // chunks (one per occupied slot). Empty pool => no chunks written =>
+        // byte-identical saves for MIDI-only songs.
+        zt_sample *samples[ZTM_MAX_SAMPLES];
         int orderlist[ZTM_ORDERLIST_LEN];
 
         zt_mutex_handle hEditMutex;
@@ -418,6 +431,9 @@ class zt_module
         void build_song_message(CDataBuf *buf);           /* SMSG - song message */
         void build_MIDI_macro(CDataBuf *buf, int num);  /* MMAC - midi macro */
         void build_arpeggio(CDataBuf *buf, int num);  /* ARPG - arpeggio */
+        void build_sample(CDataBuf *buf, int num);  /* SMPL - one pool sample */
+        void load_sample(CDataBuf *buf, const char *fn);  /* SMPL - one pool sample */
+        void load_sample_index_map(CDataBuf *buf);  /* SMIX - per-inst sample link */
         //void build_PATT(CDataBuf *buf);  /* PATT - pattern */
         //void build_INST(CDataBuf *buf);  /* INST - instrument */
         //void build_TMUT(CDataBuf *buf);  /* TMUT - track mutes */

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -1,0 +1,84 @@
+/*************************************************************************
+ *
+ * FILE  sample.cpp
+ *
+ * DESCRIPTION
+ *   zt_sample lifecycle (see sample.h). SDL-free on purpose -- only
+ *   the standard allocator and string/memory routines, so this TU can
+ *   be compiled into the SDL-free unit-test harness.
+ *
+ ******/
+#include "sample.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <new>
+
+zt_sample::zt_sample(void)
+{
+    pcm = NULL;
+    clear();
+}
+
+zt_sample::~zt_sample(void)
+{
+    if (pcm) {
+        delete[] pcm;
+        pcm = NULL;
+    }
+}
+
+void zt_sample::clear(void)
+{
+    if (pcm) {
+        delete[] pcm;
+        pcm = NULL;
+    }
+    name[0]     = '\0';
+    frames      = 0;
+    channels    = 1;
+    root_note   = ZTM_SAMPLE_DEFAULT_ROOT;
+    flags       = 0;
+    finetune    = 0;
+    default_vol = 127;
+    rate        = 44100;
+    loop_start  = 0;
+    loop_end    = 0;
+}
+
+int zt_sample::isempty(void) const
+{
+    return (pcm == NULL || frames == 0) ? 1 : 0;
+}
+
+int zt_sample::set_pcm(const short int *src, unsigned int nframes, unsigned char nchannels)
+{
+    if (pcm) {
+        delete[] pcm;
+        pcm = NULL;
+    }
+    frames   = 0;
+    channels = (nchannels == 2) ? 2 : 1;
+
+    if (!src || nframes == 0) {
+        return 1; /* explicit clear is success */
+    }
+
+    unsigned int total = nframes * (unsigned int)channels;
+    short int *buf = new (std::nothrow) short int[total];
+    if (!buf) {
+        channels = 1;
+        return 0;
+    }
+    memcpy(buf, src, (size_t)total * sizeof(short int));
+    pcm    = buf;
+    frames = nframes;
+    return 1;
+}
+
+unsigned int zt_sample::byte_size(void) const
+{
+    if (!pcm || frames == 0) return 0;
+    return frames * (unsigned int)channels * (unsigned int)sizeof(short int);
+}
+/* eof */

--- a/src/sample.h
+++ b/src/sample.h
@@ -1,0 +1,89 @@
+/*************************************************************************
+ *
+ * FILE  sample.h
+ *
+ * DESCRIPTION
+ *   PCM sample storage for zTracker's optional sample-playback path.
+ *
+ *   zTracker is historically MIDI-only. Samples are an additive,
+ *   opt-in capability: a song carries a small pool of `zt_sample`
+ *   objects, and an instrument MAY link to one via its sample_index.
+ *   When no samples are present the song behaves exactly as before and
+ *   saves byte-identically (the optional SMPL/SMIX .zt chunks are only
+ *   emitted when there is something to write).
+ *
+ *   This header is deliberately SDL-free so the data model and the
+ *   chunk serialise/parse logic can be unit-tested under the SDL-free
+ *   test harness. The WAV loader (sample_load.{h,cpp}) is the only
+ *   piece that pulls in SDL.
+ *
+ *   PR A (foundation): storage + .zt persistence + WAV loader. No audio
+ *   engine yet -- nothing here makes sound. The SampleOutputDevice voice
+ *   mixer that consumes this pool lands in PR B.
+ *
+ ******/
+#ifndef _SAMPLE_H
+#define _SAMPLE_H
+
+/* Max samples in a song's pool. Matches Impulse Tracker's 99-sample
+ * convention with one slot of headroom; also the upper bound the SMPL
+ * loader bounds-checks pool_index against. */
+#define ZTM_MAX_SAMPLES        100
+#define ZTM_SAMPLENAME_MAXLEN  32
+
+/* zt_sample::flags bits */
+#define ZTM_SMPF_LOOP          0x01   /* loop_start..loop_end is an active forward loop */
+#define ZTM_SMPF_PINGPONG      0x02   /* reserved for the engine (PR B); ignored in PR A */
+
+/* Default MIDI note at which PCM plays back at its stored `rate`. */
+#define ZTM_SAMPLE_DEFAULT_ROOT 60    /* C5 in zTracker's numbering */
+
+/* One PCM sample in a song's pool.
+ *
+ * PCM is stored as interleaved signed 16-bit frames -- `channels`
+ * samples per frame, `frames` frames total. This matches the audio
+ * backend's SDL_AUDIO_S16 output format so the future voice mixer reads
+ * the pool with no per-sample format conversion.
+ *
+ * Frame vs sample vs byte (the trio that bit the spike's TestTone):
+ *   - a FRAME is one instant in time: `channels` 16-bit values.
+ *   - SAMPLE count  = frames * channels.
+ *   - BYTE   count  = frames * channels * sizeof(short int).
+ * Loop points are expressed in FRAMES.
+ */
+class zt_sample
+{
+public:
+    char           name[ZTM_SAMPLENAME_MAXLEN];
+    short int     *pcm;          /* interleaved S16 frames; NULL when empty */
+    unsigned int   frames;       /* number of frames (not samples, not bytes) */
+    unsigned char  channels;     /* 1 = mono, 2 = stereo */
+    unsigned char  root_note;    /* MIDI note that plays pcm at `rate` */
+    unsigned char  flags;        /* ZTM_SMPF_* */
+    signed char    finetune;     /* engine-defined fine pitch offset; 0 = none */
+    unsigned char  default_vol;  /* 0..127 */
+    unsigned int   rate;         /* source sample rate, Hz (e.g. IT C5speed) */
+    unsigned int   loop_start;   /* in frames */
+    unsigned int   loop_end;     /* in frames; no loop when flag clear / end<=start */
+
+    zt_sample(void);
+    ~zt_sample(void);
+
+    /* True when there is no PCM attached (no frames / null buffer). */
+    int  isempty(void) const;
+
+    /* Free any PCM and reset every field to the empty default. Safe to
+     * call repeatedly. */
+    void clear(void);
+
+    /* Replace the PCM with a copy of `src` (nframes * nchannels S16
+     * values, interleaved). `src` may be NULL/0 to just clear. Returns
+     * 1 on success, 0 on allocation failure (leaves the sample empty). */
+    int  set_pcm(const short int *src, unsigned int nframes, unsigned char nchannels);
+
+    /* frames * channels * sizeof(short int). 0 when empty. */
+    unsigned int byte_size(void) const;
+};
+
+#endif /* _SAMPLE_H */
+/* eof */

--- a/src/sample_load.cpp
+++ b/src/sample_load.cpp
@@ -1,0 +1,118 @@
+/*************************************************************************
+ *
+ * FILE  sample_load.cpp
+ *
+ * DESCRIPTION
+ *   WAV loading for the sample pool (see sample_load.h). Decodes via
+ *   SDL_LoadWAV / SDL_LoadWAV_IO, converts to interleaved S16 mono/
+ *   stereo with SDL_ConvertAudioSamples, and copies the PCM into the
+ *   zt_sample (which owns its own buffer).
+ *
+ ******/
+#include "sample_load.h"
+
+#include <string.h>
+
+// Fill out->name from a path or hint: basename, extension stripped,
+// truncated to the sample name field.
+static void set_name_from_hint(zt_sample *out, const char *hint)
+{
+    out->name[0] = '\0';
+    if (!hint || !hint[0]) return;
+
+    // basename: last '/' or '\\'
+    const char *base = hint;
+    for (const char *p = hint; *p; ++p) {
+        if (*p == '/' || *p == '\\') base = p + 1;
+    }
+
+    // copy up to the field cap, stopping at the final '.' (extension)
+    const char *dot = NULL;
+    for (const char *p = base; *p; ++p)
+        if (*p == '.') dot = p;
+
+    unsigned int n = 0;
+    for (const char *p = base; *p && (dot ? p < dot : 1); ++p) {
+        if (n < ZTM_SAMPLENAME_MAXLEN - 1)
+            out->name[n++] = *p;
+    }
+    out->name[n] = '\0';
+}
+
+// Shared tail: take an SDL-decoded buffer (spec/buf/len), convert to
+// interleaved S16 mono/stereo, store in `out`. Frees `buf` via SDL_free.
+static int finish_from_decoded(const SDL_AudioSpec *spec, Uint8 *buf, Uint32 len,
+                               zt_sample *out)
+{
+    SDL_AudioSpec dst;
+    dst.format   = SDL_AUDIO_S16;                       // native-endian S16
+    dst.channels = (spec->channels >= 2) ? 2 : 1;       // downmix >2ch to stereo
+    dst.freq     = spec->freq;
+
+    Uint8 *conv     = NULL;
+    int    conv_len = 0;
+    bool   ok = SDL_ConvertAudioSamples(spec, buf, (int)len, &dst, &conv, &conv_len);
+    SDL_free(buf);
+    if (!ok || !conv || conv_len <= 0) {
+        if (conv) SDL_free(conv);
+        return 0;
+    }
+
+    unsigned int bytes_per_frame = (unsigned int)dst.channels * (unsigned int)sizeof(short int);
+    unsigned int frames = (bytes_per_frame > 0) ? ((unsigned int)conv_len / bytes_per_frame) : 0;
+
+    int rc = out->set_pcm((const short int *)conv, frames, (unsigned char)dst.channels);
+    SDL_free(conv);
+    if (!rc || out->isempty())
+        return 0;
+
+    out->rate      = (unsigned int)(spec->freq > 0 ? spec->freq : 44100);
+    out->root_note = ZTM_SAMPLE_DEFAULT_ROOT;
+    return 1;
+}
+
+int zt_sample_load_wav_io(SDL_IOStream *io, int closeio, const char *name_hint,
+                          zt_sample *out)
+{
+    if (!out) {
+        if (io && closeio) SDL_CloseIO(io);
+        return 0;
+    }
+    out->clear();
+    if (!io) return 0;
+
+    SDL_AudioSpec spec;
+    Uint8 *buf = NULL;
+    Uint32 len = 0;
+    bool ok = SDL_LoadWAV_IO(io, closeio ? true : false, &spec, &buf, &len);
+    if (!ok || !buf) {
+        if (buf) SDL_free(buf);
+        return 0;
+    }
+
+    set_name_from_hint(out, name_hint);
+    int rc = finish_from_decoded(&spec, buf, len, out);
+    if (!rc) out->clear();
+    return rc;
+}
+
+int zt_sample_load_wav(const char *path, zt_sample *out)
+{
+    if (!out) return 0;
+    out->clear();
+    if (!path || !path[0]) return 0;
+
+    SDL_AudioSpec spec;
+    Uint8 *buf = NULL;
+    Uint32 len = 0;
+    if (!SDL_LoadWAV(path, &spec, &buf, &len) || !buf) {
+        if (buf) SDL_free(buf);
+        return 0;
+    }
+
+    set_name_from_hint(out, path);
+    int rc = finish_from_decoded(&spec, buf, len, out);
+    if (!rc) out->clear();
+    return rc;
+}
+/* eof */

--- a/src/sample_load.h
+++ b/src/sample_load.h
@@ -1,0 +1,41 @@
+/*************************************************************************
+ *
+ * FILE  sample_load.h
+ *
+ * DESCRIPTION
+ *   WAV file loading for the sample pool. The only sample-subsystem TU
+ *   that depends on SDL (it uses SDL_LoadWAV + SDL_ConvertAudioSamples).
+ *
+ *   Two entry points:
+ *     - zt_sample_load_wav(path, out)    -- load from a file path.
+ *     - zt_sample_load_wav_io(io, ...)   -- load from an SDL_IOStream.
+ *
+ *   The IO variant exists so the loader can be exercised against an
+ *   in-memory WAV in the unit test (SDL_IOFromMem) without a temp file
+ *   or a committed binary fixture.
+ *
+ *   Both decode to interleaved S16 (mono or stereo; >2 source channels
+ *   are downmixed to stereo), which is exactly what the sample pool and
+ *   the future voice mixer expect.
+ *
+ ******/
+#ifndef _SAMPLE_LOAD_H
+#define _SAMPLE_LOAD_H
+
+#include <SDL.h>
+#include "sample.h"
+
+/* Load a WAV file from `path` into `out` (which is cleared first).
+ * `out`'s name is set to the file's basename (extension stripped,
+ * truncated to fit). Returns 1 on success, 0 on failure (out left empty). */
+int zt_sample_load_wav(const char *path, zt_sample *out);
+
+/* Load a WAV from an already-open SDL_IOStream. If `closeio` is true the
+ * stream is closed before returning (success or failure). `name_hint`
+ * (may be NULL) is copied into out->name. Returns 1 on success, 0 on
+ * failure. */
+int zt_sample_load_wav_io(SDL_IOStream *io, int closeio, const char *name_hint,
+                          zt_sample *out);
+
+#endif /* _SAMPLE_LOAD_H */
+/* eof */

--- a/src/ztfile-io.cpp
+++ b/src/ztfile-io.cpp
@@ -38,6 +38,7 @@
  *
  ******/
 #include <stdarg.h>
+#include <new>
 #include "zt.h"
 #include "sysex_macro.h"
 
@@ -413,6 +414,59 @@ void zt_module::build_arpeggio(CDataBuf *buf, int num) {
 
 /*************************************************************************
  *
+ * NAME  zt_module::build_sample()
+ *
+ * DESCRIPTION
+ *   Serialise one pool sample into `buf` for a SMPL chunk. One chunk
+ *   per occupied pool slot (mirrors the one-ZTin-per-instrument shape),
+ *   which keeps each chunk's PCM under readblock's 64 MB cap.
+ *
+ *   Layout (all little-endian / native, like every other zt chunk):
+ *     uint16 pool_index
+ *     uint16 name_len
+ *     bytes  name        (name_len)
+ *     uint8  channels    (1 or 2)
+ *     uint8  root_note
+ *     uint8  flags
+ *     int8   finetune
+ *     uint8  default_vol
+ *     uint32 rate
+ *     uint32 loop_start
+ *     uint32 loop_end
+ *     uint32 frames
+ *     int16  pcm[frames * channels]   (interleaved)
+ *
+ ******/
+void zt_module::build_sample(CDataBuf *buf, int num) {
+    zt_sample *s = this->samples[num];
+
+    unsigned short len = (unsigned short)strlen(s->name);
+    if (len >= ZTM_SAMPLENAME_MAXLEN)
+        len = ZTM_SAMPLENAME_MAXLEN - 1;
+
+    buf->pushusi((unsigned short)num);
+    buf->pushusi(len);
+    buf->write(s->name, len);
+
+    buf->pushuc(s->channels);
+    buf->pushuc(s->root_note);
+    buf->pushuc(s->flags);
+    buf->pushc((char)s->finetune);
+    buf->pushuc(s->default_vol);
+    buf->pushui(s->rate);
+    buf->pushui(s->loop_start);
+    buf->pushui(s->loop_end);
+    buf->pushui(s->frames);
+
+    if (s->pcm && s->frames) {
+        buf->write((const char *)s->pcm,
+                   (int)(s->frames * (unsigned int)s->channels * sizeof(short int)));
+    }
+    return;
+}
+
+/*************************************************************************
+ *
  * NAME  zt_module::build_MIDI_macro()
  *
  * SYNOPSIS
@@ -732,6 +786,38 @@ int zt_module::save(char *fn, int compressed)
         }
     }
 
+    // SMPL: one optional chunk per occupied sample-pool slot (PCM lives
+    // here). Skipped by older zTracker (unrecognized chunk -> harmless).
+    // Nothing is written when the pool is empty, so MIDI-only songs save
+    // byte-identically to before samples existed.
+    for (i = 0; i < ZTM_MAX_SAMPLES; i++) {
+        if (this->samples[i] && !this->samples[i]->isempty()) {
+            build_sample(&buffer, i);
+            writeblock("SMPL", &buffer, compressed, f, lpDS);
+        }
+    }
+
+    // SMIX: optional per-instrument links into the sample pool (CCBN-style
+    // parallel chunk). Only emitted when an instrument actually links to a
+    // sample. Format: int16 count, then {uint8 inst_idx, int16 sample_index}.
+    {
+        short int count = 0;
+        for (i = 0; i < ZTM_MAX_INSTS; i++) {
+            if (this->instruments[i] && this->instruments[i]->sample_index >= 0)
+                count++;
+        }
+        if (count > 0) {
+            buffer.pushsi(count);
+            for (i = 0; i < ZTM_MAX_INSTS; i++) {
+                if (!this->instruments[i] || this->instruments[i]->sample_index < 0)
+                    continue;
+                buffer.pushuc((unsigned char)i);
+                buffer.pushsi(this->instruments[i]->sample_index);
+            }
+            writeblock("SMIX", &buffer, compressed, f, lpDS);
+        }
+    }
+
 
     for(i=0;i<ZTM_MAX_ARPEGGIOS;i++) {
         if (this->arpeggios[i] && !this->arpeggios[i]->isempty()) {
@@ -962,6 +1048,130 @@ int zt_module::load_arpeggio(CDataBuf *buf) {
     // all is well, install the arpeggio
     this->arpeggios[num]=arp;
     return 0;
+}
+
+/*************************************************************************
+ *
+ * NAME  zt_module::load_sample()
+ *
+ * DESCRIPTION
+ *   Load one SMPL chunk into the sample pool. Layout in build_sample().
+ *   Every field is bounds-checked: a corrupt frames/channels value can
+ *   never request an allocation larger than the chunk payload that
+ *   readblock already capped at 64 MB. On any anomaly we keep whatever
+ *   loaded cleanly and surface a status warning rather than failing the
+ *   whole song load (matches the CCBN reader's posture).
+ *
+ ******/
+void zt_module::load_sample(CDataBuf *buf, const char *fn) {
+    int payload   = buf->getsize();
+    int truncated = 0;
+
+    unsigned short idx     = buf->getusi();
+    unsigned short namelen = buf->getusi();
+
+    char name[ZTM_SAMPLENAME_MAXLEN];
+    unsigned int nstore = 0;
+    for (unsigned short b = 0; b < namelen; b++) {
+        char c = buf->getch();
+        if (nstore < ZTM_SAMPLENAME_MAXLEN - 1)
+            name[nstore++] = c;
+    }
+    name[nstore] = '\0';
+
+    unsigned char  channels    = buf->getuch();
+    unsigned char  root_note   = buf->getuch();
+    unsigned char  flags       = buf->getuch();
+    signed char    finetune    = (signed char)buf->getch();
+    unsigned char  default_vol = buf->getuch();
+    unsigned int   rate        = buf->getui();
+    unsigned int   loop_start  = buf->getui();
+    unsigned int   loop_end    = buf->getui();
+    unsigned int   frames      = buf->getui();
+
+    if (channels != 1 && channels != 2) { channels = 1; truncated = 1; }
+
+    // Bound the frame count against the bytes actually left in the chunk
+    // so a bogus `frames` can't drive a giant allocation.
+    int consumed  = 2 + 2 + (int)namelen + 5 + 16; /* hdr fields, see build_sample */
+    int remaining = payload - consumed;
+    if (remaining < 0) remaining = 0;
+    unsigned int max_frames =
+        (unsigned int)remaining / ((unsigned int)channels * (unsigned int)sizeof(short int));
+    if (frames > max_frames) { frames = max_frames; truncated = 1; }
+
+    if (idx >= ZTM_MAX_SAMPLES) {
+        setstatusstr("Warning: SMPL chunk in %s has out-of-range pool index "
+                     "%u; sample dropped.", fn, (unsigned)idx);
+        return;
+    }
+
+    // Read PCM into a fresh buffer (interleaved S16).
+    unsigned int total = frames * (unsigned int)channels;
+    short int   *pcm   = NULL;
+    if (total) {
+        pcm = new (std::nothrow) short int[total];
+        if (pcm) {
+            for (unsigned int i = 0; i < total; i++)
+                pcm[i] = buf->getsi();
+        } else {
+            truncated = 1;
+            frames    = 0;
+        }
+    }
+
+    // Install (replacing any existing sample in this slot).
+    if (this->samples[idx]) {
+        delete this->samples[idx];
+        this->samples[idx] = NULL;
+    }
+    zt_sample *s = new zt_sample();
+    snprintf(s->name, sizeof(s->name), "%s", name);
+    s->channels    = channels;
+    s->root_note   = root_note;
+    s->flags       = flags;
+    s->finetune    = finetune;
+    s->default_vol = default_vol;
+    s->rate        = rate ? rate : 44100;
+    s->loop_start  = loop_start;
+    s->loop_end    = loop_end;
+    if (pcm) {
+        s->pcm    = pcm;   /* ownership transferred to the sample */
+        s->frames = frames;
+    }
+    this->samples[idx] = s;
+
+    if (truncated)
+        setstatusstr("Warning: SMPL chunk in %s looks truncated "
+                     "(payload %d B); sample may be incomplete.", fn, payload);
+    return;
+}
+
+/*************************************************************************
+ *
+ * NAME  zt_module::load_sample_index_map()
+ *
+ * DESCRIPTION
+ *   Load the SMIX chunk: per-instrument links into the sample pool.
+ *   CCBN-style parallel chunk so the instrument record format is
+ *   untouched. Layout:
+ *     int16 count
+ *     repeat count: uint8 inst_idx, int16 sample_index
+ *
+ ******/
+void zt_module::load_sample_index_map(CDataBuf *buf) {
+    short int count = buf->getsi();
+    if (count < 0 || count > ZTM_MAX_INSTS)
+        return;
+    for (short int k = 0; k < count; k++) {
+        unsigned char inst_idx = buf->getuch();
+        short int     sidx     = buf->getsi();
+        if (inst_idx < ZTM_MAX_INSTS && this->instruments[inst_idx]) {
+            if (sidx >= -1 && sidx < ZTM_MAX_SAMPLES)
+                this->instruments[inst_idx]->sample_index = sidx;
+        }
+    }
+    return;
 }
 
 /*************************************************************************
@@ -1300,6 +1510,8 @@ int zt_module::load(char *fn)
             if (cmp_hd(&header[0], "ZTpp")) { load_ZT_pattern_properties(&buffer); recognized_chunks++; }
             if (cmp_hd(&header[0], "ZTin")) { load_ZT_instrument(&buffer); recognized_chunks++; }
             if (cmp_hd(&header[0], "ZTev")) { load_ZT_event_list(&buffer); recognized_chunks++; saw_event_list = 1; }
+            if (cmp_hd(&header[0], "SMPL")) { load_sample(&buffer, fn); recognized_chunks++; }
+            if (cmp_hd(&header[0], "SMIX")) { load_sample_index_map(&buffer); recognized_chunks++; }
             if (cmp_hd(&header[0], "INSE")) {
                 // Per-instrument CC envelopes chunk (see save side for
                 // layout). Bounds-checked at every step; on malformed

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,6 +133,44 @@ target_include_directories(test_ccenv PRIVATE "${CMAKE_SOURCE_DIR}/src")
 target_compile_features(test_ccenv PRIVATE cxx_std_17)
 add_test(NAME ccenv COMMAND test_ccenv)
 
+# SMPL / SMIX .zt chunk round-trip + the zt_sample data model. SDL-free:
+# compiles the real src/sample.cpp (zt_sample has no SDL deps) and mirrors
+# the SMPL/SMIX reader/writer byte-for-byte in a tiny in-test buffer, the
+# same approach test_ccbn_roundtrip uses for the CCBN chunk.
+add_executable(test_sample_chunk
+    test_sample_chunk.cpp
+    "${CMAKE_SOURCE_DIR}/src/sample.cpp"
+)
+target_include_directories(test_sample_chunk PRIVATE "${CMAKE_SOURCE_DIR}/src")
+target_compile_features(test_sample_chunk PRIVATE cxx_std_17)
+add_test(NAME sample_chunk COMMAND test_sample_chunk)
+
+# WAV loader. Unlike the other suites this DOES link SDL3, because the
+# loader's whole job is SDL_LoadWAV + SDL_ConvertAudioSamples. The test
+# feeds in-memory WAV blobs via SDL_IOFromMem -- no temp file or committed
+# fixture. SDL is wired the same way as the main `zt` target (pkg-config
+# preferred, manual SDL3_INCLUDE_DIR/SDL3_LIBRARY fallback).
+add_executable(test_sample_load
+    test_sample_load.cpp
+    "${CMAKE_SOURCE_DIR}/src/sample.cpp"
+    "${CMAKE_SOURCE_DIR}/src/sample_load.cpp"
+)
+target_include_directories(test_sample_load PRIVATE "${CMAKE_SOURCE_DIR}/src")
+target_compile_features(test_sample_load PRIVATE cxx_std_17)
+if(TARGET PkgConfig::SDL3PC)
+    target_link_libraries(test_sample_load PRIVATE PkgConfig::SDL3PC)
+    if(SDL3_COMPAT_INCLUDE_DIR)
+        target_include_directories(test_sample_load SYSTEM PRIVATE "${SDL3_COMPAT_INCLUDE_DIR}")
+    endif()
+else()
+    target_include_directories(test_sample_load SYSTEM PRIVATE "${SDL3_INCLUDE_DIR}")
+    if(EXISTS "${SDL3_INCLUDE_DIR}/SDL3/SDL.h")
+        target_include_directories(test_sample_load SYSTEM PRIVATE "${SDL3_INCLUDE_DIR}/SDL3")
+    endif()
+    target_link_libraries(test_sample_load PRIVATE ${SDL3_LIBRARY})
+endif()
+add_test(NAME sample_load COMMAND test_sample_load)
+
 # Shared keyjazz note table (keyjazz_map.h). Regression-guards the tracker
 # layout byte-for-byte after the four-switch -> one-function refactor, and
 # locks in the Ableton/Logic piano layout + the two layouts' mutual exclusivity.

--- a/tests/test_sample_chunk.cpp
+++ b/tests/test_sample_chunk.cpp
@@ -1,0 +1,381 @@
+// SMPL / SMIX chunk round-trip test (PR A: sample foundation).
+//
+// The SMPL chunk persists one PCM sample from the song's sample pool;
+// the SMIX chunk persists per-instrument links into that pool. Both are
+// optional, additive .zt chunks (old zTracker skips them via readblock's
+// advance-past behavior).
+//
+// SMPL layout (from src/ztfile-io.cpp build_sample/load_sample):
+//   uint16 pool_index
+//   uint16 name_len
+//   bytes  name        (name_len)
+//   uint8  channels    (1 or 2)
+//   uint8  root_note
+//   uint8  flags
+//   int8   finetune
+//   uint8  default_vol
+//   uint32 rate
+//   uint32 loop_start
+//   uint32 loop_end
+//   uint32 frames
+//   int16  pcm[frames * channels]   (interleaved)
+//
+// SMIX layout:
+//   int16 count
+//   repeat: uint8 inst_idx, int16 sample_index
+//
+// SDL-free. Compiles the real src/sample.cpp (zt_sample is SDL-free) and
+// uses a tiny in-test Buf that mirrors CDataBuf's push/get methods
+// byte-for-byte, exactly as tests/test_ccbn_roundtrip.cpp does for CCBN.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "sample.h"
+
+static int failures = 0;
+static int checks   = 0;
+
+#define CHECK(expr) do {                                                \
+    checks++;                                                           \
+    if (!(expr)) { failures++;                                          \
+        fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #expr); \
+    }                                                                   \
+} while(0)
+
+// ---- Minimal CDataBuf stand-in (mirrors the real push/get) -------------
+struct Buf {
+    char data[1 << 20];   // 1 MB is plenty for the tiny synthetic samples here
+    int  size;
+    int  read_cursor;
+    Buf() : size(0), read_cursor(0) {}
+
+    void write(const char *p, int n) { memcpy(data + size, p, n); size += n; }
+    void pushuc(unsigned char c)       { write((const char *)&c, 1); }
+    void pushc(char c)                 { write(&c, 1); }
+    void pushsi(short int v)           { write((const char *)&v, sizeof(short int)); }
+    void pushusi(unsigned short int v) { write((const char *)&v, sizeof(unsigned short int)); }
+    void pushui(unsigned int v)        { write((const char *)&v, sizeof(unsigned int)); }
+
+    void reset_read() { read_cursor = 0; }
+    int  getsize() const { return size; }
+
+    char getch() {
+        if (read_cursor >= size) return 0;
+        return data[read_cursor++];
+    }
+    unsigned char getuch() { return (unsigned char)getch(); }
+    short int getsi() {
+        if (read_cursor + (int)sizeof(short int) > size) return 0;
+        short int v; memcpy(&v, data + read_cursor, sizeof(short int));
+        read_cursor += sizeof(short int); return v;
+    }
+    unsigned short int getusi() {
+        if (read_cursor + (int)sizeof(unsigned short int) > size) return 0;
+        unsigned short int v; memcpy(&v, data + read_cursor, sizeof(unsigned short int));
+        read_cursor += sizeof(unsigned short int); return v;
+    }
+    unsigned int getui() {
+        if (read_cursor + (int)sizeof(unsigned int) > size) return 0;
+        unsigned int v; memcpy(&v, data + read_cursor, sizeof(unsigned int));
+        read_cursor += sizeof(unsigned int); return v;
+    }
+};
+
+// ---- Mirror of build_sample() ------------------------------------------
+static void write_smpl(Buf *buf, const zt_sample *s, int idx) {
+    unsigned short len = (unsigned short)strlen(s->name);
+    if (len >= ZTM_SAMPLENAME_MAXLEN) len = ZTM_SAMPLENAME_MAXLEN - 1;
+    buf->pushusi((unsigned short)idx);
+    buf->pushusi(len);
+    buf->write(s->name, len);
+    buf->pushuc(s->channels);
+    buf->pushuc(s->root_note);
+    buf->pushuc(s->flags);
+    buf->pushc((char)s->finetune);
+    buf->pushuc(s->default_vol);
+    buf->pushui(s->rate);
+    buf->pushui(s->loop_start);
+    buf->pushui(s->loop_end);
+    buf->pushui(s->frames);
+    if (s->pcm && s->frames)
+        buf->write((const char *)s->pcm,
+                   (int)(s->frames * (unsigned int)s->channels * sizeof(short int)));
+}
+
+// ---- Mirror of load_sample() -------------------------------------------
+// Returns the parsed pool index, fills *out, sets *truncated.
+static int read_smpl(Buf *buf, zt_sample *out, int *truncated) {
+    int payload = buf->getsize();
+    int trunc   = 0;
+
+    unsigned short idx     = buf->getusi();
+    unsigned short namelen = buf->getusi();
+
+    char name[ZTM_SAMPLENAME_MAXLEN];
+    unsigned int nstore = 0;
+    for (unsigned short b = 0; b < namelen; b++) {
+        char c = buf->getch();
+        if (nstore < ZTM_SAMPLENAME_MAXLEN - 1) name[nstore++] = c;
+    }
+    name[nstore] = '\0';
+
+    unsigned char  channels    = buf->getuch();
+    unsigned char  root_note   = buf->getuch();
+    unsigned char  flags       = buf->getuch();
+    signed char    finetune    = (signed char)buf->getch();
+    unsigned char  default_vol = buf->getuch();
+    unsigned int   rate        = buf->getui();
+    unsigned int   loop_start  = buf->getui();
+    unsigned int   loop_end    = buf->getui();
+    unsigned int   frames      = buf->getui();
+
+    if (channels != 1 && channels != 2) { channels = 1; trunc = 1; }
+
+    int consumed  = 2 + 2 + (int)namelen + 5 + 16;
+    int remaining = payload - consumed;
+    if (remaining < 0) remaining = 0;
+    unsigned int max_frames =
+        (unsigned int)remaining / ((unsigned int)channels * (unsigned int)sizeof(short int));
+    if (frames > max_frames) { frames = max_frames; trunc = 1; }
+
+    out->clear();
+    if (idx >= ZTM_MAX_SAMPLES) { if (truncated) *truncated = trunc; return -1; }
+
+    unsigned int total = frames * (unsigned int)channels;
+    short int *pcm = NULL;
+    if (total) {
+        pcm = new short int[total];
+        for (unsigned int i = 0; i < total; i++) pcm[i] = buf->getsi();
+    }
+    snprintf(out->name, sizeof(out->name), "%s", name);
+    out->channels    = channels;
+    out->root_note   = root_note;
+    out->flags       = flags;
+    out->finetune    = finetune;
+    out->default_vol = default_vol;
+    out->rate        = rate ? rate : 44100;
+    out->loop_start  = loop_start;
+    out->loop_end    = loop_end;
+    if (pcm) { out->set_pcm(pcm, frames, channels); delete[] pcm; }
+
+    if (truncated) *truncated = trunc;
+    return (int)idx;
+}
+
+// ========================================================================
+// zt_sample data-model tests (real src/sample.cpp)
+// ========================================================================
+static void test_sample_model() {
+    zt_sample s;
+    CHECK(s.isempty());
+    CHECK(s.byte_size() == 0);
+    CHECK(s.channels == 1);
+    CHECK(s.root_note == ZTM_SAMPLE_DEFAULT_ROOT);
+
+    short int pcm[8] = { 0, 100, -100, 32767, -32768, 1, 2, 3 };
+    CHECK(s.set_pcm(pcm, 8, 1) == 1);
+    CHECK(!s.isempty());
+    CHECK(s.frames == 8);
+    CHECK(s.channels == 1);
+    CHECK(s.byte_size() == 8 * 1 * sizeof(short int));
+    CHECK(s.pcm != pcm);                         // set_pcm copies
+    CHECK(memcmp(s.pcm, pcm, sizeof(pcm)) == 0);
+
+    // stereo: 4 frames * 2 ch = 8 values
+    CHECK(s.set_pcm(pcm, 4, 2) == 1);
+    CHECK(s.frames == 4);
+    CHECK(s.channels == 2);
+    CHECK(s.byte_size() == 4 * 2 * sizeof(short int));
+
+    // clearing
+    s.clear();
+    CHECK(s.isempty());
+    CHECK(s.pcm == NULL);
+
+    // set_pcm(NULL) is an explicit clear, counts as success
+    CHECK(s.set_pcm(NULL, 0, 1) == 1);
+    CHECK(s.isempty());
+}
+
+// ========================================================================
+// SMPL round-trip tests
+// ========================================================================
+static void fill_sample(zt_sample *s, const char *name, unsigned char ch,
+                        unsigned int frames) {
+    s->clear();
+    snprintf(s->name, sizeof(s->name), "%s", name);
+    s->root_note   = 64;
+    s->flags       = ZTM_SMPF_LOOP;
+    s->finetune    = -7;
+    s->default_vol = 100;
+    s->rate        = 48000;
+    s->loop_start  = 10;
+    s->loop_end    = 20;
+    unsigned int total = frames * ch;
+    short int *pcm = new short int[total];
+    for (unsigned int i = 0; i < total; i++) pcm[i] = (short int)(i * 37 - 5000);
+    s->set_pcm(pcm, frames, ch);
+    delete[] pcm;
+}
+
+static void test_smpl_roundtrip_mono() {
+    zt_sample in;  fill_sample(&in, "kick.wav", 1, 64);
+    Buf buf;       write_smpl(&buf, &in, 7);
+    buf.reset_read();
+    zt_sample out; int trunc = 0;
+    int idx = read_smpl(&buf, &out, &trunc);
+
+    CHECK(idx == 7);
+    CHECK(trunc == 0);
+    CHECK(strcmp(out.name, "kick.wav") == 0);
+    CHECK(out.channels == 1);
+    CHECK(out.root_note == 64);
+    CHECK(out.flags == ZTM_SMPF_LOOP);
+    CHECK(out.finetune == -7);
+    CHECK(out.default_vol == 100);
+    CHECK(out.rate == 48000);
+    CHECK(out.loop_start == 10);
+    CHECK(out.loop_end == 20);
+    CHECK(out.frames == 64);
+    CHECK(out.byte_size() == in.byte_size());
+    CHECK(memcmp(out.pcm, in.pcm, in.byte_size()) == 0);
+}
+
+static void test_smpl_roundtrip_stereo() {
+    zt_sample in;  fill_sample(&in, "loop_st", 2, 128);
+    Buf buf;       write_smpl(&buf, &in, 0);
+    buf.reset_read();
+    zt_sample out; int trunc = 0;
+    int idx = read_smpl(&buf, &out, &trunc);
+
+    CHECK(idx == 0);
+    CHECK(trunc == 0);
+    CHECK(out.channels == 2);
+    CHECK(out.frames == 128);
+    CHECK(out.byte_size() == in.byte_size());
+    CHECK(memcmp(out.pcm, in.pcm, in.byte_size()) == 0);
+}
+
+static void test_smpl_empty_name() {
+    zt_sample in;  fill_sample(&in, "", 1, 4);
+    Buf buf;       write_smpl(&buf, &in, 3);
+    buf.reset_read();
+    zt_sample out; int trunc = 0;
+    int idx = read_smpl(&buf, &out, &trunc);
+    CHECK(idx == 3);
+    CHECK(out.name[0] == '\0');
+    CHECK(out.frames == 4);
+}
+
+static void test_smpl_bad_pool_index() {
+    zt_sample in;  fill_sample(&in, "x", 1, 4);
+    Buf buf;       write_smpl(&buf, &in, ZTM_MAX_SAMPLES + 5);
+    buf.reset_read();
+    zt_sample out; int trunc = 0;
+    int idx = read_smpl(&buf, &out, &trunc);
+    CHECK(idx == -1);                  // out-of-range index dropped
+    CHECK(out.isempty());
+}
+
+static void test_smpl_truncated_frames() {
+    // Hand-build a SMPL claiming 1000 frames but with no PCM payload.
+    Buf buf;
+    buf.pushusi(2);     // idx
+    buf.pushusi(0);     // name_len
+    buf.pushuc(1);      // channels
+    buf.pushuc(60);     // root
+    buf.pushuc(0);      // flags
+    buf.pushc(0);       // finetune
+    buf.pushuc(127);    // vol
+    buf.pushui(44100);  // rate
+    buf.pushui(0);      // loop_start
+    buf.pushui(0);      // loop_end
+    buf.pushui(1000);   // frames -- a lie; no PCM follows
+    buf.reset_read();
+
+    zt_sample out; int trunc = 0;
+    int idx = read_smpl(&buf, &out, &trunc);
+    CHECK(idx == 2);
+    CHECK(trunc == 1);                 // frames clamped against payload
+    CHECK(out.frames == 0);            // no PCM bytes available -> empty
+    CHECK(out.isempty());
+}
+
+static void test_smpl_long_name_clamped() {
+    zt_sample in; in.clear();
+    char longn[200]; memset(longn, 'Z', sizeof(longn)); longn[199] = '\0';
+    snprintf(in.name, sizeof(in.name), "%s", longn);   // already capped by field
+    short int pcm[2] = { 7, 8 };
+    in.set_pcm(pcm, 2, 1);
+    Buf buf; write_smpl(&buf, &in, 1);
+    buf.reset_read();
+    zt_sample out; int trunc = 0;
+    int idx = read_smpl(&buf, &out, &trunc);
+    CHECK(idx == 1);
+    CHECK(strlen(out.name) <= ZTM_SAMPLENAME_MAXLEN - 1);
+    CHECK(out.name[0] == 'Z');
+}
+
+// ========================================================================
+// SMIX round-trip
+// ========================================================================
+struct SmixEntry { unsigned char inst; short int sidx; };
+
+static void write_smix(Buf *buf, const SmixEntry *e, int count) {
+    buf->pushsi((short int)count);
+    for (int i = 0; i < count; i++) { buf->pushuc(e[i].inst); buf->pushsi(e[i].sidx); }
+}
+
+static int read_smix(Buf *buf, SmixEntry *out, int max_out) {
+    short int count = buf->getsi();
+    if (count < 0 || count > 100 /* ZTM_MAX_INSTS */) return -1;
+    int n = 0;
+    for (short int k = 0; k < count; k++) {
+        unsigned char inst = buf->getuch();
+        short int sidx     = buf->getsi();
+        if (n < max_out) { out[n].inst = inst; out[n].sidx = sidx; n++; }
+    }
+    return n;
+}
+
+static void test_smix_roundtrip() {
+    SmixEntry in[3] = { {0, 5}, {12, 0}, {99, ZTM_MAX_SAMPLES - 1} };
+    Buf buf; write_smix(&buf, in, 3);
+    buf.reset_read();
+    SmixEntry out[8]; int n = read_smix(&buf, out, 8);
+    CHECK(n == 3);
+    CHECK(out[0].inst == 0  && out[0].sidx == 5);
+    CHECK(out[1].inst == 12 && out[1].sidx == 0);
+    CHECK(out[2].inst == 99 && out[2].sidx == ZTM_MAX_SAMPLES - 1);
+}
+
+static void test_smix_corrupt_count() {
+    Buf buf; short int bogus = 9999; buf.pushsi(bogus);
+    buf.reset_read();
+    SmixEntry out[8]; int n = read_smix(&buf, out, 8);
+    CHECK(n == -1);
+}
+
+static void test_smix_empty() {
+    Buf buf; write_smix(&buf, NULL, 0);
+    buf.reset_read();
+    SmixEntry out[8]; int n = read_smix(&buf, out, 8);
+    CHECK(n == 0);
+}
+
+int main(void) {
+    test_sample_model();
+    test_smpl_roundtrip_mono();
+    test_smpl_roundtrip_stereo();
+    test_smpl_empty_name();
+    test_smpl_bad_pool_index();
+    test_smpl_truncated_frames();
+    test_smpl_long_name_clamped();
+    test_smix_roundtrip();
+    test_smix_corrupt_count();
+    test_smix_empty();
+    printf("sample_chunk: %d checks, %d failures\n", checks, failures);
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_sample_load.cpp
+++ b/tests/test_sample_load.cpp
@@ -1,0 +1,126 @@
+// WAV loader test (PR A: sample foundation).
+//
+// Exercises the real src/sample_load.cpp against in-memory WAV files
+// built by the test (no temp file, no committed fixture): a canonical
+// PCM RIFF/WAVE blob is handed to the loader via SDL_IOFromMem +
+// zt_sample_load_wav_io.
+//
+// Unlike the other suites this one DOES link SDL3, because SDL_LoadWAV /
+// SDL_ConvertAudioSamples are the loader's whole job. CI's Linux job has
+// SDL3 available.
+
+#include <stdio.h>
+#include <string.h>
+
+#include <SDL.h>
+#include "sample.h"
+#include "sample_load.h"
+
+static int failures = 0;
+static int checks   = 0;
+
+#define CHECK(expr) do {                                                \
+    checks++;                                                           \
+    if (!(expr)) { failures++;                                          \
+        fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #expr); \
+    }                                                                   \
+} while(0)
+
+// Build a canonical little-endian PCM WAV into `out`. Returns total bytes.
+static int build_wav(unsigned char *out, int channels, int rate, int bits,
+                     const void *pcm, int pcm_bytes) {
+    unsigned char *p = out;
+    auto w32  = [&](unsigned int v){ p[0]=(unsigned char)v; p[1]=(unsigned char)(v>>8);
+                                     p[2]=(unsigned char)(v>>16); p[3]=(unsigned char)(v>>24); p+=4; };
+    auto w16  = [&](unsigned short v){ p[0]=(unsigned char)v; p[1]=(unsigned char)(v>>8); p+=2; };
+    auto wtag = [&](const char *t){ memcpy(p, t, 4); p+=4; };
+
+    int byte_rate   = rate * channels * (bits/8);
+    int block_align = channels * (bits/8);
+
+    wtag("RIFF"); w32((unsigned int)(4 + (8+16) + (8+pcm_bytes))); wtag("WAVE");
+    wtag("fmt "); w32(16); w16(1); w16((unsigned short)channels);
+    w32((unsigned int)rate); w32((unsigned int)byte_rate);
+    w16((unsigned short)block_align); w16((unsigned short)bits);
+    wtag("data"); w32((unsigned int)pcm_bytes);
+    memcpy(p, pcm, pcm_bytes); p += pcm_bytes;
+    return (int)(p - out);
+}
+
+static void test_16bit_mono() {
+    short int pcm[8] = { 0, 1000, -1000, 32767, -32768, 5, 6, 7 };
+    unsigned char wav[256];
+    int sz = build_wav(wav, 1, 44100, 16, pcm, (int)sizeof(pcm));
+
+    SDL_IOStream *io = SDL_IOFromMem(wav, (size_t)sz);
+    CHECK(io != NULL);
+    zt_sample s;
+    int rc = zt_sample_load_wav_io(io, 1, "kick.wav", &s);
+    CHECK(rc == 1);
+    CHECK(s.channels == 1);
+    CHECK(s.rate == 44100);
+    CHECK(s.frames == 8);
+    CHECK(!s.isempty());
+    CHECK(memcmp(s.pcm, pcm, sizeof(pcm)) == 0);     // S16 in -> S16 out, exact
+    CHECK(strcmp(s.name, "kick") == 0);              // basename, extension stripped
+}
+
+static void test_16bit_stereo() {
+    short int pcm[8] = { 100, -100, 200, -200, 300, -300, 400, -400 };  // 4 frames * 2ch
+    unsigned char wav[256];
+    int sz = build_wav(wav, 2, 48000, 16, pcm, (int)sizeof(pcm));
+
+    SDL_IOStream *io = SDL_IOFromMem(wav, (size_t)sz);
+    zt_sample s;
+    int rc = zt_sample_load_wav_io(io, 1, "pad.wav", &s);
+    CHECK(rc == 1);
+    CHECK(s.channels == 2);
+    CHECK(s.rate == 48000);
+    CHECK(s.frames == 4);
+    CHECK(memcmp(s.pcm, pcm, sizeof(pcm)) == 0);
+}
+
+static void test_8bit_converts_to_s16() {
+    // 8-bit WAV PCM is unsigned (128 = zero). Exact converted values are
+    // SDL's business; we only assert structure + non-empty + conversion ran.
+    unsigned char pcm[6] = { 128, 200, 64, 128, 255, 0 };
+    unsigned char wav[256];
+    int sz = build_wav(wav, 1, 22050, 8, pcm, (int)sizeof(pcm));
+
+    SDL_IOStream *io = SDL_IOFromMem(wav, (size_t)sz);
+    zt_sample s;
+    int rc = zt_sample_load_wav_io(io, 1, "noise", &s);
+    CHECK(rc == 1);
+    CHECK(s.channels == 1);
+    CHECK(s.rate == 22050);
+    CHECK(s.frames == 6);
+    CHECK(!s.isempty());
+    CHECK(s.byte_size() == 6 * sizeof(short int));   // widened to S16
+}
+
+static void test_garbage_rejected() {
+    unsigned char junk[64];
+    memset(junk, 0xAB, sizeof(junk));
+    SDL_IOStream *io = SDL_IOFromMem(junk, sizeof(junk));
+    zt_sample s;
+    int rc = zt_sample_load_wav_io(io, 1, "bad.wav", &s);
+    CHECK(rc == 0);
+    CHECK(s.isempty());
+}
+
+static void test_null_io() {
+    zt_sample s;
+    int rc = zt_sample_load_wav_io(NULL, 0, "x", &s);
+    CHECK(rc == 0);
+    CHECK(s.isempty());
+}
+
+int main(void) {
+    test_16bit_mono();
+    test_16bit_stereo();
+    test_8bit_converts_to_s16();
+    test_garbage_rejected();
+    test_null_io();
+    printf("sample_load: %d checks, %d failures\n", checks, failures);
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

**PR A of the optional sample-playback work** (design doc: [`doc/sample-playback-design.md`](https://github.com/m6502/ztrackerprime/blob/esa/sample-foundation/doc/sample-playback-design.md), landing plan: [`doc/sample-playback-pr-plan.md`](https://github.com/m6502/ztrackerprime/blob/esa/sample-foundation/doc/sample-playback-pr-plan.md)).

This is the **foundation only** — storage, `.zt` persistence, and a WAV loader. **There is no audio engine yet, so nothing here makes sound.** It's deliberately silent and reviewable on its own. The point of landing it first is to get the **data model and the file format blessed before** the engine is built on top of them (the `SMPL` chunk is a permanent compatibility commitment). The `SampleOutputDevice` voice mixer that actually plays the pool is **PR B**.

> Context: zTracker has a complete-but-dormant SDL3 audio output path behind a commented-out `_ENABLE_AUDIO` flag (the `audio_mixer` callback + `AudioOutputDevice`/`MixAudio` polymorphism + TestTone/Noise demo plugins). A spike confirmed it still runs under SDL3 3.4.4 (device opens via CoreAudio, the mixer pumps, demo plugins make sound). Sample playback is "write a real `AudioOutputDevice` that resamples PCM" on that existing foundation — see the design doc.

This is also a **product decision**, not just code: it begins to change the "MIDI-only" identity. Nothing is wired into the UI or playback in this PR, so it's safe to land while that's discussed. Questions for you are in §4 of the design doc.

## What's in this PR

- **`zt_sample`** (`src/sample.{h,cpp}`) — a song-level PCM sample: interleaved S16 frames, loop points (in frames), root note, finetune, rate. SDL-free so the data model + chunk codec unit-test in the SDL-free harness. Owns its PCM.
- **Sample pool** — `zt_module::samples[ZTM_MAX_SAMPLES]` (NULL-init in `init()`, freed in `de_init()`, mirroring the arpeggio/midimacro pattern). `instrument` gains `signed short int sample_index` (`-1` = MIDI-only, the default).
- **`.zt` persistence — two new OPTIONAL chunks**, following the `CCBN` precedent exactly:
  - **`SMPL`** — one chunk per occupied pool slot, carries the PCM. Bounds-checked on load (channels ∈ {1,2}; `frames` clamped against the chunk payload so a corrupt count can't drive a huge allocation; out-of-range pool index dropped with a status warning).
  - **`SMIX`** — per-instrument sample-pool links. Parallel chunk so the **instrument record format is untouched**.
  - Old zTracker skips unknown chunks via `readblock`'s advance-past, and **nothing is written when the pool is empty**, so MIDI-only songs save **byte-identically** and load cleanly both directions.
- **WAV loader** (`src/sample_load.{h,cpp}`) — `SDL_LoadWAV` / `SDL_LoadWAV_IO` + `SDL_ConvertAudioSamples` → interleaved S16 mono/stereo (>2ch downmixed). The `_io` entry point exists purely so the loader is testable against in-memory WAVs.

## Backward / forward compatibility

Same contract as `CCBN`: additive optional chunks, skipped by older builds, omitted entirely for songs with no samples. A song saved before this PR loads unchanged; a song saved by this build with no samples is byte-identical to before; a song with samples loaded by old zTracker just ignores the `SMPL`/`SMIX` chunks.

## Test plan

- [x] Builds clean on macOS (SDL3 3.4.4); only the pre-existing unrelated `/usr/local/opt/zlib` search-path warning.
- [x] `ctest` — **all 14 suites pass** (12 existing + 2 new).
- [x] **`test_sample_chunk`** (SDL-free): real `zt_sample` model + `SMPL`/`SMIX` round-trip — mono, stereo, empty name, truncated-frames clamp, bad pool index, long-name clamp, `SMIX` map + corrupt-count + empty. Mirrors the reader/writer the same way `test_ccbn_roundtrip` does for CCBN.
- [x] **`test_sample_load`** (SDL-linked): 16-bit mono/stereo + 8-bit WAVs fed in-memory through the real loader, decoded PCM asserted; garbage / null IO rejected.
- [x] **Real writer exercised end-to-end** (throwaway harness, removed before commit): saving a module with a pooled sample + an instrument link produces a `.zt` containing the `SMPL` + `SMIX` chunks and the sample name. (The real *load* path can't be driven this PR without the editor — `load()` derefs `ztPlayer`/`UIP_*` — so the load side is covered by the byte-layout round-trip test; full UI round-trip arrives with PR B's editor.)

## Not in this PR (PR B)

The `SampleOutputDevice` voice mixer, `_ENABLE_AUDIO` wake-up + the two spike-found fixes (audio-device index ordering, S16/byte format), playback routing, and the sample-editor page.
