### PR TITLE
Samples PR B (engine): SampleOutputDevice voice mixer + routing + audio wake-up

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -197,6 +197,44 @@ zt 2026_05_31 (Pattern Editor keymap: Ctrl-D select, Ctrl-Shift-P duration)
           global "Load Song" rather than the documented "select whole
           track / pattern" block function -- the global handler shadows
           the page binding. Left as-is for now.
+zt 2026_05_29 (Sample playback engine: SampleOutputDevice voice mixer)
+----------------------------------------------------------------------------
+
+        ! PR B (engine) of the optional sample-playback work, stacked on the
+          PR A foundation. This is where samples actually make sound. Audio
+          is OFF by default -- pure-MIDI users are unaffected unless they
+          opt in via the new zt.conf audio_enabled key or --load-sample.
+
+        + SampleOutputDevice (src/OutputDevices.{h,cpp}): a polyphonic
+          software sampler (32 voices). Plays PCM from the song's sample
+          pool, pitched from the played note relative to each sample's root
+          note, with linear interpolation, forward loops, velocity scaling
+          and 14-bit pitch-bend. Writes interleaved S16 stereo. The audio
+          callback thread and the UI/playback threads are guarded by a
+          mutex (same lesson as the midiInQueue work). Pure DSP lives in
+          src/sample_voice.h and is unit-tested.
+
+        + The dormant SDL3 audio backend is now compiled in (_ENABLE_AUDIO)
+          and runtime-gated. Audio output devices are registered AFTER MIDI
+          devices, so enabling audio never shifts the MIDI device indices
+          that instruments persist in their .zt files. The old TestTone /
+          Noise demo plugins (and their 8-bit-into-S16 format bug) are gone,
+          replaced by the real sampler.
+
+        + Routing: an instrument with a sample_index whose MIDI Out device
+          is the Sample Player plays its pooled sample instead of sending
+          MIDI. Playback sends the sample selection (as a program change)
+          before each note-on; MIDI instruments are unaffected.
+
+        + New CLI flag --load-sample <file.wav>: load a WAV into sample
+          slot 0 and route instrument 1 to it (forcing audio on for the
+          session). A way to hear the engine before the sample-editor page
+          (the follow-up PR) exists.
+
+        + New zt.conf key audio_enabled (default no). New unit suite
+          test_sample_voice (pitch/advance/loop/interpolation). ctest is
+          now 15 suites.
+
 zt 2026_05_29 (Sample playback foundation: pool + .zt persistence + WAV loader)
 ----------------------------------------------------------------------------
 

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -270,6 +270,12 @@
                               (sets midi_in_sync + midi_in_sync_chase_
                               tempo so the song tempo follows incoming
                               F8 MIDI clock from that port).
+       --load-sample <file>   Load a WAV into sample slot 0 and route
+                              instrument 1 to it, turning audio on for
+                              this session. Play notes on instrument 1
+                              to hear the sample player. (Audio is off by
+                              default; the zt.conf audio_enabled key turns
+                              it on permanently.)
 
  Examples:
    zt mysong.zt

--- a/src/OutputDevices.cpp
+++ b/src/OutputDevices.cpp
@@ -14,11 +14,11 @@ void AddPlugin(midiOut *mout, OutputDevice *o)
 
 void InitializePlugins(midiOut *mout)
 {
-    // MIDI devices first, so their indices match midiOutGetNumDevs() order --
-    // the device picker and saved selections index by position. Audio plugins
-    // are appended AFTER, so enabling _ENABLE_AUDIO never shifts a MIDI device
-    // index (the selection-breaking bug the enable-audio spike found when the
-    // audio plugins sat at indices 0,1 ahead of MIDI).
+    // MIDI devices first, so their indices -- which instruments persist in .zt
+    // as midi_device, and which the device picker shows -- stay stable whether
+    // or not audio is enabled. Audio output devices are appended AFTER, so
+    // enabling _ENABLE_AUDIO never shifts a MIDI index (the selection-breaking
+    // bug the enable-audio spike found with audio plugins at indices 0,1).
     unsigned int i = mout->numOuputDevices;
     unsigned int devs = midiOutGetNumDevs();
     unsigned int total = i+devs;
@@ -28,6 +28,16 @@ void InitializePlugins(midiOut *mout)
     }
 
 #ifdef _ENABLE_AUDIO
+    // Sample voice mixer first (when enabled), so the sampler's "first audio
+    // device" lookup resolves to it. Opened immediately so the backend can
+    // pump it. Opt-in via zt.conf audio_enabled / --load-sample.
+    if (zt_config_globals.audio_enabled) {
+        SampleOutputDevice *smp = new SampleOutputDevice();
+        smp->open();
+        AddPlugin(mout, smp);
+    }
+    // Fun-sounds generators (Ctrl+Alt+F finds TestTone by name). Always
+    // registered, never opened until the easter egg asks.
     AddPlugin(mout, new NoiseOutputDevice());
     AddPlugin(mout, new TestToneOutputDevice());
 #endif
@@ -194,12 +204,14 @@ int MidiOutputDevice::sendSysEx(const unsigned char *bytes, int len) {
 
 
 
-#ifdef _ENABLE_AUDIO    
+#ifdef _ENABLE_AUDIO
 
+#include "sample_voice.h"
 
 ///////
 //
-// TestTone plugin - Plays a square wave at fixed freq
+// TestTone plugin - the Ctrl+Alt+F fun-sounds generator. A square-ish 8-bit
+// wave written byte-wise into the S16 stream, so it aliases into a warble.
 //
 
 TestToneOutputDevice::TestToneOutputDevice()
@@ -214,7 +226,6 @@ TestToneOutputDevice::TestToneOutputDevice()
         wave[i]=0;
     for(i=128;i<256;i++)
         wave[i]=0x7F;
-    //smp = NULL;
 }
 
 
@@ -223,14 +234,12 @@ TestToneOutputDevice::~TestToneOutputDevice() {
 
 
 int TestToneOutputDevice::open(void) {
-    //smp = Mix_LoadWAV("sound.wav");
     opened = 1;
     return 0;
 }
 
 
 int TestToneOutputDevice::close(void) {
-    //Mix_FreeChunk(smp);
     opened = 0;
     return 0;
 }
@@ -247,7 +256,6 @@ void TestToneOutputDevice::send(unsigned int msg) {
 }
 void TestToneOutputDevice::noteOn(unsigned char note, unsigned char chan, unsigned char vol) {
     makenoise=1;
-    //Mix_PlayChannel(-1,smp,0);
 }
 void TestToneOutputDevice::noteOff(unsigned char note, unsigned char chan, unsigned char vol) {
     makenoise=0;
@@ -261,12 +269,10 @@ void TestToneOutputDevice::progChange(int program, int bank, unsigned char chan)
 void TestToneOutputDevice::sendCC(unsigned char cc, unsigned char value,unsigned char chan) {
 }
 void TestToneOutputDevice::work( void *udata, Uint8 *stream, int len) {
-    //Mix_PlayChannelTimed()
-    
         if (makenoise) {
         for(int i=0;i<len;i++) {
             stream[i] = wave[wavec&0xFF];
-            wavec++; 
+            wavec++;
         }
     }
 }
@@ -275,7 +281,7 @@ void TestToneOutputDevice::work( void *udata, Uint8 *stream, int len) {
 
 ///////
 //
-// NoiseMaker plugin - Makes random static
+// NoiseMaker plugin - the fun-sounds static generator (sibling of TestTone).
 //
 
 
@@ -323,6 +329,129 @@ void NoiseOutputDevice::work( void *udata, Uint8 *stream, int len) {
         for(int i=0;i<len;i++) {
             stream[i] = rand()&0x3F;
         }
+    }
+}
+
+
+///////
+//
+// SampleOutputDevice - software sampler. Plays PCM from song->samples[]
+// polyphonically, pitched from the note relative to each sample's root.
+//
+
+SampleOutputDevice::SampleOutputDevice() {
+    type = OUTPUTDEVICE_TYPE_AUDIO;
+    strcpy(szName, "Sample Player");
+    for (int v = 0; v < ZT_SAMPLE_MAX_VOICES; v++) voices[v].active = false;
+    for (int c = 0; c < 16; c++) sample_for_chan[c] = -1;
+}
+
+SampleOutputDevice::~SampleOutputDevice() {
+}
+
+int SampleOutputDevice::open(void)  { opened = 1; return 0; }
+int SampleOutputDevice::close(void) { opened = 0; return 0; }
+
+void SampleOutputDevice::all_voices_off_locked() {
+    for (int v = 0; v < ZT_SAMPLE_MAX_VOICES; v++) voices[v].active = false;
+}
+
+void SampleOutputDevice::reset(void) {
+    {
+        std::lock_guard<std::mutex> lk(mtx);
+        all_voices_off_locked();
+        for (int c = 0; c < 16; c++) sample_for_chan[c] = -1;
+    }
+    OutputDevice::reset(); // clears notestates
+}
+
+void SampleOutputDevice::hardpanic(void) {
+    panic();
+}
+
+void SampleOutputDevice::send(unsigned int /*msg*/) {}
+
+// program = sample-pool index for this channel (-1 / out-of-range clears it).
+void SampleOutputDevice::progChange(int program, int /*bank*/, unsigned char chan) {
+    std::lock_guard<std::mutex> lk(mtx);
+    sample_for_chan[chan & 15] = (program >= 0 && program < ZTM_MAX_SAMPLES) ? program : -1;
+}
+
+void SampleOutputDevice::noteOn(unsigned char note, unsigned char chan, unsigned char vol) {
+    std::lock_guard<std::mutex> lk(mtx);
+    int idx = sample_for_chan[chan & 15];
+    if (idx < 0 || !song || !song->samples[idx] || song->samples[idx]->isempty())
+        return;
+    const zt_sample *s = song->samples[idx];
+
+    // find a free voice, else steal the one nearest its end (largest pos)
+    int slot = -1; double worst = -1.0;
+    for (int v = 0; v < ZT_SAMPLE_MAX_VOICES; v++) {
+        if (!voices[v].active) { slot = v; break; }
+        if (voices[v].pos > worst) { worst = voices[v].pos; slot = v; }
+    }
+    voice &vo = voices[slot];
+    vo.smp    = s;
+    vo.pos    = 0.0;
+    vo.step   = zt_voice_step(s, (int)note, ZT_SAMPLE_OUT_RATE);
+    vo.note   = note;
+    vo.chan   = chan;
+    vo.vel    = vol;
+    vo.active = true;
+}
+
+void SampleOutputDevice::noteOff(unsigned char note, unsigned char chan, unsigned char /*vol*/) {
+    std::lock_guard<std::mutex> lk(mtx);
+    // One-shot/looped: a note-off stops matching voices. (No release tail
+    // in this first cut; the editor PR can add loop-release behaviour.)
+    for (int v = 0; v < ZT_SAMPLE_MAX_VOICES; v++) {
+        if (voices[v].active && voices[v].note == note && voices[v].chan == chan)
+            voices[v].active = false;
+    }
+}
+
+void SampleOutputDevice::afterTouch(unsigned char, unsigned char, unsigned char) {}
+
+// Live pitch-bend: scale every active voice on the channel. value is the
+// raw 14-bit wheel (0x2000 = center); map to +/- 2 semitones.
+void SampleOutputDevice::pitchWheel(unsigned char chan, unsigned short int value) {
+    std::lock_guard<std::mutex> lk(mtx);
+    double semis = ((double)value - 8192.0) / 8192.0 * 2.0;
+    double bend  = pow(2.0, semis / 12.0);
+    for (int v = 0; v < ZT_SAMPLE_MAX_VOICES; v++) {
+        if (voices[v].active && voices[v].chan == chan && voices[v].smp) {
+            double base = zt_voice_step(voices[v].smp, (int)voices[v].note, ZT_SAMPLE_OUT_RATE);
+            voices[v].step = base * bend;
+        }
+    }
+}
+
+void SampleOutputDevice::sendCC(unsigned char, unsigned char, unsigned char) {}
+
+// Audio callback thread. Writes interleaved S16 stereo, `len` bytes total
+// (= len/4 frames). Always writes every frame (silence when no voice), so
+// the uninitialised mix buffer never leaks garbage.
+void SampleOutputDevice::work(void * /*udata*/, Uint8 *stream, int len) {
+    std::lock_guard<std::mutex> lk(mtx);
+    short int *out = (short int *)stream;
+    int frames = len / (int)(2 * sizeof(short int));
+
+    for (int f = 0; f < frames; f++) {
+        double accL = 0.0, accR = 0.0;
+        for (int v = 0; v < ZT_SAMPLE_MAX_VOICES; v++) {
+            voice &vo = voices[v];
+            if (!vo.active || !vo.smp) continue;
+            double g = (double)vo.vel / 127.0;
+            accL += g * (double)zt_voice_read(vo.smp, vo.pos, 0);
+            accR += g * (double)zt_voice_read(vo.smp, vo.pos, 1);
+            bool active = true;
+            vo.pos = zt_voice_advance(vo.smp, vo.pos, vo.step, &active);
+            vo.active = active;
+        }
+        if (accL >  32767.0) accL =  32767.0; if (accL < -32768.0) accL = -32768.0;
+        if (accR >  32767.0) accR =  32767.0; if (accR < -32768.0) accR = -32768.0;
+        out[f * 2 + 0] = (short int)accL;
+        out[f * 2 + 1] = (short int)accR;
     }
 }
 

--- a/src/OutputDevices.h
+++ b/src/OutputDevices.h
@@ -44,8 +44,11 @@ class MidiOutputDevice : public OutputDevice {
 
 
 
-#ifdef _ENABLE_AUDIO    
+#ifdef _ENABLE_AUDIO
 
+// Fun-sounds generators (Ctrl+Alt+F easter egg). Kept alongside the real
+// sampler below: TestTone is the deliberately warbly 8-bit-into-S16 tone the
+// fun button plays; Noise is its sibling static generator.
 class TestToneOutputDevice : public AudioOutputDevice {
     public:
         int makenoise;
@@ -84,6 +87,60 @@ class NoiseOutputDevice : public AudioOutputDevice {
         virtual void progChange(int program, int bank, unsigned char chan);
         virtual void sendCC(unsigned char cc, unsigned char value,unsigned char chan);
         virtual void work( void *udata, Uint8 *stream, int len);
+};
+
+#include <mutex>
+#include "sample.h"
+
+// Output rate of the SDL audio backend (see main.cpp zt_backend_audio_start).
+#define ZT_SAMPLE_OUT_RATE   44100
+#define ZT_SAMPLE_MAX_VOICES 32
+
+// Software sampler output device. Plays PCM from the song's sample pool
+// (song->samples[]) polyphonically, pitched from the played note relative
+// to each sample's root note. Routed to like any other output device: an
+// instrument whose midi_device points here plays a sample instead of
+// sending MIDI. progChange(sample_index, _, chan) selects which pool slot
+// a channel plays (playback sends it before noteOn for sample instruments).
+//
+// Thread model: noteOn/noteOff/progChange/reset run on the UI + playback
+// threads; work() runs on the SDL audio callback thread. A single mutex
+// guards the voice array + per-channel sample map. Each voice captures a
+// raw `const zt_sample *` at noteOn; whoever frees a pool sample MUST stop
+// this device's voices first (the sample editor in the follow-up PR locks
+// + clears before mutating the pool).
+class SampleOutputDevice : public AudioOutputDevice {
+    public:
+        SampleOutputDevice();
+        ~SampleOutputDevice();
+        virtual int  open(void);
+        virtual int  close(void);
+        virtual void reset(void);
+        virtual void hardpanic(void);
+        virtual void send(unsigned int msg);
+        virtual void noteOn(unsigned char note, unsigned char chan, unsigned char vol);
+        virtual void noteOff(unsigned char note, unsigned char chan, unsigned char vol);
+        virtual void afterTouch(unsigned char note, unsigned char chan, unsigned char vol);
+        virtual void pitchWheel(unsigned char chan, unsigned short int value);
+        virtual void progChange(int program, int bank, unsigned char chan);
+        virtual void sendCC(unsigned char cc, unsigned char value,unsigned char chan);
+        virtual void work( void *udata, Uint8 *stream, int len);
+
+    private:
+        struct voice {
+            const zt_sample *smp;
+            double           pos;     // fractional read position, in frames
+            double           step;    // frames advanced per output frame
+            unsigned char    note;
+            unsigned char    chan;
+            unsigned char    vel;
+            bool             active;
+        };
+        voice      voices[ZT_SAMPLE_MAX_VOICES];
+        int        sample_for_chan[16];   // pool index per channel, -1 = none
+        std::mutex mtx;
+
+        void all_voices_off_locked();
 };
 
 #endif

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -257,6 +257,7 @@ ZTConf::ZTConf() {
     control_navigation_amount = 2;
     default_directory[0] = '\0';
     record_velocity = 1;
+    audio_enabled = 0;      // default OFF: pure MIDI, no audio device opened
     cc_draw_overwrite = 0;  // default OFF: protect existing drawbars
     keyjazz_piano_layout = 0;  // default OFF: classic tracker keyjazz layout
     post_load_page = POST_LOAD_PATTERN_EDIT;
@@ -382,6 +383,7 @@ int ZTConf::load()
   record_velocity = getFlag("record_velocity");
   if (Config->get("cc_draw_overwrite")) cc_draw_overwrite = getFlag("cc_draw_overwrite");
   if (Config->get("keyjazz_piano")) keyjazz_piano_layout = getFlag("keyjazz_piano");
+  if (Config->get("audio_enabled")) audio_enabled = getFlag("audio_enabled");
 
   if(Config->get("default_directory"))                strcpy(default_directory, Config->get("default_directory"));
   if(Config->get("autoload_ztfile_filename"))         strcpy(autoload_ztfile_filename, Config->get("autoload_ztfile_filename"));
@@ -517,6 +519,11 @@ int ZTConf::save() {
         Config->set("cc_draw_overwrite","yes");
     else
         Config->set("cc_draw_overwrite","no");
+
+    if (audio_enabled)
+        Config->set("audio_enabled","yes");
+    else
+        Config->set("audio_enabled","no");
 
     if (keyjazz_piano_layout)
         Config->set("keyjazz_piano","yes");

--- a/src/conf.h
+++ b/src/conf.h
@@ -94,6 +94,13 @@ class ZTConf {
         int autosave_interval_seconds;
         int midi_clock; // default_midiclock;
         int midi_stop_start; // default_midistopstart;
+        // Sample playback (optional). 0 (default) = pure MIDI: no audio
+        // device is opened and the SampleOutputDevice is not registered,
+        // so MIDI-only users are completely unaffected. 1 = open the SDL
+        // audio backend at startup and register the sample voice mixer as
+        // an output device. The --load-sample CLI flag forces this on for
+        // the session.
+        int audio_enabled;
         int instrument_global_volume;
         int cur_edit_mode;
         int default_tpb;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,6 +81,7 @@
 #include "ccizer.h"
 #include "ableton_link.h"
 #include "midi_clock_sync.h"
+#include "sample_load.h"
 
 #ifdef __APPLE__
 extern "C" void zt_macos_disable_cmd_q(void);
@@ -330,6 +331,12 @@ WStack window_stack;
 bool bDontKeyRepeat=false;
 
 midiOut *MidiOut = NULL;
+
+// Set from the --load-sample CLI flag: a WAV to load into sample-pool slot 0
+// and auto-route to instrument 0 at startup. NULL = flag not given. Forces
+// audio_enabled on for the session. Primarily a way to hear the sample
+// engine before the sample-editor page lands.
+const char *g_cli_load_sample = NULL;
 midiIn *MidiIn = NULL;
 
 CUI_Page *ActivePage = NULL, *LastPage = NULL, *PopupWindow = NULL;
@@ -3683,6 +3690,11 @@ int initSDL(void)
     }
     ZT_DEBUG_LOG("[conf] zt.conf not found, created default configuration\n");
   }
+
+  // --load-sample forces the audio backend on for this session, regardless
+  // of the zt.conf audio_enabled key, so the sample plays. Must happen
+  // after config load and before the midiOut ctor registers devices.
+  if (g_cli_load_sample) zt_config_globals.audio_enabled = 1;
   /*
   if (zcmp(Config.get("fullscreen"),"yes")) {
   //FULLSCREEN=1;
@@ -3844,6 +3856,7 @@ static void audio_mixer(void *udata, SDL_AudioStream *stream, int additional_amo
 
 static int zt_backend_audio_start(void)
 {
+  if (g_audio_stream) return 1;   // idempotent: sampler boot + fun-button lazy start share one stream
   SDL_AudioSpec wanted;
   SDL_zero(wanted);
   wanted.freq = 44100;
@@ -3960,6 +3973,9 @@ struct ZtCliArgs {
     // and exits 0 (all checks passed) / 1 (failures). Pairs with --headless
     // for CI. Output (PASS/FAIL per check) goes to stdout.
     bool        lua_test        = false;
+    // --load-sample <file.wav>: load into sample-pool slot 0 + route to
+    // instrument 0, forcing audio on for the session.
+    const char *load_sample_path = NULL;
 };
 
 static void zt_print_cli_help(const char *progname) {
@@ -3999,6 +4015,10 @@ static void zt_print_cli_help(const char *progname) {
         "                              (lua/selftest.lua) against a scratch\n"
         "                              song and exit 0 (all checks passed) /\n"
         "                              1 (failures). Pair with --headless.\n"
+        "      --load-sample <file>    Load a WAV into sample slot 0 and\n"
+        "                              route instrument 1 to it, forcing\n"
+        "                              audio on for this session. Play notes\n"
+        "                              on instrument 1 to hear the sampler.\n"
         "\n"
         "Examples:\n"
         "  %s mysong.zt\n"
@@ -4091,6 +4111,10 @@ static int zt_parse_cli(int argc, char *argv[], ZtCliArgs *out) {
         if (r < 0) return -1;
         if (r > 0) { out->script_path = value; continue; }
 
+        r = zt_cli_match_flag_with_value(argc, argv, &i, "load-sample", &value);
+        if (r < 0) return -1;
+        if (r > 0) { out->load_sample_path = value; continue; }
+
         if (a[0] == '-') {
             fprintf(stderr, "zt: unknown flag '%s' (try --help)\n", a);
             return -1;
@@ -4162,6 +4186,8 @@ int main(int argc, char *argv[])
   if (zt_parse_cli(argc, argv, &cli_args) != 0) {
       return 2;
   }
+  // Publish to the global initSDL reads before it builds the device list.
+  g_cli_load_sample = cli_args.load_sample_path;
   if (cli_args.show_help) {
       const char *prog = (argc > 0 && argv[0]) ? argv[0] : "zt";
       // Strip path so "Usage: /path/to/zt" doesn't dominate the line.
@@ -4323,9 +4349,37 @@ int main(int argc, char *argv[])
     }
 
 #ifdef _ENABLE_AUDIO
-    // Audio stays dormant at boot: the fun-sounds easter egg (Ctrl+Alt+F)
-    // calls zt_backend_audio_start() lazily on first press, so a normal
-    // MIDI-only session never opens an output device.
+    // A plain MIDI-only session opens no audio device at boot -- the
+    // fun-sounds easter egg (Ctrl+Alt+F) wakes it lazily on first press.
+    // The sampler, when audio_enabled (or --load-sample), opens it now so
+    // loaded samples can play. Failure is non-fatal: warn and keep running
+    // MIDI-only rather than refusing to launch.
+    if (zt_config_globals.audio_enabled) {
+      if (!zt_backend_audio_start())
+        fprintf(stderr, "Audio disabled: could not open the audio device.\n");
+    }
+
+    // --load-sample: load the WAV into pool slot 0 and route instrument 0
+    // to the sample device, so notes on instrument 0 play the sample. A
+    // stop-gap for hearing the engine before the sample-editor page lands.
+    if (g_cli_load_sample && song && song->samples[0] == NULL) {
+      zt_sample *s = new zt_sample();
+      if (zt_sample_load_wav(g_cli_load_sample, s)) {
+        song->samples[0] = s;
+        int dev = -1;
+        for (unsigned int d = 0; d < MidiOut->numOuputDevices; d++)
+          if (MidiOut->get_type(d) == OUTPUTDEVICE_TYPE_AUDIO) { dev = (int)d; break; }
+        if (dev >= 0 && song->instruments[0]) {
+          song->instruments[0]->sample_index = 0;
+          song->instruments[0]->midi_device  = (unsigned char)dev;
+        }
+        fprintf(stderr, "Loaded sample '%s' (%u frames, %uch) -> instrument 1, device %d\n",
+                g_cli_load_sample, s->frames, s->channels, dev);
+      } else {
+        delete s;
+        fprintf(stderr, "Could not load sample WAV: %s\n", g_cli_load_sample);
+      }
+    }
 #endif
 
     while (1) {

--- a/src/midi-io.h
+++ b/src/midi-io.h
@@ -228,6 +228,11 @@ class midiOut {
             if (dev>=numOuputDevices) return;
             outputDevices[dev]->progChange(program,bank,chan);
         }
+        // OUTPUTDEVICE_TYPE_* of a device (NONE for an out-of-range index).
+        inline int get_type(unsigned int dev) {
+            if (dev>=numOuputDevices) return OUTPUTDEVICE_TYPE_NONE;
+            return outputDevices[dev]->type;
+        }
         inline void sendCC(unsigned int dev,unsigned char cc, unsigned char value,unsigned char chan) {
             if (dev>=numOuputDevices) return;
             outputDevices[dev]->sendCC(cc,value,chan);

--- a/src/playback.cpp
+++ b/src/playback.cpp
@@ -689,7 +689,14 @@ void player::play_current_row()
 
         if (song->instruments[pEvent->inst]->midi_device!=0xff && song->instruments[pEvent->inst]->midi_device<=MAX_MIDI_DEVS) {
 
-          MidiOut->noteOn(song->instruments[pEvent->inst]->midi_device,set_note,song->instruments[pEvent->inst]->channel,p1,MAX_TRACKS,0);            
+          // Sample instrument routed to the audio device: tell the voice
+          // mixer which pool slot this channel plays before the note-on.
+          if (song->instruments[pEvent->inst]->sample_index >= 0 &&
+              MidiOut->get_type(song->instruments[pEvent->inst]->midi_device) == OUTPUTDEVICE_TYPE_AUDIO)
+            MidiOut->progChange(song->instruments[pEvent->inst]->midi_device,
+                                song->instruments[pEvent->inst]->sample_index, -1,
+                                song->instruments[pEvent->inst]->channel);
+          MidiOut->noteOn(song->instruments[pEvent->inst]->midi_device,set_note,song->instruments[pEvent->inst]->channel,p1,MAX_TRACKS,0);
           jazz_set_state(SDLK_8, set_note, song->instruments[pEvent->inst]->channel);
         }
       }
@@ -738,6 +745,12 @@ void player::play_current_note()
 
     if (song->instruments[e->inst]->midi_device!=0xff && song->instruments[e->inst]->midi_device<=MAX_MIDI_DEVS) {
 
+      // Sample instrument routed to the audio device: select the pool slot.
+      if (song->instruments[e->inst]->sample_index >= 0 &&
+          MidiOut->get_type(song->instruments[e->inst]->midi_device) == OUTPUTDEVICE_TYPE_AUDIO)
+        MidiOut->progChange(song->instruments[e->inst]->midi_device,
+                            song->instruments[e->inst]->sample_index, -1,
+                            song->instruments[e->inst]->channel);
       MidiOut->noteOn(song->instruments[e->inst]->midi_device,set_note,song->instruments[e->inst]->channel,p1,MAX_TRACKS /*cur_edit_track*/,0);
 
       jazz_set_state(SDLK_4, set_note, song->instruments[e->inst]->channel);

--- a/src/sample_voice.h
+++ b/src/sample_voice.h
@@ -1,0 +1,74 @@
+/*************************************************************************
+ *
+ * FILE  sample_voice.h
+ *
+ * DESCRIPTION
+ *   Pure (SDL-free) DSP for the sample voice mixer: pitch-from-note,
+ *   fractional-position advance with optional forward loop, and
+ *   linear-interpolated PCM read. Kept header-only and dependency-free
+ *   so it unit-tests without an audio device (tests/test_sample_voice).
+ *
+ *   The stateful SampleOutputDevice in OutputDevices.{h,cpp} is a thin
+ *   shell around these functions.
+ *
+ ******/
+#ifndef _SAMPLE_VOICE_H
+#define _SAMPLE_VOICE_H
+
+#include "sample.h"
+#include <math.h>
+
+/* Frames of source PCM to advance per output frame, for `note` played on
+ * sample `s` to an output stream running at `out_rate` Hz. A note equal to
+ * the sample's root_note plays at the sample's natural rate (resampled to
+ * out_rate); each semitone above/below scales by 2^(1/12). `finetune` is
+ * interpreted as cents. Returns 0 for invalid input. */
+static inline double zt_voice_step(const zt_sample *s, int note, int out_rate)
+{
+    if (!s || out_rate <= 0 || s->rate == 0) return 0.0;
+    double semis = (double)note - (double)s->root_note + (double)s->finetune / 100.0;
+    double pitch = pow(2.0, semis / 12.0);
+    return ((double)s->rate / (double)out_rate) * pitch;
+}
+
+/* Advance `pos` (in frames) by `step`. With a valid forward loop
+ * (ZTM_SMPF_LOOP and loop_end > loop_start) the position wraps back into
+ * [loop_start, loop_end). Without a loop, reaching the end clears *active.
+ * Returns the new position. */
+static inline double zt_voice_advance(const zt_sample *s, double pos, double step,
+                                      bool *active)
+{
+    pos += step;
+    bool loop = (s->flags & ZTM_SMPF_LOOP) && s->loop_end > s->loop_start;
+    if (loop) {
+        if (pos >= (double)s->loop_end) {
+            double loplen = (double)(s->loop_end - s->loop_start);
+            double over   = pos - (double)s->loop_end;
+            pos = (double)s->loop_start + fmod(over, loplen);
+        }
+    } else if (pos >= (double)s->frames) {
+        if (active) *active = false;
+        pos = (double)s->frames;
+    }
+    return pos;
+}
+
+/* Linear-interpolated read of channel `c` (0 = left, 1 = right) at
+ * fractional frame position `pos`. Mono samples return the same value for
+ * both channels. Result is in S16 range, as a float for accumulation. */
+static inline float zt_voice_read(const zt_sample *s, double pos, int c)
+{
+    if (!s || !s->pcm || s->frames == 0) return 0.0f;
+    unsigned int i0 = (unsigned int)pos;
+    if (i0 >= s->frames) i0 = s->frames - 1;
+    unsigned int i1 = (i0 + 1 < s->frames) ? i0 + 1 : i0;
+    double frac = pos - (double)i0;
+    int ch = (s->channels == 2) ? 2 : 1;
+    int cc = (ch == 2) ? (c & 1) : 0;
+    short v0 = s->pcm[i0 * ch + cc];
+    short v1 = s->pcm[i1 * ch + cc];
+    return (float)((1.0 - frac) * (double)v0 + frac * (double)v1);
+}
+
+#endif /* _SAMPLE_VOICE_H */
+/* eof */

--- a/src/zt.h
+++ b/src/zt.h
@@ -119,7 +119,7 @@ static inline void zt_text_input_stop(void) {
 #endif
 #define ZTRACKER_VERSION                "zTracker' v" ZT_BUILD_DATE
 
-#define _ENABLE_AUDIO                 1  // audio path: dormant by default (no device opened at boot); woken lazily by the Ctrl+Alt+F fun-sounds easter egg
+#define _ENABLE_AUDIO                 1  // compile in the SDL audio backend (TestTone/Noise + sample voice mixer). No device opened at boot: the sampler opens it when audio_enabled, and the Ctrl+Alt+F fun-sounds easter egg wakes it lazily.
 
 #define ZOOM                            (zt_config_globals.zoom)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -171,6 +171,17 @@ else()
 endif()
 add_test(NAME sample_load COMMAND test_sample_load)
 
+# Sample voice DSP (sample_voice.h): pitch-from-note, fractional advance
+# with forward loop wrap / end-of-sample, linear interpolation, stereo
+# channel selection. SDL-free (header + src/sample.cpp only).
+add_executable(test_sample_voice
+    test_sample_voice.cpp
+    "${CMAKE_SOURCE_DIR}/src/sample.cpp"
+)
+target_include_directories(test_sample_voice PRIVATE "${CMAKE_SOURCE_DIR}/src")
+target_compile_features(test_sample_voice PRIVATE cxx_std_17)
+add_test(NAME sample_voice COMMAND test_sample_voice)
+
 # Shared keyjazz note table (keyjazz_map.h). Regression-guards the tracker
 # layout byte-for-byte after the four-switch -> one-function refactor, and
 # locks in the Ableton/Logic piano layout + the two layouts' mutual exclusivity.

--- a/tests/test_sample_voice.cpp
+++ b/tests/test_sample_voice.cpp
@@ -1,0 +1,118 @@
+// Sample voice DSP test (PR B: sample engine).
+//
+// Pure-function coverage of src/sample_voice.h -- the pitch/advance/read
+// math behind SampleOutputDevice. SDL-free, no audio device: compiles only
+// the header + src/sample.cpp.
+
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
+#include "sample.h"
+#include "sample_voice.h"
+
+static int failures = 0;
+static int checks   = 0;
+
+#define CHECK(expr) do {                                                \
+    checks++;                                                           \
+    if (!(expr)) { failures++;                                          \
+        fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #expr); \
+    }                                                                   \
+} while(0)
+
+#define CLOSE(a,b) (fabs((double)(a) - (double)(b)) < 1e-6)
+
+static void mk(zt_sample *s, unsigned int frames, unsigned char ch, unsigned int rate,
+               unsigned char root) {
+    s->clear();
+    s->rate = rate; s->channels = ch; s->root_note = root; s->finetune = 0;
+    short int pcm[512];
+    unsigned int total = frames * ch;
+    for (unsigned int i = 0; i < total && i < 512; i++) pcm[i] = (short int)(i + 1);
+    s->set_pcm(pcm, frames, ch);
+}
+
+static void test_step_pitch() {
+    zt_sample s; mk(&s, 64, 1, 44100, 60);
+
+    // root note at output rate == 1.0 frame/frame
+    CHECK(CLOSE(zt_voice_step(&s, 60, 44100), 1.0));
+    // one octave up == 2x
+    CHECK(CLOSE(zt_voice_step(&s, 72, 44100), 2.0));
+    // one octave down == 0.5x
+    CHECK(CLOSE(zt_voice_step(&s, 48, 44100), 0.5));
+
+    // sample rate below output rate scales the base ratio
+    zt_sample h; mk(&h, 64, 1, 22050, 60);
+    CHECK(CLOSE(zt_voice_step(&h, 60, 44100), 0.5));
+    CHECK(CLOSE(zt_voice_step(&h, 72, 44100), 1.0));   // octave up cancels the half-rate
+
+    // invalid inputs
+    CHECK(zt_voice_step(NULL, 60, 44100) == 0.0);
+    CHECK(zt_voice_step(&s, 60, 0) == 0.0);
+}
+
+static void test_finetune() {
+    zt_sample s; mk(&s, 64, 1, 44100, 60);
+    s.finetune = 100;   // +100 cents == +1 semitone
+    CHECK(CLOSE(zt_voice_step(&s, 60, 44100), pow(2.0, 1.0/12.0)));
+}
+
+static void test_advance_no_loop_ends() {
+    zt_sample s; mk(&s, 10, 1, 44100, 60);   // no loop flag
+    bool active = true;
+    double pos = 9.0;
+    pos = zt_voice_advance(&s, pos, 0.5, &active);   // 9.5, still inside
+    CHECK(active);
+    pos = zt_voice_advance(&s, pos, 1.0, &active);   // 10.5 -> past end
+    CHECK(!active);
+}
+
+static void test_advance_forward_loop_wraps() {
+    zt_sample s; mk(&s, 100, 1, 44100, 60);
+    s.flags = ZTM_SMPF_LOOP; s.loop_start = 20; s.loop_end = 30;  // 10-frame loop
+    bool active = true;
+    double pos = 29.0;
+    pos = zt_voice_advance(&s, pos, 3.0, &active);   // 32 -> wrap: 20 + (32-30)%10 = 22
+    CHECK(active);
+    CHECK(CLOSE(pos, 22.0));
+    // a huge step still lands inside the loop region
+    pos = zt_voice_advance(&s, 25.0, 137.0, &active);
+    CHECK(active);
+    CHECK(pos >= 20.0 && pos < 30.0);
+}
+
+static void test_read_interpolation() {
+    zt_sample s; mk(&s, 8, 1, 44100, 60);   // pcm[i] = i+1 -> 1,2,3,...,8
+    CHECK(CLOSE(zt_voice_read(&s, 0.0, 0), 1.0));
+    CHECK(CLOSE(zt_voice_read(&s, 1.0, 0), 2.0));
+    CHECK(CLOSE(zt_voice_read(&s, 0.5, 0), 1.5));     // halfway between 1 and 2
+    CHECK(CLOSE(zt_voice_read(&s, 2.25, 0), 3.25));   // 3 + .25*(4-3)
+    // mono returns the same value for both channels
+    CHECK(CLOSE(zt_voice_read(&s, 3.0, 0), zt_voice_read(&s, 3.0, 1)));
+    // past the end clamps to the last frame
+    CHECK(CLOSE(zt_voice_read(&s, 100.0, 0), 8.0));
+    // empty sample reads as silence
+    zt_sample e; e.clear();
+    CHECK(zt_voice_read(&e, 0.0, 0) == 0.0f);
+}
+
+static void test_read_stereo_channels() {
+    zt_sample s; mk(&s, 4, 2, 44100, 60);   // interleaved: (1,2)(3,4)(5,6)(7,8)
+    CHECK(CLOSE(zt_voice_read(&s, 0.0, 0), 1.0));   // L
+    CHECK(CLOSE(zt_voice_read(&s, 0.0, 1), 2.0));   // R
+    CHECK(CLOSE(zt_voice_read(&s, 1.0, 0), 3.0));
+    CHECK(CLOSE(zt_voice_read(&s, 1.0, 1), 4.0));
+}
+
+int main(void) {
+    test_step_pitch();
+    test_finetune();
+    test_advance_no_loop_ends();
+    test_advance_forward_loop_wraps();
+    test_read_interpolation();
+    test_read_stereo_channels();
+    printf("sample_voice: %d checks, %d failures\n", checks, failures);
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

**PR B (engine) of the optional sample-playback work** — **this is where samples make sound.**

> ⛓️ **Stacked on #140 (PR A, `esa/sample-foundation`).** Base is set to that branch, so this diff is just the engine. Review/merge #140 first; this re-targets to `master` once #140 lands.

**Audio is OFF by default** — pure-MIDI users are completely unaffected unless they opt in via the new `zt.conf` `audio_enabled` key or the `--load-sample` CLI flag. Nothing opens an audio device or registers a sampler unless asked.

## What's in this PR

**Engine** (`src/OutputDevices.{h,cpp}`, `src/sample_voice.h`)
- **`SampleOutputDevice`** — a 32-voice polyphonic software sampler. Plays PCM from the song's sample pool (PR A), pitched from the played note relative to each sample's root note, with linear interpolation, forward loops, velocity scaling, and 14-bit pitch-bend. Writes **interleaved S16 stereo**, always filling the buffer (no stale-garbage leak — that was the spike's "warble").
- **Thread safety** — the SDL audio callback thread and the UI/playback threads share the voice array + per-channel sample map under one `std::mutex` (same lesson as the PR #116 `midiInQueue` work). Each voice captures a `const zt_sample*` at note-on.
- **Pure DSP** (pitch step, fractional advance with loop-wrap / end, linear read) is isolated in `sample_voice.h`, SDL-free and unit-tested.

**Audio wake-up** (the two defects the spike surfaced)
- `_ENABLE_AUDIO` is compiled in and **runtime-gated** by `audio_enabled` (default off); `zt_backend_audio_start` is opt-in and **non-fatal** on failure (warn, keep running MIDI-only).
- **Device ordering fixed**: MIDI devices register first, audio devices after — so turning audio on **never shifts the MIDI device indices** instruments persist in `.zt`. The TestTone/Noise demo plugins (and their 8-bit-into-S16 bug) are gone.

**Routing** (`src/playback.cpp`, `src/midi-io.h`)
- An instrument with `sample_index >= 0` whose MIDI Out device is the Sample Player plays its pooled sample. Playback sends `progChange(sample_index)` to the audio device before the note-on; MIDI instruments are untouched (gated on device type via the new `midiOut::get_type()`).

**CLI** — `--load-sample <file.wav>` loads a WAV into slot 0 and routes instrument 1 to it (forcing audio on for the session). A way to hear the engine before the editor exists. New `zt.conf` `audio_enabled` key.

## Test plan

- [x] Full build green on macOS (SDL3 3.4.4).
- [x] `ctest` — **all 15 suites pass** (new: `test_sample_voice` — pitch/finetune, loop wrap, end-of-sample, linear interpolation, stereo channel select).
- [x] **Real voice mixer verified end-to-end** (throwaway harness, removed before commit): a 440 Hz sine routed `progChange → noteOn → work()` produced non-silent S16 output (RMS ≈ 14k), and the sample device registered at **index 2 — after the 2 MIDI devices**, confirming the ordering fix.
- [x] `--load-sample` of a generated WAV loads + routes cleanly, no crash, audio device opens via CoreAudio.

## How to try it

```
zt --load-sample /path/to/a.wav
```
Then play notes on **instrument 1** (keyjazz or a pattern) — pitched sample playback. Or set `audio_enabled = yes` in `zt.conf` to keep audio on across sessions.

## Not in this PR (PR B2)

The **sample-editor page** (load / assign-to-instrument / loop points / root note), so samples can be managed in-app without the CLI flag. That's the foot-gun-heavy UI work, kept separate so this engine PR can be verified by ear first.
