### PR TITLE
Don't bleed the playback status line over a modal popup (ESC menu)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3386,7 +3386,12 @@ int action(Screen *S)
         need_refresh++;
     }
 
-    if (status_change) {
+    // Don't paint the playback status line while a modal popup (e.g. the
+    // ESC main menu) is open -- update_status() draws straight to the
+    // surface every frame during playback and would bleed over the popup,
+    // which is supposed to be on top. status_change stays set, so the
+    // status line repaints as soon as the popup closes.
+    if (status_change && window_stack.isempty()) {
         update_status(S);
     }
 


### PR DESCRIPTION
## Summary

While playback is running, opening the ESC **Main Menu** (or any modal popup) shows the live playback status line bleeding **on top of** the menu — the `Row: / Time: / BPM:` text paints over the menu title and "Views" subheading.

![report](screenshot showed "Row: 047/064, Time: 00:06.0/..., BPM: 138" over the Main Menu)

## Root cause

`update_status(S)` builds and draws the playback status line straight to the surface, and it's called every frame whenever `status_change` is set (which playback sets continuously). It has no awareness of the modal popup that's supposed to be on top, so during playback it repaints over the popup every frame.

## Fix

Gate the per-frame `update_status(S)` call on `window_stack.isempty()`:

```c
if (status_change && window_stack.isempty()) {
    update_status(S);
}
```

- While a popup is open, the status line isn't drawn, so the popup stays clean.
- `status_change` is left set (we skip the call that would clear it), so the status line repaints the instant the popup closes — no stale region, self-healing.
- Applies to **every** modal popup, not just the main menu (any popup during playback had the same bleed).

## Test plan

- [x] Clean build (macOS), `ctest` 12/12 pass.
- [x] One-line guard at the single per-frame call site; no change to `update_status` itself.
- [x] Reasoned through close path: closing the popup triggers `clear_popup`/`need_refresh` (page redraw) and the next `status_change` frame repaints the status line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
