### PR TITLE
Lua: notifiers (zt.on/off/fire) for play/stop/row/idle events

### DIFF
--- a/assets/lua/selftest.lua
+++ b/assets/lua/selftest.lua
@@ -146,6 +146,18 @@ a:set_pitch(2, nil) ;              check("arpeggio:pitch nil empties", a:pitch(2
 a:set_cc(0, 74) ;                  eq("arpeggio:cc", a:cc(0), 74)
 a:set_ccval(0, 0, 100) ;           eq("arpeggio:ccval", a:ccval(0, 0), 100)
 
+-- ── notifiers (zt.on / zt.off / zt.fire) ─────────────────────────────
+local fired = 0
+zt.on("selftest_evt", function(x) fired = fired + (x or 1) end)
+zt.fire("selftest_evt", 5)
+eq("notifier fires with arg", fired, 5)
+zt.on("selftest_evt", function() fired = fired + 100 end)  -- second cb
+zt.fire("selftest_evt", 1)
+eq("notifier multiple callbacks", fired, 106)   -- +1 (first) +100 (second)
+zt.off("selftest_evt")
+zt.fire("selftest_evt", 5)
+eq("notifier off stops firing", fired, 106)     -- unchanged
+
 -- ── file save / load roundtrip ───────────────────────────────────────
 local tmp = (os.getenv("TMPDIR") or os.getenv("TEMP") or "/tmp") .. "/zt_selftest.zt"
 zt.song.bpm = 171

--- a/doc/lua-scripting.md
+++ b/doc/lua-scripting.md
@@ -56,6 +56,25 @@ dump = rprint       -- alias
 `rprint(zt)` lists the entire API and `rprint(_G)` walks the globals
 (depth-limited so it won't hang).
 
+## Notifiers (react to events)
+
+Register Lua callbacks that fire from the main loop:
+
+```lua
+zt.on("row", function(r) zt.status("row " .. r) end)  -- playhead advanced
+zt.on("play",  function() print("started") end)
+zt.on("stop",  function() print("stopped") end)
+zt.on("idle",  function() --[[ every frame; keep it cheap ]] end)
+zt.off("row")                       -- remove all callbacks for an event
+zt.fire("my_event", 42)             -- fire a custom (or built-in) event yourself
+```
+
+Built-in events: **`idle`** (every frame), **`play`** / **`stop`** (transport
+transitions), **`row`** (arg = current playing row). Multiple callbacks per
+event are allowed. A callback that errors prints to the console and the others
+still run; a callback that loops forever stalls the app (same trade-off as any
+Lua call here).
+
 ## Self-test (every feature, runnable)
 
 `lua/selftest.lua` exercises the whole `zt.*` API with PASS/FAIL checks. Run it:

--- a/src/lua_engine.cpp
+++ b/src/lua_engine.cpp
@@ -252,6 +252,45 @@ static int l_zt_print_fn(lua_State *L)
     return l_zt_print(L);
 }
 
+// --- notifiers: zt.on(event, fn) / zt.off(event) / zt.fire(event [,arg]) ----
+// Built-in events fired from the main loop: "idle" (every frame), "play",
+// "stop", "row" (arg = current row). Custom event names work too via fire().
+static int l_on(lua_State *L)
+{
+    const char *ev = luaL_checkstring(L, 1);
+    luaL_checktype(L, 2, LUA_TFUNCTION);
+    lua_getfield(L, LUA_REGISTRYINDEX, "zt_notifiers");   // t
+    lua_getfield(L, -1, ev);                              // t[ev]
+    if (!lua_istable(L, -1)) {
+        lua_pop(L, 1);
+        lua_newtable(L);                                  // new list
+        lua_pushvalue(L, -1);                             // dup
+        lua_setfield(L, -3, ev);                          // t[ev] = list
+    }
+    int n = (int)lua_rawlen(L, -1);
+    lua_pushvalue(L, 2);                                  // the function
+    lua_rawseti(L, -2, n + 1);                            // list[n+1] = fn
+    lua_pop(L, 2);                                        // list, t
+    return 0;
+}
+static int l_off(lua_State *L)   // clear all callbacks for an event
+{
+    const char *ev = luaL_checkstring(L, 1);
+    lua_getfield(L, LUA_REGISTRYINDEX, "zt_notifiers");
+    lua_pushnil(L);
+    lua_setfield(L, -2, ev);
+    lua_pop(L, 1);
+    return 0;
+}
+static int l_fire(lua_State *L)  // zt.fire(event [, arg])
+{
+    const char *ev = luaL_checkstring(L, 1);
+    bool has_arg = !lua_isnoneornil(L, 2);
+    long arg = has_arg ? (long)luaL_checkinteger(L, 2) : 0;
+    g_lua.fire(ev, arg, has_arg);
+    return 0;
+}
+
 // ===========================================================================
 // Object layer — Renoise-style proxies with dot-property access.
 //   zt.song            properties: bpm, tpb, name, cur_pattern, cur_track,
@@ -1124,6 +1163,33 @@ void ZtLuaEngine::print_line(const char *text)
     // (scroll_off stays; caller should reset it on Enter)
 }
 
+void ZtLuaEngine::fire(const char *event, long arg, bool has_arg)
+{
+    if (!L || !event) return;
+    lua_getfield(L, LUA_REGISTRYINDEX, "zt_notifiers");   // notifiers table
+    if (!lua_istable(L, -1)) { lua_pop(L, 1); return; }
+    lua_getfield(L, -1, event);                           // notifiers[event]
+    if (!lua_istable(L, -1)) { lua_pop(L, 2); return; }
+    int n = (int)lua_rawlen(L, -1);
+    for (int i = 1; i <= n; i++) {
+        lua_rawgeti(L, -1, i);                            // fn
+        if (lua_isfunction(L, -1)) {
+            int nargs = 0;
+            if (has_arg) { lua_pushinteger(L, (lua_Integer)arg); nargs = 1; }
+            if (lua_pcall(L, nargs, 0, 0) != LUA_OK) {
+                const char *err = lua_tostring(L, -1);
+                char msg[LUA_CONSOLE_LINE_LEN];
+                snprintf(msg, sizeof(msg), "[notifier:%s] %s", event, err ? err : "?");
+                print_line(msg);
+                lua_pop(L, 1);                            // pop error
+            }
+        } else {
+            lua_pop(L, 1);                                // not a function
+        }
+    }
+    lua_pop(L, 2);                                        // list, table
+}
+
 bool ZtLuaEngine::init()
 {
     if (L) return true;  // already init'd
@@ -1142,6 +1208,11 @@ bool ZtLuaEngine::init()
     lua_setglobal(L, "print");
 
     registerBindings();
+
+    // Notifier registry: a table  event-name -> { fn1, fn2, ... }  kept in
+    // the Lua registry so zt.on()/zt.off()/fire() can find it.
+    lua_newtable(L);
+    lua_setfield(L, LUA_REGISTRYINDEX, "zt_notifiers");
 
     // Prelude: Renoise-style introspection helpers (rprint / oprint / dump)
     // plus a help() that documents the zt.* API. Kept here as a Lua string so
@@ -1230,6 +1301,7 @@ bool ZtLuaEngine::init()
         "      print('  ' .. objdocs.midimacro)\n"
         "      print('  ' .. objdocs.arpeggio)\n"
         "      print('Helpers: zt.note_name(60)->\"C-5\", zt.note_value(\"C-5\")->60 ; zt.load(path), zt.save(path)')\n"
+        "      print('Notifiers: zt.on(event,fn) / zt.off(event) / zt.fire(event[,arg]).  events: idle, play, stop, row')\n"
         "      print('Consts: zt.MAX_PATTERNS/TRACKS/INSTRUMENTS/ORDERS/MIDIMACROS/ARPEGGIOS, NOTE_*, MIDDLE_C, BREAK, SKIP, MACRO_END/PARAM')\n"
         "      print('  e.g.  zt.song.bpm=140   zt.cell(0,0).note = zt.note_value(\"C-5\")   zt.orders[0]=2   zt.transport:play()')\n"
         "      print('Introspect: rprint(zt) dumps all, oprint(t) lists one level, help(\"name\") for one.')\n"
@@ -1442,6 +1514,9 @@ void ZtLuaEngine::registerBindings()
     lua_pushcfunction(L, l_note_value);   lua_setfield(L, -2, "note_value");
     lua_pushcfunction(L, l_load);         lua_setfield(L, -2, "load");
     lua_pushcfunction(L, l_save);         lua_setfield(L, -2, "save");
+    lua_pushcfunction(L, l_on);           lua_setfield(L, -2, "on");
+    lua_pushcfunction(L, l_off);          lua_setfield(L, -2, "off");
+    lua_pushcfunction(L, l_fire);         lua_setfield(L, -2, "fire");
 
     // Singletons: zt.song, zt.transport, zt.orders.
     lua_newuserdatauv(L, 1, 0);

--- a/src/lua_engine.h
+++ b/src/lua_engine.h
@@ -48,6 +48,13 @@ public:
     // Execute a string of Lua code; output/errors go to scrollback
     void execute(const char *code);
 
+    // Fire any Lua callbacks registered for `event` (via zt.on). `arg` is
+    // passed to each callback when has_arg is true (e.g. the row number for
+    // the "row" event). Safe to call when nothing is registered. Called
+    // from the main loop for "idle"/"play"/"stop"/"row"; also reachable
+    // from Lua via zt.fire() for custom events / testing.
+    void fire(const char *event, long arg = 0, bool has_arg = false);
+
     // Append a line of text to the scrollback
     void print_line(const char *text);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4239,6 +4239,28 @@ int main(int argc, char *argv[])
 #endif
 
     while (1) {
+      // Lua notifiers: fire play/stop on transport transitions, row on the
+      // playhead advancing, and idle every iteration. Cheap when nothing is
+      // registered (fire() bails immediately). A heavy/looping callback will
+      // stall the loop -- same trade-off as any other Lua call here.
+      {
+        static int s_prev_playing = 0;
+        static int s_prev_row     = -1;
+        if (ztPlayer) {
+          int playing = ztPlayer->playing ? 1 : 0;
+          if (playing != s_prev_playing) {
+            g_lua.fire(playing ? "play" : "stop");
+            s_prev_playing = playing;
+            if (!playing) s_prev_row = -1;
+          }
+          if (playing && ztPlayer->playing_cur_row != s_prev_row) {
+            s_prev_row = ztPlayer->playing_cur_row;
+            g_lua.fire("row", s_prev_row, true);
+          }
+        }
+        g_lua.fire("idle");
+      }
+
       CUI_Page *focus_page = NULL;
       if (!window_stack.isempty()) {
         focus_page = window_stack.top();


### PR DESCRIPTION
## Summary

Adds the one real remaining Lua capability gap vs Renoise: **reacting to events** instead of being one-shot.

```lua
zt.on("row",  function(r) zt.status("row " .. r) end)   -- playhead advanced
zt.on("play", function() print("started") end)
zt.on("stop", function() print("stopped") end)
zt.on("idle", function() --[[ every frame; keep it cheap ]] end)
zt.off("row")                       -- remove all callbacks for an event
zt.fire("my_event", 42)             -- fire a custom (or built-in) event yourself
```

Built-in events fired from the main loop: **`idle`** (every frame), **`play`**/**`stop`** (transport transitions), **`row`** (arg = current playing row). Multiple callbacks per event allowed.

## How it works

- The callback lists live in the Lua registry (`zt_notifiers[event] = {fn,...}`).
- `ZtLuaEngine::fire()` walks the list and `pcall()`s each — an erroring callback prints to the console and the rest still run; `fire()` bails immediately when nothing is registered (cheap to call every frame).
- `main.cpp` fires `play`/`stop` on `ztPlayer->playing` transitions, `row` on `playing_cur_row` advancing, and `idle` each loop iteration.
- A callback that loops forever stalls the app — the same trade-off as any Lua call here (consistent with the engine's "Lua blocks the main thread" design).

## Test plan

- [x] `selftest.lua` gains 3 notifier checks (fire-with-arg, multiple callbacks, off-stops-firing) → **90/90**, `ctest` green.
- [x] In-app: registered a `play` callback, started playback, no errors; dispatch path verified via the self-test's `zt.fire`.
- [x] `doc/lua-scripting.md` documents the events + semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
