### PR TITLE
Lua: full API self-test (lua/selftest.lua) + --lua-test + ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,6 +401,9 @@ if(APPLE)
     COMMAND ${CMAKE_COMMAND} -E copy_directory
       "${CMAKE_SOURCE_DIR}/assets/syx"
       "$<TARGET_BUNDLE_CONTENT_DIR:zt>/Resources/syx"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+      "${CMAKE_SOURCE_DIR}/assets/lua"
+      "$<TARGET_BUNDLE_CONTENT_DIR:zt>/Resources/lua"
     VERBATIM
   )
 else()
@@ -418,6 +421,8 @@ else()
           "${CMAKE_SOURCE_DIR}/assets/ccizer" "$<TARGET_FILE_DIR:zt>/ccizer"
       COMMAND ${CMAKE_COMMAND} -E copy_directory
           "${CMAKE_SOURCE_DIR}/assets/syx" "$<TARGET_FILE_DIR:zt>/syx"
+      COMMAND ${CMAKE_COMMAND} -E copy_directory
+          "${CMAKE_SOURCE_DIR}/assets/lua" "$<TARGET_FILE_DIR:zt>/lua"
   )
 endif()
 

--- a/assets/lua/selftest.lua
+++ b/assets/lua/selftest.lua
@@ -1,0 +1,161 @@
+-- selftest.lua — exercises every zTracker Lua API surface and reports
+-- PASS/FAIL per check. Run it two ways:
+--   * headless / CI:   zt --headless --lua-test
+--   * in the console:  dofile("lua/selftest.lua")   (Ctrl+Alt+L)
+-- It mutates the in-memory song (notes, bpm, arps, ...) and saves a temp
+-- file, so run it on a scratch song. Sets the global SELFTEST_FAILURES
+-- (0 = all good); the --lua-test runner uses it for the process exit code.
+
+local fails, total = 0, 0
+local function check(name, cond)
+  total = total + 1
+  if cond then
+    print("PASS  " .. name)
+  else
+    fails = fails + 1
+    print("FAIL  " .. name)
+  end
+end
+local function eq(name, got, want)
+  check(name .. "  (got " .. tostring(got) .. ", want " .. tostring(want) .. ")", got == want)
+end
+
+-- ── introspection helpers exist ──────────────────────────────────────
+check("rprint exists", type(rprint) == "function")
+check("oprint exists", type(oprint) == "function")
+check("help exists",   type(help)   == "function")
+check("dump alias",    dump == rprint)
+
+-- ── constants ────────────────────────────────────────────────────────
+eq("MAX_PATTERNS",    zt.MAX_PATTERNS,    256)
+eq("MAX_TRACKS",      zt.MAX_TRACKS,      64)
+eq("MAX_INSTRUMENTS", zt.MAX_INSTRUMENTS, 100)
+eq("MAX_ORDERS",      zt.MAX_ORDERS,      256)
+eq("MAX_MIDIMACROS",  zt.MAX_MIDIMACROS,  256)
+eq("MAX_ARPEGGIOS",   zt.MAX_ARPEGGIOS,   256)
+eq("NOTE_EMPTY",      zt.NOTE_EMPTY,      0x80)
+eq("NOTE_CUT",        zt.NOTE_CUT,        0x81)
+eq("NOTE_OFF",        zt.NOTE_OFF,        0x82)
+eq("MIDDLE_C",        zt.MIDDLE_C,        60)
+eq("BREAK",           zt.BREAK,           0x100)
+eq("SKIP",            zt.SKIP,            0x101)
+eq("MACRO_END",       zt.MACRO_END,       0x100)
+eq("MACRO_PARAM",     zt.MACRO_PARAM,     0x101)
+
+-- ── note name <-> value ──────────────────────────────────────────────
+eq("note_name(60)",      zt.note_name(60),      "C-5")
+eq("note_value('C-5')",  zt.note_value("C-5"),  60)
+eq("note_value('F#3')",  zt.note_value("F#3"),  42)
+eq("note roundtrip",     zt.note_value(zt.note_name(72)), 72)
+eq("note_value off",     zt.note_value("off"),  0x82)
+eq("note_value cut",     zt.note_value("cut"),  0x81)
+
+-- ── flat functions still work ────────────────────────────────────────
+zt.set_bpm(140) ; eq("flat get/set_bpm", zt.get_bpm(), 140)
+zt.set_note(0, 0, 0, 60) ; eq("flat get/set_note", zt.get_note(0, 0, 0), 60)
+
+-- ── zt.song properties ───────────────────────────────────────────────
+zt.song.bpm = 150 ;          eq("song.bpm",  zt.song.bpm,  150)
+zt.song.tpb = 6 ;            eq("song.tpb",  zt.song.tpb,  6)
+zt.song.name = "selftest" ;  eq("song.name", zt.song.name, "selftest")
+zt.song.cur_pattern = 1 ;    eq("song.cur_pattern", zt.song.cur_pattern, 1)
+zt.song.cur_pattern = 0
+zt.song.cur_track = 2 ;      eq("song.cur_track", zt.song.cur_track, 2)
+zt.song.cur_instrument = 3 ; eq("song.cur_instrument", zt.song.cur_instrument, 3)
+zt.song.message = "hi from selftest" ; eq("song.message", zt.song.message, "hi from selftest")
+
+-- ── zt.instrument(i) ─────────────────────────────────────────────────
+local ins = zt.instrument(1)
+ins.name = "Lead" ;        eq("instrument.name",   ins.name, "Lead")
+ins.channel = 9 ;          eq("instrument.channel", ins.channel, 9)
+ins.device = 1 ;           eq("instrument.device",  ins.device, 1)
+ins.transpose = -12 ;      eq("instrument.transpose", ins.transpose, -12)
+ins.bank = 5 ;             eq("instrument.bank", ins.bank, 5)
+ins.volume = 100 ;         eq("instrument.volume", ins.volume, 100)
+ins.global_volume = 110 ;  eq("instrument.global_volume", ins.global_volume, 110)
+ins.default_length = 24 ;  eq("instrument.default_length", ins.default_length, 24)
+ins.ccizer_bank = "mf.txt"; eq("instrument.ccizer_bank", ins.ccizer_bank, "mf.txt")
+eq("instrument.index", ins.index, 1)
+
+-- ── zt.pattern(p) ────────────────────────────────────────────────────
+local pat = zt.pattern(0)
+pat.length = 64 ;          eq("pattern.length", pat.length, 64)
+eq("pattern.index", pat.index, 0)
+pat:set_note(1, 4, 62) ;   eq("pattern:note", pat:note(1, 4), 62)
+check("pattern.empty false", pat.empty == false)
+local pt = pat:track(1)
+eq("pattern:track -> track", pt.index, 1)
+
+-- ── zt.track(t) ──────────────────────────────────────────────────────
+local trk = zt.track(3)
+eq("track.index", trk.index, 3)
+trk:set_note(2, 64) ;      eq("track:note", trk:note(2), 64)
+trk.muted = true ;         eq("track.muted true", trk.muted, true)
+trk.muted = false ;        eq("track.muted false", trk.muted, false)
+
+-- ── zt.cell — every field, with per-field merge ──────────────────────
+local c = zt.cell(0, 8)            -- track 0, row 8
+c.note = zt.MIDDLE_C ;             eq("cell.note", c.note, 60)
+c.instrument = 2 ;                 eq("cell.instrument", c.instrument, 2)
+c.volume = 96 ;                    eq("cell.volume", c.volume, 96)
+c.length = 4 ;                     eq("cell.length", c.length, 4)
+c.effect = 0x53 ;                  eq("cell.effect", c.effect, 0x53)
+c.effect_data = 0x1234 ;           eq("cell.effect_data", c.effect_data, 0x1234)
+eq("cell.name", c.name, "C-5")
+check("cell.empty false", c.empty == false)
+-- setting one field must not clobber the others (merge)
+c.volume = 64
+eq("cell merge keeps note", c.note, 60)
+eq("cell merge sets volume", c.volume, 64)
+c:clear() ;                        check("cell:clear -> empty", c.empty == true)
+eq("empty cell reads NOTE_EMPTY", c.note, zt.NOTE_EMPTY)
+
+-- ── zt.orders ────────────────────────────────────────────────────────
+zt.orders[0] = 2 ;                 eq("orders[0]", zt.orders[0], 2)
+zt.orders[1] = 5 ;                 eq("orders[1]", zt.orders[1], 5)
+zt.orders[2] = zt.BREAK
+eq("orders.count", zt.orders.count, 2)
+eq("#orders", #zt.orders, 2)
+
+-- ── zt.transport ─────────────────────────────────────────────────────
+zt.transport:stop()
+check("transport.playing is bool", type(zt.transport.playing) == "boolean")
+zt.transport:play_pattern()
+check("transport playing after play", zt.transport.playing == true)
+zt.transport:stop()
+check("transport stopped", zt.transport.playing == false)
+
+-- ── zt.midimacro(i) ──────────────────────────────────────────────────
+local m = zt.midimacro(0)
+m.name = "Bank" ;                  eq("midimacro.name", m.name, "Bank")
+m:set(0, 0xB0) ; m:set(1, 0x20)
+eq("midimacro:get", m:get(0), 0xB0)
+check("midimacro not empty", m.empty == false)
+m.name = "dump.syx" ;              check("midimacro.syx", m.syx == true)
+
+-- ── zt.arpeggio(i) ───────────────────────────────────────────────────
+local a = zt.arpeggio(0)
+a.name = "up" ;                    eq("arpeggio.name", a.name, "up")
+a.length = 3 ;                     eq("arpeggio.length", a.length, 3)
+a.speed = 2 ;                      eq("arpeggio.speed", a.speed, 2)
+a.repeat_pos = 0 ;                 eq("arpeggio.repeat_pos", a.repeat_pos, 0)
+a.num_cc = 1 ;                     eq("arpeggio.num_cc", a.num_cc, 1)
+a:set_pitch(0, 0) ; a:set_pitch(1, 4) ; a:set_pitch(2, 7)
+eq("arpeggio:pitch", a:pitch(2), 7)
+a:set_pitch(2, nil) ;              check("arpeggio:pitch nil empties", a:pitch(2) == nil)
+a:set_cc(0, 74) ;                  eq("arpeggio:cc", a:cc(0), 74)
+a:set_ccval(0, 0, 100) ;           eq("arpeggio:ccval", a:ccval(0, 0), 100)
+
+-- ── file save / load roundtrip ───────────────────────────────────────
+local tmp = (os.getenv("TMPDIR") or os.getenv("TEMP") or "/tmp") .. "/zt_selftest.zt"
+zt.song.bpm = 171
+check("save ok", zt.save(tmp) == true)
+zt.song.bpm = 99
+check("load ok", zt.load(tmp) == true)
+eq("load restores bpm", zt.song.bpm, 171)
+os.remove(tmp)
+
+-- ── summary ──────────────────────────────────────────────────────────
+print(string.format("=== %d/%d checks passed, %d failed ===", total - fails, total, fails))
+SELFTEST_FAILURES = fails
+return fails

--- a/doc/lua-scripting.md
+++ b/doc/lua-scripting.md
@@ -56,6 +56,17 @@ dump = rprint       -- alias
 `rprint(zt)` lists the entire API and `rprint(_G)` walks the globals
 (depth-limited so it won't hang).
 
+## Self-test (every feature, runnable)
+
+`lua/selftest.lua` exercises the whole `zt.*` API with PASS/FAIL checks. Run it:
+
+```sh
+zt --headless --lua-test     # CI-friendly: prints PASS/FAIL, exits 0 (ok) / 1 (fail)
+```
+or in the console (Ctrl+Alt+L): `dofile("lua/selftest.lua")`. It also runs as the
+`lua_api` test under `ctest`. The script is readable — it's the quickest way to
+see exactly what every call does and returns.
+
 ## Object API (Renoise-style, dot properties)
 
 In addition to the flat `zt.get_*/set_*` functions, there are proxy objects

--- a/src/lua_engine.cpp
+++ b/src/lua_engine.cpp
@@ -1083,7 +1083,12 @@ static int l_save(lua_State *L)   // zt.save("song.zt" [, compressed=true]) -> o
     const char *path = luaL_checkstring(L, 1);
     int compressed = lua_isnoneornil(L, 2) ? 1 : (lua_toboolean(L, 2) ? 1 : 0);
     if (!song) { lua_pushboolean(L, 0); return 1; }
-    int rc = song->save((char *)path, compressed);
+    // zt_module::save() writes to this->filename and ignores its fn arg, so
+    // point the song's filename at the requested path first (this is also
+    // the "save as" behaviour: the song adopts the new filename).
+    strncpy((char *)song->filename, path, ZTM_FILENAME_MAXLEN - 1);
+    song->filename[ZTM_FILENAME_MAXLEN - 1] = '\0';
+    int rc = song->save(NULL, compressed);
     lua_pushboolean(L, rc >= 0);
     return 1;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3870,6 +3870,10 @@ struct ZtCliArgs {
     // --script to drive the running app to a chosen state and exit.
     bool        headless        = false;
     const char *script_path     = NULL;
+    // --lua-test runs the bundled lua/selftest.lua against a scratch song
+    // and exits 0 (all checks passed) / 1 (failures). Pairs with --headless
+    // for CI. Output (PASS/FAIL per check) goes to stdout.
+    bool        lua_test        = false;
 };
 
 static void zt_print_cli_help(const char *progname) {
@@ -3905,13 +3909,18 @@ static void zt_print_cli_help(const char *progname) {
         "                              'shot <png-path>', 'quit'. See\n"
         "                              docs/headless-script.md for the full\n"
         "                              command set.\n"
+        "      --lua-test              Run the bundled Lua API self-test\n"
+        "                              (lua/selftest.lua) against a scratch\n"
+        "                              song and exit 0 (all checks passed) /\n"
+        "                              1 (failures). Pair with --headless.\n"
         "\n"
         "Examples:\n"
         "  %s mysong.zt\n"
         "  %s --midi-in \"IAC Driver Bus 1\"\n"
         "  %s --midi-clock 0 mysong.zt\n"
-        "  %s --headless --script tests/scripts/smoke.txt\n",
-        progname, progname, progname, progname, progname);
+        "  %s --headless --script tests/scripts/smoke.txt\n"
+        "  %s --headless --lua-test\n",
+        progname, progname, progname, progname, progname, progname);
 }
 
 // Strip leading '-' or '--' so we accept "-midi-in" or "--midi-in" --
@@ -3991,6 +4000,7 @@ static int zt_parse_cli(int argc, char *argv[], ZtCliArgs *out) {
         if (r > 0) { out->midi_clock_port = value; continue; }
 
         if (zt_cli_match_flag(a, "headless")) { out->headless = true; continue; }
+        if (zt_cli_match_flag(a, "lua-test")) { out->lua_test = true; continue; }
         r = zt_cli_match_flag_with_value(argc, argv, &i, "script", &value);
         if (r < 0) return -1;
         if (r > 0) { out->script_path = value; continue; }
@@ -4003,6 +4013,36 @@ static int zt_parse_cli(int argc, char *argv[], ZtCliArgs *out) {
         if (!out->song_filename) out->song_filename = a;
     }
     return 0;
+}
+
+// Run the bundled Lua self-test against the (scratch) song and return a
+// process exit code: 0 if every check passed, 1 otherwise. The test's
+// print() output is captured in the engine scrollback; we dump it to
+// stdout so CI / the user can read the PASS/FAIL lines.
+static int zt_run_lua_selftest(void) {
+    if (!g_lua.init()) {                 // already inited in initSDL(); no-op then
+        fprintf(stderr, "lua-test: engine init failed\n");
+        return 1;
+    }
+    lua_State *L = g_lua.L;
+    g_lua.line_count = 0;                // drop the startup banner so only
+    g_lua.scroll_off = 0;                // the test output is dumped
+    int rc = luaL_dofile(L, "lua/selftest.lua");
+    int start = g_lua.line_count - LUA_CONSOLE_MAX_LINES;
+    if (start < 0) start = 0;
+    for (int i = start; i < g_lua.line_count; ++i)
+        fprintf(stdout, "%s\n", g_lua.lines[i % LUA_CONSOLE_MAX_LINES]);
+    if (rc != LUA_OK) {
+        const char *err = lua_tostring(L, -1);
+        fprintf(stderr, "lua-test: error: %s\n", err ? err : "(nil)");
+        return 1;
+    }
+    lua_getglobal(L, "SELFTEST_FAILURES");
+    int fails = (int)lua_tointeger(L, -1);
+    lua_pop(L, 1);
+    fprintf(stdout, "lua-test: %s (%d failure%s)\n",
+            fails == 0 ? "PASS" : "FAIL", fails, fails == 1 ? "" : "s");
+    return fails == 0 ? 0 : 1;
 }
 
 // Resolve a MIDI in port spec to an index in MidiIn->midiInDev[].
@@ -4128,6 +4168,13 @@ int main(int argc, char *argv[])
 
   if (!initSDL()) {
     return -1;
+  }
+
+  // --lua-test: initSDL() has created the song + Lua engine, which is all
+  // the self-test needs. Run it now (before GFX / skin / window setup, so a
+  // headless box with no display still works) and exit with its pass/fail.
+  if (cli_args.lua_test) {
+    return zt_run_lua_selftest();
   }
 
   // CLI MIDI handling. Runs after initSDL because that's where MidiIn

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -146,3 +146,14 @@ target_include_directories(test_keyjazz_map PRIVATE
 )
 target_compile_features(test_keyjazz_map PRIVATE cxx_std_17)
 add_test(NAME keyjazz_map COMMAND test_keyjazz_map)
+
+# Full Lua API self-test. Unlike the SDL-free unit tests above, this drives
+# the REAL zt binary headless (--lua-test) against a scratch song, running
+# lua/selftest.lua and asserting exit 0 (every check passed). Covers the
+# entire zt.* Lua surface end-to-end.
+if(TARGET zt)
+    add_test(NAME lua_api COMMAND $<TARGET_FILE:zt> --headless --lua-test)
+    set_tests_properties(lua_api PROPERTIES
+        WORKING_DIRECTORY "$<TARGET_FILE_DIR:zt>"
+        LABELS "lua")
+endif()


### PR DESCRIPTION
## Summary

A complete, **runnable** test of the zTracker Lua API — so the whole `zt.*` surface is verifiable by you, me, and CI. Requested: "write full tests for all zTracker lua features so i can see them and you can see them working."

### `lua/selftest.lua` (readable, bundled)
87 PASS/FAIL checks covering **everything**:
- constants, `note_name`/`note_value` (+ roundtrip, off/cut)
- the flat `zt.get_*/set_*` functions
- `zt.song` (incl. `message`), `zt.instrument` (all fields), `zt.pattern`, `zt.track`, `zt.cell` (all fields + **per-field merge** + `clear`), `zt.orders`, `zt.transport` (play/stop), `zt.midimacro`, `zt.arpeggio`, and a **file save/load roundtrip**.

### `--lua-test` runner
Runs the bundled selftest against the scratch song `initSDL()` creates, prints PASS/FAIL to stdout, exits `0` (all passed) / `1` (failures). Runs before GFX/skin/window so it works **headless**:
```sh
zt --headless --lua-test
```
Also runnable in the console: `dofile("lua/selftest.lua")`.

### CI / ctest
New `lua_api` ctest drives the real `zt` binary headless end-to-end. **Full suite now 13/13.**

## The self-test earned its keep immediately
It caught a real bug: **`zt.save(path)` wrote to the song's current filename, not the path** — `zt_module::save()` ignores its `fn` arg and opens `this->filename`. Fixed `l_save` to set `song->filename` first (also the natural "save as" behaviour). **87/87 now pass.**

## Sample output
```
PASS  cell merge keeps note  (got 60, want 60)
PASS  orders.count  (got 2, want 2)
PASS  transport playing after play
PASS  arpeggio:pitch nil empties
PASS  load restores bpm  (got 171, want 171)
=== 87/87 checks passed, 0 failed ===
lua-test: PASS (0 failures)
```

## Test plan
- [x] `zt --headless --lua-test` → 87/87, exit 0 (macOS).
- [x] `ctest` → 13/13 (the new `lua_api` test included).
- [x] CMake bundles `assets/lua` next to the binary / in `Resources` (like `ccizer`/`syx`).
- [x] `doc/lua-scripting.md` documents how to run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
