### PR TITLE
keybuffer: treat AltGr as plain Alt for shortcuts (KDE/X11 fix)

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,34 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_05_31 (AltGr behaves like Alt for keyboard shortcuts)
+----------------------------------------------------------------------------
+
+        * AltGr (right-Alt on EU/ISO layouts, Finnish included) now acts
+          EXACTLY like plain Alt for every shortcut. Reported on KDE Neon
+          (noble) X11: AltGr+P popped Song Duration instead of doing the
+          Alt+P action, because KDE/X11 delivers AltGr as a synthetic
+          Ctrl+right-Alt combo, which the dispatcher saw as Ctrl+Alt+P
+          (= Song Duration), while the Alt-only bindings (paste-cont. in
+          the Pattern Editor / duplicate-pattern elsewhere) never fired.
+
+        * Fixed at the source in keybuffer.cpp: when AltGr is in play
+          (SDL_KMOD_MODE set, or right-Alt held without left-Alt) the
+          modifier state is normalised to KS_ALT and the stray KS_CTRL is
+          dropped. Genuine Ctrl+Alt chords are pressed with the LEFT Alt
+          (Ctrl+Alt+L Lua, Ctrl+Alt+K keybindings, Ctrl+Alt+N new song,
+          Ctrl+Alt+Q quit) and are left untouched. Scoped to non-Apple;
+          macOS right-Option keeps its existing behaviour.
+
+        ! Reminder, unchanged: "copy pattern -> next empty slot -> jump
+          to it" is Ctrl+Shift+D (Clone Pattern) inside the F2 Pattern
+          Editor. The Alt+P duplicate variant only fires OUTSIDE the
+          Pattern Editor by design (in F2, Alt+P is paste-continuously).
+
+        * test_keybuffer: added 5 AltGr cases (MODE, RALT-alone,
+          synthetic LCTRL+RALT, genuine LCTRL+LALT preserved, LCTRL-only
+          unaffected). sdl_stub.h gains SDL_KMOD_MODE + SDLK_L.
+
 zt 2026_05_29 (Instrument Editor: Create 16 channels for a MIDI device)
 ----------------------------------------------------------------------------
 

--- a/src/keybuffer.cpp
+++ b/src/keybuffer.cpp
@@ -170,6 +170,29 @@ void KeyBuffer::insert(KBKey key, KBMod state, unsigned char actual_char, unsign
 #else
     if (state & SDL_KMOD_GUI)
         c |= KS_META;
+    // --- AltGr == Alt (Linux/X11/Wayland + Windows) -------------------
+    // On EU/ISO layouts (Finnish included) the right-Alt key is "AltGr".
+    // Depending on the platform + keyboard layout, SDL delivers it either
+    // as SDL_KMOD_MODE, or -- on KDE/X11 setups that emulate Windows-style
+    // AltGr -- as a synthetic Ctrl + right-Alt combo. We want AltGr+<key>
+    // to behave EXACTLY like Alt+<key> for shortcut dispatch, never as a
+    // Ctrl+Alt chord. Without this, e.g. AltGr+P arrives as Ctrl+Alt+P and
+    // gets routed to Song Duration instead of paste-continuously, and the
+    // duplicate-pattern binding (which requires Ctrl absent) never fires.
+    //
+    // Detection: MODE set, OR the RIGHT Alt held without the LEFT Alt.
+    // Genuine Ctrl+Alt chords (Ctrl+Alt+L Lua, Ctrl+Alt+K keybindings,
+    // Ctrl+Alt+N new song, Ctrl+Alt+Q quit) are pressed with the LEFT Alt,
+    // so they stay untouched. When AltGr is in play, force KS_ALT on and
+    // drop the KS_CTRL that rode in with it.
+    //
+    // Scoped to non-Apple: macOS has no AltGr, and its right-Option must
+    // keep its current behaviour (Cmd handles the KS_HAS_ALT path there).
+    if ((state & SDL_KMOD_MODE) ||
+        ((state & SDL_KMOD_RALT) && !(state & SDL_KMOD_LALT))) {
+        c |=  KS_ALT;
+        c &= ~KS_CTRL;
+    }
 #endif
     if (state == KS_LAST_STATE) {
         buffer[head].actual_char = last_actual_char;

--- a/tests/sdl_stub.h
+++ b/tests/sdl_stub.h
@@ -29,6 +29,7 @@ typedef uint16_t SDL_Keymod;
 #define SDL_KMOD_LGUI   0x0400
 #define SDL_KMOD_RGUI   0x0800
 #define SDL_KMOD_GUI    (SDL_KMOD_LGUI   | SDL_KMOD_RGUI)
+#define SDL_KMOD_MODE   0x4000  // AltGr (Mode) key, matches SDL3
 
 // SDLK_* values used by keybuffer.cpp's keypad-to-digit normalisation.
 // Real SDL3 values are 0x40000059..0x40000062 for KP_0..KP_9; for the
@@ -59,6 +60,7 @@ typedef uint16_t SDL_Keymod;
 // Other letter keys we pass to ListBox-style typeahead in tests.
 #define SDLK_A ((unsigned int)0x61)
 #define SDLK_B ((unsigned int)0x62)
+#define SDLK_L ((unsigned int)0x6C)
 #define SDLK_P ((unsigned int)0x70)
 #define SDLK_S ((unsigned int)0x73)
 #define SDLK_W ((unsigned int)0x77)

--- a/tests/test_keybuffer.cpp
+++ b/tests/test_keybuffer.cpp
@@ -144,6 +144,72 @@ static void test_state_alt_alone_no_ctrl() {
     CHECK(!(s & KS_CTRL));
 }
 
+#ifndef __APPLE__
+// Non-Apple (Linux/X11/Wayland + Windows): AltGr must behave exactly
+// like plain Alt for shortcut dispatch, never as a Ctrl+Alt chord.
+// On EU/ISO layouts (Finnish) the right-Alt key is AltGr; KDE/X11 often
+// delivers it as a synthetic Ctrl + right-Alt combo, which without
+// normalisation would route AltGr+P to Song Duration (Ctrl+Alt+P)
+// instead of paste-continuously. See keybuffer.cpp's AltGr==Alt block.
+
+// AltGr delivered as the SDL Mode modifier -> KS_ALT, no KS_CTRL.
+static void test_altgr_mode_maps_to_alt_only() {
+    KeyBuffer kb;
+    kb.insert(SDLK_P, SDL_KMOD_MODE);
+    (void)kb.checkkey();
+    int s = (int)kb.getstate();
+    CHECK(s & KS_ALT);
+    CHECK(!(s & KS_CTRL));
+    CHECK(KS_HAS_ALT(s));
+}
+
+// AltGr delivered Windows-style as Ctrl + right-Alt -> Ctrl stripped,
+// leaving plain KS_ALT. This is the KDE-Neon-X11 symptom case.
+static void test_altgr_synthetic_ctrl_ralt_strips_ctrl() {
+    KeyBuffer kb;
+    kb.insert(SDLK_P, SDL_KMOD_LCTRL | SDL_KMOD_RALT);
+    (void)kb.checkkey();
+    int s = (int)kb.getstate();
+    CHECK(s & KS_ALT);
+    CHECK(!(s & KS_CTRL));
+    CHECK(KS_HAS_ALT(s));
+}
+
+// Right-Alt alone (clean AltGr) -> KS_ALT, no KS_CTRL.
+static void test_altgr_ralt_alone_is_alt() {
+    KeyBuffer kb;
+    kb.insert(SDLK_P, SDL_KMOD_RALT);
+    (void)kb.checkkey();
+    int s = (int)kb.getstate();
+    CHECK(s & KS_ALT);
+    CHECK(!(s & KS_CTRL));
+}
+
+// CRITICAL: a genuine Ctrl+Alt chord uses the LEFT Alt and must be
+// preserved -- Ctrl+Alt+L (Lua console) etc. depend on KS_CTRL+KS_ALT
+// both being set. The AltGr normalisation must NOT touch this.
+static void test_genuine_left_ctrl_alt_preserved() {
+    KeyBuffer kb;
+    kb.insert(SDLK_L, SDL_KMOD_LCTRL | SDL_KMOD_LALT);
+    (void)kb.checkkey();
+    int s = (int)kb.getstate();
+    CHECK(s & KS_CTRL);
+    CHECK(s & KS_ALT);
+    CHECK(!KS_HAS_ALT(s)); // Ctrl present => KS_HAS_ALT is false, by design
+}
+
+// Plain left-Ctrl alone stays Ctrl-only (no spurious Alt from the AltGr
+// path) -- guards against the normalisation over-reaching.
+static void test_left_ctrl_alone_unaffected() {
+    KeyBuffer kb;
+    kb.insert(SDLK_S, SDL_KMOD_LCTRL);
+    (void)kb.checkkey();
+    int s = (int)kb.getstate();
+    CHECK(s & KS_CTRL);
+    CHECK(!(s & KS_ALT));
+}
+#endif
+
 #ifdef __APPLE__
 // macOS-only: Cmd (SDL_KMOD_GUI) maps to BOTH KS_META and KS_ALT so
 // that Cmd+key works wherever Alt+key does. The KS_HAS_ALT macro
@@ -263,6 +329,13 @@ int main() {
     test_state_ctrl_only();
     test_state_shift_ctrl();
     test_state_alt_alone_no_ctrl();
+#ifndef __APPLE__
+    test_altgr_mode_maps_to_alt_only();
+    test_altgr_synthetic_ctrl_ralt_strips_ctrl();
+    test_altgr_ralt_alone_is_alt();
+    test_genuine_left_ctrl_alt_preserved();
+    test_left_ctrl_alone_unaffected();
+#endif
 #ifdef __APPLE__
     test_macos_cmd_maps_to_meta_and_alt();
     test_macos_cmd_shift_does_not_set_ctrl();


### PR DESCRIPTION
## Summary

A user on **KDE Neon (noble) X11** with a Finnish keyboard reported that **AltGr+P pops Song Duration** instead of doing the Alt+P action, and that no Alt/Ctrl combo seemed to do "copy pattern → next empty slot → jump to it". This fixes the root cause: **AltGr now behaves exactly like plain Alt for every shortcut.**

## Root cause

On EU/ISO layouts the right-Alt key is **AltGr**. KDE/X11 commonly delivers it as a *synthetic Ctrl + right-Alt* combo. So a keypress the user thinks of as `Alt+P` arrives as `kstate = KS_CTRL | KS_ALT`:

- The **Song Duration** guard (`main.cpp:1602`) is `(KS_CTRL) && !KS_HAS_ALT && !KS_SHIFT`. `KS_HAS_ALT` is false whenever Ctrl is present, so `Ctrl+Alt+P` *passes* → Song Duration pops.
- The **Alt-only** bindings never fire: in the Pattern Editor `Alt+P` = paste-continuously, and the global duplicate-pattern `Alt+P` (`main.cpp:1608`) explicitly requires `!(kstate & KS_CTRL)`.

Net effect on AltGr layouts: every Alt-shortcut that collides with a Ctrl-shortcut on the same letter gets hijacked.

## Fix

Normalised at the source in `KeyBuffer::insert` (`src/keybuffer.cpp`), where the `SDL_KMOD_*` → `KS_*` translation already lives. When AltGr is in play — `SDL_KMOD_MODE` set, **or** right-Alt held without left-Alt — force `KS_ALT` on and clear the stray `KS_CTRL`:

```cpp
if ((state & SDL_KMOD_MODE) ||
    ((state & SDL_KMOD_RALT) && !(state & SDL_KMOD_LALT))) {
    c |=  KS_ALT;
    c &= ~KS_CTRL;
}
```

Genuine `Ctrl+Alt` chords are pressed with the **LEFT** Alt (`Ctrl+Alt+L` Lua console, `Ctrl+Alt+K` keybindings, `Ctrl+Alt+N` new song, `Ctrl+Alt+Q` quit) so they are left untouched. Handles all delivery forms: `MODE`, bare `RALT`, `LCTRL+RALT`, `RCTRL+RALT`. Scoped to **non-Apple** — macOS has no AltGr and its right-Option must keep current behaviour.

## Note for the reporter

"Copy pattern → next empty slot → jump to it" is **`Ctrl+Shift+D`** (Clone Pattern) inside the F2 Pattern Editor — no Alt involved, so it was never affected. The `Alt+P` duplicate variant fires only *outside* the Pattern Editor by design (in F2, `Alt+P` is paste-continuously). With this fix, AltGr+P in F2 now does paste-continuously as intended instead of Song Duration.

## Test plan

- [x] `keybuffer.cpp` AltGr block added, scoped `#ifndef __APPLE__`.
- [x] 5 new `test_keybuffer` cases (`#ifndef __APPLE__`): MODE→Alt, RALT-alone→Alt, synthetic `LCTRL+RALT`→Alt (Ctrl stripped), genuine `LCTRL+LALT` preserved, `LCTRL`-only unaffected.
- [x] `sdl_stub.h` gains `SDL_KMOD_MODE` (0x4000) + `SDLK_L`.
- [x] Standalone truth-table check of the normalisation: all 7 cases correct.
- [x] `ctest` — 12/12 pass on macOS (AltGr tests compiled out there; Linux CI runs them).
- [x] Clean build, no warnings introduced.

Symptom quote: *"ALT+P does calculate song duration like it is documented in the help. Is it possible these are changed/colliding because of my system? (KDE Neon noble on X11)"*

🤖 Generated with [Claude Code](https://claude.com/claude-code)