### PR TITLE
skill: refresh ztrackerprime contributor skill (drift fixes + foot-guns)

### DIFF
--- a/.claude/skills/ztrackerprime/SKILL.md
+++ b/.claude/skills/ztrackerprime/SKILL.md
@@ -13,7 +13,7 @@ triggers:
 
 # zTracker Prime Development Skill
 
-> **Last verified: 2026-05-02.** If this date is more than ~7 days old when you load this skill, your first move is to check what merged since: `gh pr list --repo m6502/ztrackerprime --state merged --json number,title,mergedAt --jq '[.[] | select(.mergedAt > "<this date>")]'`. Reconcile any architecture / shortcut / invariant claims below against current `master` before acting on them. Then bump this date in the same PR that fixes the drift.
+> **Last verified: 2026-05-30.** If this date is more than ~7 days old when you load this skill, your first move is to check what merged since: `gh pr list --repo m6502/ztrackerprime --state merged --json number,title,mergedAt --jq '[.[] | select(.mergedAt > "<this date>")]'`. Reconcile any architecture / shortcut / invariant claims below against current `master` before acting on them. Then bump this date in the same PR that fixes the drift.
 >
 > **What lives elsewhere on purpose:** the open-PR list and merged landmarks are NOT in this skill — they go stale fast. For current state run `gh pr list --repo m6502/ztrackerprime` (open) or `gh pr list --repo m6502/ztrackerprime --state merged --limit 30` (recent landings). The skill stays timeless: architecture, invariants, foot-guns, conventions.
 
@@ -72,7 +72,7 @@ ctest --output-on-failure      # unit-test harness (Linux CI runs this)
 | `src/editor_layout.h` | Shared character-grid constants for F4/Shift+F4 |
 | `assets/ccizer/` | Bundled CCizer banks (sc88st, microfreak, minilogue, monologue, Prophet6, deepmind6, waldorf_blofeld, tb03, se02, pro800, polyend_*, midi_control_example) — copied from Paketti. README.md documents the format. |
 | `assets/syx/` | Bundled SysEx files. `request_universal_inquiry.syx` = `F0 7E 7F 06 01 F7` for first-test handshakes. README.md documents the librarian workflow. |
-| `tests/` | CTest unit-test executables — 8 suites: `presets`, `selector`, `page_sync`, `save_key`, `keybuffer`, `ccizer`, `sysex_inq`, `sysex_macro` |
+| `tests/` | CTest unit-test executables — 12 suites: `presets`, `selector`, `page_sync`, `save_key`, `keybuffer`, `ccizer`, `sysex_inq`, `sysex_stress`, `sysex_macro`, `ccbn_roundtrip`, `ccenv`, `keyjazz_map`. (Count drifts as suites are added — `ctest` is the source of truth.) |
 | `doc/help.txt` | In-app F1 help — update when adding keybinds or CLI flags |
 | `doc/CHANGELOG.txt` | Release notes, chronological |
 | `.github/workflows/build.yml` | 5-platform CI matrix; Linux job runs `ctest` |
@@ -84,19 +84,20 @@ For the live PR queue: `gh pr list --repo m6502/ztrackerprime`.
 | Key | Page | Notes |
 |---|---|---|
 | F1 | Help | |
-| F2 | Pattern Editor | F2 again from PE → PEParms |
-| F3 | Instrument Editor | F3 row 11 shows `CCizer Bank: <basename>` (per-instrument bank) |
+| F2 | Pattern Editor | F2 again from PE → PEParms. **F2 F2 toggles "PianoKey"** — the Ableton/Logic piano keyjazz layout (PR #135, `keyjazz_piano_layout`). |
+| F3 | Instrument Editor | F3 row 11 shows `CCizer Bank: <basename>` (per-instrument bank). **F3 again → "Create 16 Channels"** popup: fills the next empty instrument slots with the current device on ch 1..16 (PR #136). |
 | F4 | MIDI Macro Editor | A macro whose name ends in `.syx` is dispatched as a SysEx file send by the playback engine; data grid is ignored (hint shown). |
 | **Shift+F2** | **Shortcuts & MIDI Mappings** | Was Shift+F3 historically; moved 2026-04-30 to free the slot for CC Console. |
 | **Shift+F3** | **CC Console** | Loads CCizer `.txt`, sliders/knobs send CC out, `L` to MIDI Learn, `B` to assign as current instrument's bank. |
 | Shift+F4 | Arpeggio Editor | |
 | F5 | Play Song | |
 | **Shift+F5** | **SysEx Librarian** | Lists `.syx` files. Enter sends. Incoming SysEx auto-saved as `recv_<timestamp>.syx`. |
+| **Shift+F6** | **CC Envelope Editor** | Per-instrument, CCizer-aware CC envelopes (Schism-style). New page, PR #132. Persisted in the optional `INSE` chunk; editor loads/saves `.env` presets from a configurable folder. |
 | F6 / F7 / F8 / F9 | Play Pattern / From Cursor / Stop / Panic | |
 | F10 | Song Message Editor | |
 | F11 | Song Configuration / Order | |
 | F12 | System Configuration | Includes `CCizer Folder` text input (binds to `ccizer_folder` zt.conf key). |
-| **Ctrl+Shift+§** | **CC drawmode toggle** | While ON, incoming CC writes `Sxxyy` and PB writes `Wxxxx` at the cursor row. Per-session UNDO_SAVE. `[CC DRAW]` badge shown top-right of Pattern Editor while active. |
+| **Ctrl+Shift+§** | **CC drawmode toggle** | While ON, incoming CC writes `Sxxyy` and PB writes `Wxxxx` at the cursor row. Per-session UNDO_SAVE. `[CC DRAW]` badge shown top-right of Pattern Editor while active. Extended by PRs #123–#129: **mouse drag-to-draw** drawbars (`MD_CC_DRAW`), CCizer-slot cycling, one-key arm-and-draw, double-click reset, `Ctrl+F2` slot cycle, keyjazz audition while mouse-drawing. Windows fires the toggle via `Ctrl+Shift+`` ` ``. |
 
 ## Coordinate system
 
@@ -133,7 +134,7 @@ Seven-PR feature stack landed end of April 2026 wiring Paketti-style CCizer bank
 
 **Cross-platform status** (verified 2026-05-02):
 - SysEx send: works on macOS (CoreMIDI `MIDIPacketListAdd`), Windows (WinMM `midiOutLongMsg` + MHDR_DONE poll, PR #87), Linux (ALSA `snd_seq_ev_set_sysex`).
-- SysEx receive: works on macOS (CoreMIDI read_proc parsing F0..F7) and Windows (`MIM_LONGDATA` accumulator, PR #90). Linux ALSA-in is still stubbed at the platform layer — receive on Linux is the remaining gap.
+- SysEx receive: works on macOS (CoreMIDI read_proc parsing F0..F7) and Windows (`MIM_LONGDATA` accumulator, PR #90). Initial **Linux ALSA MIDI input** landed in PR #113 (marked "needs hardware verification") — so the Linux-in platform layer is no longer a bare stub, but confirm SysEx-receive-on-Linux against that path on real hardware before relying on it.
 - Audit cluster (PRs #87–#93) hardened the foundation: Windows MHDR_DONE polling, macOS heap-alloc on receive, recv_seq survives restart, recv rotation, *.syx macro caching at load, lifetime docs, CCBN roundtrip test.
 
 **Test suites added**:

--- a/.claude/skills/ztrackerprime/references/foot-guns.md
+++ b/.claude/skills/ztrackerprime/references/foot-guns.md
@@ -73,3 +73,22 @@ When you add a new page whose ESC has dedicated meaning, **add its `STATE_*` to 
 ## Saturated ring buffer with `head == tail`
 
 `KeyBuffer` originally checked `head != tail` to gate read/peek. Fails when the buffer is exactly full (head wraps back to tail). Fix: gate on `cursize > 0`. If you write a fixed-capacity ring with two pointers, also keep a count.
+
+## `zt_module::save(fn)` ignores its `fn` argument
+
+`save(char *fn, int compressed)` copies `fn` into a static `ls_filename`, then **reassigns `fn = (char*)&this->filename[0]`** — so bytes are written to `this->filename`, *not* the path you passed. The real app sets `song->filename` (Save dialog / load path) before calling `save()`. Call `save()` from a test/harness with a fresh module and it opens an empty path, `ofstream` fails, and **no file is written** (returns -1 silently).
+
+`load(char *fn)` is the opposite — it *does* honour its `fn` argument. The asymmetry is the trap. (Cost real time on the sample-chunk save/load harness: the save produced no file until `filename` was set.)
+
+## `zt_module::load()` needs the full app initialised
+
+`load()` dereferences globals that only exist once `initSDL()` is well underway — `ztPlayer->...`, `UIP_InstEditor`, `cur_edit_pattern`, etc. Calling it early in `main` (e.g. a startup self-test, before `ztPlayer` / the `UIP_*` pages exist) **segfaults inside `load()`**, not in your code. There is no easy "load a song headless before the UI exists" path. To exercise load/save logic in isolation, test the chunk codec directly (SDL-free, mirror the reader/writer — see `test_ccbn_roundtrip`) rather than driving the real `load()`.
+
+## Adding a backward-compatible `.zt` chunk
+
+The `.zt` format is `[4-byte id][4-byte int size][payload]` per chunk; `readblock` consumes the whole payload regardless of recognition, so **unknown chunks are skipped automatically** — that's what makes additive chunks forward-compatible. The recipe, proven by `CCBN` (PR #84):
+
+- **Write** with a `build_<thing>()` filling a `CDataBuf` via `pushusi/pushuc/pushui/write`, then `writeblock("TAG", ...)`. `writeblock` flushes the buffer after each chunk, so a per-item loop emitting many same-tag chunks (one per record, like `ZTin` per instrument) is fine.
+- **Read** in the `load()` dispatch loop: `if (cmp_hd(&header[0], "TAG")) { ... }`. Bounds-check *every* field — a corrupt length must never drive an allocation; `readblock` already caps one chunk at **64 MB**, so split large payloads (one chunk per sample, etc.) to stay under it.
+- **Emit nothing when empty** so files without the feature stay byte-identical, and keep new per-record fields in a *parallel* chunk (CCBN-style) rather than editing an existing record's layout.
+- **Test** by mirroring the reader/writer byte-for-byte in an SDL-free `Buf` (the `test_ccbn_roundtrip` convention) — `CDataBuf.cpp` pulls in SDL, so the test can't use it directly.


### PR DESCRIPTION
## Summary

Refreshes the `.claude/skills/ztrackerprime` contributor skill, whose "Last verified" date had drifted 4 weeks. Pure docs — no code, no build impact.

### Stale-fact fixes (SKILL.md)
- **Last verified** 2026-05-02 → 2026-05-30.
- **Test harness** "8 suites" → the 12 current suites (`sysex_stress`, `ccbn_roundtrip`, `ccenv`, `keyjazz_map` were missing), noting `ctest` is the source of truth.
- **Linux SysEx receive** — reworded: no longer a bare stub since PR #113 landed initial Linux ALSA MIDI input (still "needs hardware verification").
- **Shortcut map** — added the post-05-02 features: `F2 F2` PianoKey toggle (#135), `F3`-again Create 16 Channels (#136), the new **Shift+F6 CC Envelope Editor** page (#132), and the CC-drawmode enhancement wave (#123–#129: mouse drag-to-draw, slot cycling, one-key arm, `Ctrl+F2` cycle, Windows `Ctrl+Shift+\``).

### New foot-guns (references/foot-guns.md)
Two that cost real debugging time, plus a reusable recipe:
- **#5** `zt_module::save(fn)` ignores its `fn` argument and writes to `this->filename` — while `load(fn)` honours its argument. The asymmetry silently produces *no file* if a harness forgets to set `filename`.
- **#6** `zt_module::load()` needs the full app initialised (derefs `ztPlayer` / `UIP_*`); calling it early segfaults *inside* `load()`, not in your code.
- **#7** recipe for adding a backward-compatible `.zt` chunk: id/size/payload framing, `readblock` auto-skips unknown chunks + caps a chunk at 64 MB (split big payloads), emit-nothing-when-empty, parallel chunks for new per-record fields, and the SDL-free mirror-test convention.

### Deliberately NOT included
The in-flight sample-playback work (#140/#141). The skill stays at merged-`master` reality per its own "no open-PR state in the skill" rule; the sample architecture section gets added when those merge.

## Test plan
- [x] Docs only — no build/test impact. `gh`-rendered Markdown checked.
