### PR TITLE
Palettes: fix Hotdog Stand (bright yellow), alphabetize list, doc headless screenshots

### DIFF
--- a/.claude/skills/ztrackerprime/SKILL.md
+++ b/.claude/skills/ztrackerprime/SKILL.md
@@ -42,6 +42,70 @@ ctest --output-on-failure      # unit-test harness (Linux CI runs this)
 
 `scripts/zt-screenshot.sh` (macOS) launches zt.app and captures F1/F2/F3/F11/F12/Ctrl+F12 via `screencapture -R` + AppleScript. Output at `/tmp/zt-shots/`. Use it to self-verify layout changes.
 
+### Headless screenshot recipe (verified macOS, no extra deps)
+
+When `zt-screenshot.sh` can't be used (e.g. it relies on the `Quartz`
+Python module, which is **not** present in the system `python3` on a
+stock Mac — `ModuleNotFoundError: No module named 'Quartz'`), this
+dependency-free sequence reliably captures zt's actual rendering:
+
+```sh
+# 1. Relaunch a fresh binary (kill the old instance first, or you screenshot stale pixels)
+pkill -f "zt.app/Contents/MacOS/zt"; sleep 1
+open build/Program/zt.app && sleep 2
+
+# 2. Bring zt to the front — screencapture grabs whatever is frontmost, and
+#    `open` does NOT guarantee focus over the terminal you launched it from
+osascript -e 'tell application "zt" to activate' \
+  || osascript -e 'tell application "System Events" to set frontmost of (first process whose name is "zt") to true'
+sleep 2
+
+# 3. Capture. Full-screen is the robust fallback; -o omits the window shadow, -x silences the shutter
+screencapture -o -x /tmp/zt_shot.png
+```
+
+Then `Read` the PNG to eyeball it. Foot-guns learned the hard way:
+- **`cp` is interactive.** A bare `cp src dst` prompts `overwrite? (y/n)`
+  and, with no tty answer, **silently does NOT overwrite** — your swap
+  never happened. Use `/bin/cp -f` for any scripted overwrite.
+- **`open` then capture grabs the terminal**, not zt, unless you
+  `activate` zt first (step 2). The first capture attempt usually shows
+  iTerm — bring zt forward and recapture.
+- A backgrounded `python3 - <<'PY' ... Quartz ...` window-id lookup will
+  fail on stock macOS; don't depend on it. Full-screen `screencapture`
+  needs no window id.
+
+### Screenshotting a specific palette / skin without driving the UI
+
+To verify how a palette `.conf` (e.g. `palettes/hotdog_stand.conf`) or a
+skin renders, you don't have to click through the Palette Editor. The
+startup colours come from the skin named in `zt.conf` (`skin: default`),
+loaded from `<bundle>/skins/<name>/colors.conf` — **same slot format** as
+`palettes/*.conf`. So:
+
+```sh
+RES=build/Program/zt.app/Contents/Resources
+/bin/cp -f "$RES/skins/default/colors.conf" /tmp/colors_backup.conf   # back up
+/bin/cp -f "$RES/palettes/hotdog_stand.conf" "$RES/skins/default/colors.conf"  # swap in
+# ... relaunch + capture per the recipe above ...
+/bin/cp -f /tmp/colors_backup.conf "$RES/skins/default/colors.conf"   # ALWAYS restore
+```
+
+`COLORS.Background` is the full-screen fill (`main.cpp` `fillRect(0,0,…,COLORS.Background)`),
+so a wrong `Background` value shows instantly. Note that palettes/skins
+are copied into the bundle by a CMake POST_BUILD step — edit the **source**
+`palettes/*.conf` (repo root) and rebuild to propagate; editing only the
+bundle copy is for throwaway verification and must be restored.
+
+Palette gotcha (PR: Hotdog Stand): `scripts/import-schism-palettes.py`
+maps Schism colour **index 1** to `Background`, but some Schism palettes
+(Hotdog Stand) put the desktop fill on **index 2** — the importer left
+Background black and Lowlight yellow, so the desktop was black and, worse,
+black `Text` on a black desktop was invisible. Frames draw with **both**
+`Lowlight` (top/left) and `Highlight` (bottom/right), so a `Lowlight` that
+equals `Background` makes half of every frame vanish. Hand-tune imported
+palettes against an actual screenshot; don't trust the 16→18 slot mapping.
+
 ## Key files
 
 | File | Purpose |

--- a/palettes/hotdog_stand.conf
+++ b/palettes/hotdog_stand.conf
@@ -1,7 +1,11 @@
-# Hotdog Stand -- imported from Schism Tracker palettes.c
-Background:      #000000
+# Hotdog Stand -- the Win3.1 theme, matched to Schism Tracker.
+# Bright yellow desktop, black text, red frames (Schism palette index 2
+# is the yellow desktop fill; the auto-import wrongly took index 1/black
+# for Background and yellow for Lowlight, which made the desktop black and
+# the top/left frame edges invisible once the bg was corrected).
+Background:      #FFFF00
 Highlight:       #FF0000
-Lowlight:        #FFFF00
+Lowlight:        #FF0000
 Text:            #000000
 Data:            #FF0000
 Black:           #000000

--- a/src/CUI_PaletteEditor.cpp
+++ b/src/CUI_PaletteEditor.cpp
@@ -230,8 +230,17 @@ CUI_PaletteEditor::~CUI_PaletteEditor(void) {
 void CUI_PaletteEditor::rebuild_preset_list(void) {
     num_presets = 0;
 
-    // 1. Static palette presets (palettes/*.conf next to the binary).
-    for (int i = 0; i < NUM_STATIC_PRESETS && num_presets < 64; ++i) {
+    // 1. Static palette presets (palettes/*.conf next to the binary),
+    //    listed alphabetically by label. (Labels are Title Case, so a
+    //    plain strcmp is already alphabetical; selection is by path, not
+    //    index, so reordering the display is safe.)
+    int order[NUM_STATIC_PRESETS];
+    for (int i = 0; i < NUM_STATIC_PRESETS; ++i) order[i] = i;
+    std::sort(order, order + NUM_STATIC_PRESETS, [](int a, int b) {
+        return strcmp(g_palette_presets[a].label, g_palette_presets[b].label) < 0;
+    });
+    for (int k = 0; k < NUM_STATIC_PRESETS && num_presets < 64; ++k) {
+        int i = order[k];
         snprintf(preset_label[num_presets], sizeof(preset_label[0]),
                  "%s", g_palette_presets[i].label);
 #if defined(_WIN32)


### PR DESCRIPTION
## Summary

Fixes the **Hotdog Stand** palette (it wrecked everything), **alphabetizes** the palette preset list, and documents the **headless-screenshot** technique used to verify it in the contributor skill.

### 1. Hotdog Stand now matches Schism (bright yellow)

It was unusable: **black desktop**, black-on-black (invisible) `Text`, and half-vanishing frames.

Root cause: `scripts/import-schism-palettes.py` maps Schism colour **index 1 → `Background`**, but Hotdog Stand puts its bright-yellow desktop fill on **index 2**. So the importer took black for `Background` and yellow for `Lowlight`. Since the whole screen is filled with `COLORS.Background` (`main.cpp` `fillRect(0,0,…)`) and frames draw with **both** `Lowlight` (top/left) and `Highlight` (bottom/right), the result was a black screen, invisible text, and broken frames.

Fix `palettes/hotdog_stand.conf`:
- `Background` `#000000` → `#FFFF00` (Schism's yellow desktop; also makes the black `Text` visible)
- `Lowlight` `#FFFF00` → `#FF0000` (solid red frames on yellow instead of yellow-on-yellow)

**Verified** by swapping it into the startup skin and screenshotting — bright yellow desktop, black text, red frames, black pattern grid. Matches Schism Tracker.

| before | after |
|---|---|
| black desktop, invisible text | bright yellow, black text, red frames |

### 2. Alphabetized palette list

The static presets now display A→Z: Acid Gas, Atlantic, Camouflage, FX 2.0, Gold, Gold (Vintage), Hotdog Stand, Industrial, Kawaii, Light Blue, Midnight Tracking, Pine Colours, Purple Motion, Soundtracker, Volcanic, Why Colors?

Sorted at list-build time in `rebuild_preset_list` (array stays the source of truth). **Safe** because selection applies by path (`load_palette_file(preset_path[i])`) and the skin persists by name — nothing stores a palette index. Skins already listed sorted.

### 3. Skill docs (per request)

`.claude/skills/ztrackerprime/SKILL.md` gains a dependency-free headless-screenshot recipe (Quartz-free `screencapture`, activate-before-capture, the `cp -i` silent-no-overwrite foot-gun) and the palette-swap verification trick + the Schism-import index gotcha.

## Test plan

- [x] Clean build (macOS), `ctest` 12/12 pass.
- [x] Hotdog Stand rendering confirmed via screenshot (yellow desktop).
- [x] Sort order confirmed (host-compiled check of the comparator).
- [x] Reorder safety reasoned: selection by path, skin by name, no index persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
