### PR TITLE
Pattern Editor keymap: Block Functions family on Ctrl + Ctrl-Shift-P Song Duration

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -7,13 +7,17 @@ Legend
 zt 2026_05_31 (Pattern Editor keymap: Ctrl-D select, Ctrl-Shift-P duration)
 ----------------------------------------------------------------------------
 
-        * Ctrl-D now does "Select one beat" in the Pattern Editor, exactly
-          like Alt-D. It was the odd one out in the Block Functions family
-          (Ctrl-B/E/U are all Ctrl-keyed, but "select one beat" was Alt-D
-          only and plain Ctrl-D was unbound). Both Ctrl-D and Alt-D now
-          run the same gesture (shared pe_select_one_beat helper). Press
+        * The whole Block Functions family now works on Ctrl, matching the
+          F1 help. These gestures (mark begin / mark end / unselect /
+          select one beat) historically existed ONLY on Alt-B/E/U/D even
+          though help.txt documented them as Ctrl-keyed -- so muscle memory
+          and the help both failed. Ctrl-B, Ctrl-E, Ctrl-U and Ctrl-D now
+          run the same gestures as their Alt counterparts (shared
+          pe_block_set_begin / pe_block_set_end / pe_select_one_beat
+          helpers; Alt forms still work too). Press Ctrl-D / Alt-D
           repeatedly to extend the selection one highlight increment at a
-          time.
+          time. Exception: Ctrl-L stays the global "Load Song", so "select
+          whole track / pattern" remains on Alt-L (noted in the help).
 
         * Song Duration in the Pattern Editor (F2) moved from Ctrl-P to
           CTRL-SHIFT-P. Plain Ctrl-P is now deliberately free inside F2

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,29 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_05_31 (Pattern Editor keymap: Ctrl-D select, Ctrl-Shift-P duration)
+----------------------------------------------------------------------------
+
+        * Ctrl-D now does "Select one beat" in the Pattern Editor, exactly
+          like Alt-D. It was the odd one out in the Block Functions family
+          (Ctrl-B/E/U are all Ctrl-keyed, but "select one beat" was Alt-D
+          only and plain Ctrl-D was unbound). Both Ctrl-D and Alt-D now
+          run the same gesture (shared pe_select_one_beat helper). Press
+          repeatedly to extend the selection one highlight increment at a
+          time.
+
+        * Song Duration in the Pattern Editor (F2) moved from Ctrl-P to
+          CTRL-SHIFT-P. Plain Ctrl-P is now deliberately free inside F2
+          (it does nothing), so it no longer steals the key from pattern
+          work and a stray AltGr / Ctrl+Alt-P can't pop the Duration
+          popup there either. On every OTHER page, Song Duration stays on
+          plain Ctrl-P as before.
+
+        ! Known, unchanged: in the Pattern Editor, Ctrl-L triggers the
+          global "Load Song" rather than the documented "select whole
+          track / pattern" block function -- the global handler shadows
+          the page binding. Left as-is for now.
+
 zt 2026_05_29 (Instrument Editor: Create 16 channels for a MIDI device)
 ----------------------------------------------------------------------------
 

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -66,11 +66,12 @@
 
 |L|%==|H|Block Functions|L|==%|U|
 
- CTRL-B : Marks the beginning of a select block.
- CTRL-E : Marks the end of a select block.
- CTRL-L : Select whole track, pressing it again will select the entire
-          pattern.
- CTRL-U : Unselect block
+ CTRL-B / ALT-B : Marks the beginning of a select block.
+ CTRL-E / ALT-E : Marks the end of a select block.
+ ALT-L  : Select whole track, pressing it again will select the entire
+          pattern. (Use ALT-L here, not CTRL-L: plain CTRL-L is the
+          global "Load Song".)
+ CTRL-U / ALT-U : Unselect block
  CTRL-D / ALT-D : Select one beat (press multiple times to select next beats)
 
  CTRL-C : Copy the selected block to the clipboard.

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -61,6 +61,8 @@
  CTRL-SHIFT-Up   : Rotate Track Up (first row wraps to last)
  CTRL-F9         : Track Solo (mute all other tracks; repeat to unsolo all)
  ALT-H           : Humanize Velocities in selection (randomize +/- 15)
+ CTRL-SHIFT-P    : Song Duration (in the Pattern Editor; plain Ctrl-P is
+                   free here and does nothing, unlike on other pages)
 
 |L|%==|H|Block Functions|L|==%|U|
 

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -69,7 +69,7 @@
  CTRL-L : Select whole track, pressing it again will select the entire
           pattern.
  CTRL-U : Unselect block
- ALT-D  : Select one beat (press multiple times to select next beats)
+ CTRL-D / ALT-D : Select one beat (press multiple times to select next beats)
 
  CTRL-C : Copy the selected block to the clipboard.
  CTRL-V : Paste the contents of the clipboard to the cursor location.
@@ -197,7 +197,8 @@
  ALT-F12        : About
  CTRL-S         : Save Song
  CTRL-ALT-N     : New Song
- CTRL-P         : Song Duration
+ CTRL-P         : Song Duration. (On Pattern Editor F2 this is
+                  CTRL-SHIFT-P instead; plain Ctrl-P is free there.)
  ALT-P          : Duplicate current pattern to next empty pattern
                   slot and switch to it. (On Pattern Editor F2,
                   Alt-P is paste-continuously instead - see above.)

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -1161,6 +1161,39 @@ void CUI_Patterneditor::leave(void)
 // ------------------------------------------------------------------------------------------------
 //
 //
+
+// Block-function "select one beat" gesture (help: Block Functions).
+// Bound to BOTH Ctrl-D and Alt-D so it sits naturally alongside its
+// Ctrl-keyed siblings (Ctrl-B/E/U) while keeping the Impulse-Tracker
+// Alt-D muscle memory. Press repeatedly to extend the selection one
+// highlight-increment "beat" at a time down the current track.
+static void pe_select_one_beat()
+{
+  if ( selected &&
+       select_row_start == cur_edit_row &&
+       select_track_start == cur_edit_track &&
+       select_track_end == cur_edit_track ) {
+    select_row_start = cur_edit_row;
+    if (select_row_end < cur_edit_row + zt_config_globals.highlight_increment - 1)
+      select_row_end = cur_edit_row + zt_config_globals.highlight_increment - 1;
+    else {
+      float size = (float)(select_row_end - select_row_start);
+      size /= zt_config_globals.highlight_increment;
+      select_row_end = (int) (cur_edit_row + zt_config_globals.highlight_increment * (size + 1));
+    }
+    select_track_start = cur_edit_track;
+    select_track_end = cur_edit_track;
+    selected = 1;
+  } else {
+    select_row_start = cur_edit_row;
+    select_row_end = cur_edit_row + zt_config_globals.highlight_increment - 1;
+    select_track_start = cur_edit_track;
+    select_track_end = cur_edit_track;
+    selected = 1;
+  }
+  need_refresh++;
+}
+
 void CUI_Patterneditor::update()
 {
   int old_pattern_edit_rows = PATTERN_EDIT_ROWS;
@@ -2408,6 +2441,14 @@ void CUI_Patterneditor::update()
             need_refresh++;
             break;
 
+          // Ctrl-D = "select one beat", the same gesture as Alt-D. Lives
+          // here so it lines up with the other Ctrl-keyed block-selection
+          // shortcuts (Ctrl-B/E/U) instead of being the family's odd-one-
+          // out. There is no global Ctrl-D handler, so nothing shadows it.
+          case SDLK_D:
+            pe_select_one_beat();
+            break;
+
           } ;
 
 
@@ -2866,45 +2907,8 @@ void CUI_Patterneditor::update()
             }
             break;
             
-          case SDLK_D: /* select */
-            if ( selected &&
-              select_row_start == cur_edit_row &&
-              
-              select_track_start == cur_edit_track &&
-              select_track_end == cur_edit_track ) {
-              
-              select_row_start = cur_edit_row;
-              
-              if (select_row_end < cur_edit_row + zt_config_globals.highlight_increment-1)
-                select_row_end = cur_edit_row + zt_config_globals.highlight_increment - 1;
-              else  {
-                
-                float size = (float)(select_row_end - select_row_start) ;
-
-                size /= zt_config_globals.highlight_increment;
-                
-                // <Manu> Cast
-                //select_row_end = cur_edit_row + zt_config_globals.highlight_increment*(size+1);
-                select_row_end = (int) (cur_edit_row + zt_config_globals.highlight_increment*(size+1)) ;
-              }
-              
-              select_track_start = cur_edit_track;
-              select_track_end = cur_edit_track; 
-              selected = 1;
-              need_refresh++;
-            }
-            else {
-              select_row_start = cur_edit_row;
-              select_row_end = cur_edit_row + zt_config_globals.highlight_increment - 1;
-              select_track_start = cur_edit_track;
-              select_track_end = cur_edit_track; 
-              selected = 1;
-              need_refresh++;
-              
-            }
-            
-            
-            
+          case SDLK_D: /* select one beat (also on Ctrl-D, see Ctrl block) */
+            pe_select_one_beat();
             break;
           case SDLK_R: /* Replicate at Cursor (from Paketti, ALT+R / Cmd+R) */
           {

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -1194,6 +1194,54 @@ static void pe_select_one_beat()
   need_refresh++;
 }
 
+// Block-function "set begin" / "set end" gestures (help: Block Functions).
+// Historically these lived only on Alt-B / Alt-E even though the help
+// documents them as Ctrl-B / Ctrl-E. Extracted here so BOTH modifiers can
+// run the same gesture (see the Ctrl switch and the Alt switch below).
+static void pe_block_set_begin()
+{
+  int temp;
+  if (!selected) {
+    selected = 1;
+    select_row_start = cur_edit_row;
+    select_row_end = cur_edit_row;
+    select_track_start = cur_edit_track;
+    select_track_end = cur_edit_track;
+  } else {
+    select_row_start = cur_edit_row;
+    select_track_start = cur_edit_track;
+    if (select_track_start > select_track_end) {
+      temp = select_track_start; select_track_start = select_track_end; select_track_end = temp;
+    }
+    if (select_row_start > select_row_end) {
+      temp = select_row_start; select_row_start = select_row_end; select_row_end = temp;
+    }
+  }
+  need_refresh++;
+}
+
+static void pe_block_set_end()
+{
+  int temp;
+  if (!selected) {
+    selected = 1;
+    select_row_start = cur_edit_row;
+    select_row_end = cur_edit_row;
+    select_track_start = cur_edit_track;
+    select_track_end = cur_edit_track;
+  } else {
+    select_row_end = cur_edit_row;
+    select_track_end = cur_edit_track;
+    if (select_track_start > select_track_end) {
+      temp = select_track_start; select_track_start = select_track_end; select_track_end = temp;
+    }
+    if (select_row_start > select_row_end) {
+      temp = select_row_start; select_row_start = select_row_end; select_row_end = temp;
+    }
+  }
+  need_refresh++;
+}
+
 void CUI_Patterneditor::update()
 {
   int old_pattern_edit_rows = PATTERN_EDIT_ROWS;
@@ -2441,11 +2489,24 @@ void CUI_Patterneditor::update()
             need_refresh++;
             break;
 
-          // Ctrl-D = "select one beat", the same gesture as Alt-D. Lives
-          // here so it lines up with the other Ctrl-keyed block-selection
-          // shortcuts (Ctrl-B/E/U) instead of being the family's odd-one-
-          // out. There is no global Ctrl-D handler, so nothing shadows it.
-          case SDLK_D:
+          // Block Functions family on Ctrl, matching the F1 help. These
+          // gestures historically existed only on Alt-B/E/U/D even though
+          // help.txt documents them as Ctrl-keyed; bind the Ctrl forms too
+          // so the documented shortcuts actually work. None of B/E/U/D has
+          // a global handler, so nothing shadows them. (Ctrl-L is the one
+          // exception: it's the global Load Song, so "select track/pattern"
+          // stays on Alt-L -- see the help note.)
+          case SDLK_B:        // Mark begin of select block
+            pe_block_set_begin();
+            break;
+          case SDLK_E:        // Mark end of select block
+            pe_block_set_end();
+            break;
+          case SDLK_U:        // Unselect block
+            selected = 0;
+            need_refresh++;
+            break;
+          case SDLK_D:        // Select one beat (same gesture as Alt-D)
             pe_select_one_beat();
             break;
 
@@ -2813,51 +2874,11 @@ void CUI_Patterneditor::update()
               need_refresh++;
             }
             break;
-          case SDLK_B:  // Set Select Begin block
-            if (!selected) {    
-              selected = 1;
-              select_row_start = cur_edit_row;
-              select_row_end = cur_edit_row;
-              select_track_start = cur_edit_track;
-              select_track_end = cur_edit_track;
-            } else {
-              select_row_start = cur_edit_row;
-              select_track_start = cur_edit_track;
-              if (select_track_start > select_track_end) {
-                temp = select_track_start;
-                select_track_start = select_track_end;
-                select_track_end = temp;
-              }
-              if (select_row_start > select_row_end){
-                temp = select_row_start;
-                select_row_start = select_row_end;
-                select_row_end = temp;
-              }
-            }
-            need_refresh++;
+          case SDLK_B:  // Set Select Begin block (also on Ctrl-B)
+            pe_block_set_begin();
             break;
-          case SDLK_E: // Set Block End
-            if (!selected) {    
-              selected = 1;
-              select_row_start = cur_edit_row;
-              select_row_end = cur_edit_row;
-              select_track_start = cur_edit_track;
-              select_track_end = cur_edit_track;
-            } else {
-              select_row_end = cur_edit_row;
-              select_track_end = cur_edit_track;
-              if (select_track_start > select_track_end) {
-                temp = select_track_start;
-                select_track_start = select_track_end;
-                select_track_end = temp;
-              }
-              if (select_row_start > select_row_end){
-                temp = select_row_start;
-                select_row_start = select_row_end;
-                select_row_end = temp;
-              }
-            }                   
-            need_refresh++;
+          case SDLK_E: // Set Block End (also on Ctrl-E)
+            pe_block_set_end();
             break;
             
             

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1589,21 +1589,26 @@ void global_keys(Drawable *S)
                 }
                 break;
             case SDLK_P:
-                // Ctrl-P = Song Duration popup. Moved here from Alt-P so
-                // Alt-P is free for two new pattern-management bindings:
-                //   * On F2 Pattern Editor: Alt-P = paste-continuously
-                //     (fill clipboard downward to end of pattern). The
-                //     page handler implements this; the global handler
-                //     skips Alt-P when cur_state == STATE_PEDIT.
-                //   * Everywhere else: Alt-P = duplicate current pattern
-                //     into the next empty pattern slot and switch
-                //     cur_edit_pattern to it. Reachable from F11 Order
-                //     List / F3 Instrument Editor / any other page.
-                if ((kstate & KS_CTRL) && !KS_HAS_ALT(kstate) && !(kstate & KS_SHIFT)) {
-                    popup_window(UIP_SongDuration);
-                    key = Keys.getkey();
-                    clear++;
-                    break;
+                // Song Duration popup.
+                //   * Pattern Editor (F2): Ctrl-SHIFT-P. Plain Ctrl-P is
+                //     deliberately left free for pattern work there, and
+                //     keeping Song Duration behind Shift also means a stray
+                //     AltGr / Ctrl+Alt-P can't accidentally pop it.
+                //   * Every other page: plain Ctrl-P (no Shift).
+                // Alt-P is unrelated: paste-continuously in F2 / duplicate
+                // current pattern into the next empty slot elsewhere (see
+                // the KS_HAS_ALT branch below; it skips F2).
+                {
+                    bool ctrl_p   = (kstate & KS_CTRL) && !KS_HAS_ALT(kstate);
+                    bool want_dur = (cur_state == STATE_PEDIT)
+                                      ? (ctrl_p &&  (kstate & KS_SHIFT))   // F2: Ctrl-Shift-P
+                                      : (ctrl_p && !(kstate & KS_SHIFT));  // else: Ctrl-P
+                    if (want_dur) {
+                        popup_window(UIP_SongDuration);
+                        key = Keys.getkey();
+                        clear++;
+                        break;
+                    }
                 }
                 if (KS_HAS_ALT(kstate) && !(kstate & KS_CTRL) && !(kstate & KS_SHIFT)
                     && cur_state != STATE_PEDIT) {


### PR DESCRIPTION
## Summary

Pattern-Editor (F2) keymap fixes from a live session. The Block Functions family was documented in F1 as Ctrl-keyed but was actually bound only to Alt — so the documented shortcuts didn't work and muscle memory failed.

### 1. Block Functions family now works on Ctrl (matching F1)

`mark begin`, `mark end`, `unselect`, `select one beat` existed only on **Alt-B/E/U/D** even though `help.txt` documents **Ctrl-B/E/U/D**. Bound the Ctrl forms so the help is truthful:

- Extracted `pe_select_one_beat`, `pe_block_set_begin`, `pe_block_set_end` helpers.
- Alt cases delegate to them; new **Ctrl-B / Ctrl-E / Ctrl-U / Ctrl-D** cases in the `kstate == KS_CTRL` switch call the same code. Ctrl-U is a one-line inline.
- No global handler exists for B/E/U/D, so nothing shadows them.
- **Exception:** `Ctrl-L` is the global **Load Song**, so "select whole track/pattern" stays on **Alt-L** (noted in help). Left per user (*"its fine i guess"*).

User reports addressed: *"ctrl-d should work without issues"* and *"ctrl-u does NOT unmark"*.

### 2. Song Duration in F2 → Ctrl-Shift-P; plain Ctrl-P freed

Per user: *"ctrl-p should not work in F2. there it should be shift-ctrl-p."*

- **F2:** Song Duration = **Ctrl-Shift-P**; plain Ctrl-P does nothing there (frees the key; also blocks a stray AltGr/Ctrl+Alt-P from popping it).
- **Other pages:** Song Duration stays on plain **Ctrl-P**.
- Documented in both the Global Keys and the F2 Pattern Operations help sections.

## Test plan

- [x] Clean build (macOS), `ctest` 12/12 pass.
- [x] All Alt forms still work (delegate to shared helpers); Ctrl-Shift-D Clone Pattern untouched.
- [x] No global SDLK_B/E/U/D; verified Ctrl-P falls through cleanly in F2.
- [x] `doc/help.txt` Block Functions + Pattern Operations + Global Keys updated; `doc/CHANGELOG.txt` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
