### PR TITLE
ci: run ctest (incl. Lua API self-test) on the macOS jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,6 +210,9 @@ jobs:
       - name: Build
         run: cmake --build build --config Release -j
 
+      - name: Run unit tests (incl. Lua API self-test, headless)
+        run: ctest --test-dir build --output-on-failure
+
       - name: Stage release
         run: |
           mkdir -p dist/ztrackerprime-macos-arm64
@@ -293,6 +296,9 @@ jobs:
 
       - name: Build
         run: cmake --build build --config Release -j
+
+      - name: Run unit tests (incl. Lua API self-test, headless)
+        run: ctest --test-dir build --output-on-failure
 
       - name: Stage release
         run: |


### PR DESCRIPTION
## Summary

The unit tests + the new `lua_api` self-test only ran on the Linux CI job. This adds a `Run unit tests` ctest step to both macOS jobs (arm64 + x86_64), so the full suite -- including the headless `zt --lua-test` end-to-end run -- is exercised on macOS too. Windows stays build-only for now (the headless SDL self-test path there is unverified).

## Test plan

- [x] YAML validates.
- [x] ctest (incl. lua_api) passes locally on macOS -- the same invocation the new step runs.
- [x] Linux job already ran ctest; unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)