### PR TITLE
Lua: midimacro :send(), instrument CC envelopes; README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,25 @@ The file picker. Shows `.zt` and `.mid` files side by side, full-height list, do
 
 ### Lua Console — `Ctrl+Alt+L`
 
-Interactive Lua REPL with tab completion and a full API listing on open. Lets you script zTracker's internals — pattern operations, batch MIDI ops, automation around the file format. Output scrolls; the prompt accepts multi-line statements.
+Interactive Lua 5.4 REPL with a complete, Renoise/Paketti-style scripting API for zTracker's internals. A few lines of Lua can read, generate, play, and save a whole song. Output wraps; the prompt does input history (Up/Down) and **Tab completion** that advances by common prefix then cycles through candidates.
+
+**Introspection.** `help()` documents the whole API (`help("name")` for one); `rprint(t)` / `oprint(t)` dump tables Renoise-style. A bare function result is flagged with a "add `()` to call it" hint.
+
+**Object API (dot properties + colon methods).**
+
+- `zt.song` — `bpm`, `tpb`, `name`, `message`, `cur_pattern/track/row/instrument`
+- `zt.instrument(i)` — `name`, `channel`, `device`, `transpose`, `bank`, `volume`, `global_volume`, `default_length`, `flags`, `ccizer_bank`, and CC/pitchbend **envelopes** via `:envelope(n)` (cc/kind/nodes/loop/sustain)
+- `zt.pattern(p)` — `length`, `:note`/`:set_note`, `:track(t)`, `:cell(t,r)`
+- `zt.track(t)` — `index`, `muted`, `:note`/`:set_note`, `:cell(r)`
+- `zt.cell(t,r)` — every field: `note`, `instrument`, `volume`, `length`, `effect`, `effect_data`, `name`, `:clear()` (per-field merge)
+- `zt.orders` — the song sequence as an array (`zt.orders[i]`, `.count`, `zt.BREAK`/`zt.SKIP`)
+- `zt.transport` — `playing`, `:play()`/`:stop()`/`:play_pattern()`/`:panic()`
+- `zt.midimacro(i)` / `zt.arpeggio(i)` — the F4 / Shift+F4 slots, fully editable; `midimacro:send(device[,param])` fires one out of pattern
+- `zt.note_name`/`note_value` helpers, constants (`MAX_*`, `NOTE_*`, `MIDDLE_C`, …)
+
+**Notifiers.** `zt.on(event, fn)` / `zt.off` / `zt.fire` react to `idle` / `play` / `stop` / `row` events from the main loop.
+
+**Self-test.** `lua/selftest.lua` exercises every call (100+ checks); run it with `zt --headless --lua-test` (exit 0/1) or `dofile("lua/selftest.lua")` — it's also the `lua_api` CI test. See [`doc/lua-scripting.md`](doc/lua-scripting.md) for the full reference.
 
 ![Lua Console](docs/screenshots/17-lua-console.png)
 
@@ -255,7 +273,7 @@ New pages and editors:
 
 - **Keybindings Editor (Ctrl+Alt+K)** — view and rebind every keyboard shortcut in the app. Bindings are saved to `zt.conf` with Ctrl+S.
 
-- **Lua Console (Ctrl+Alt+L)** — interactive Lua REPL with tab completion and a full API listing on open. Lets you script zTracker's internals.
+- **Lua Console (Ctrl+Alt+L)** — interactive Lua 5.4 REPL with a complete Renoise/Paketti-style scripting API: object access to the song, instruments (+ CC envelopes), patterns, tracks, cells, the order list, transport, MIDI macros and arpeggios; `help()`/`rprint`/`oprint` introspection; Tab completion that cycles; `zt.on()` event notifiers; and a `lua/selftest.lua` (100+ checks, runs in CI via `--lua-test`). Full reference in `doc/lua-scripting.md`.
 
 - **Palette Editor (Shift+Ctrl+F12)** — live color editing of the current skin with seven presets. Changes apply immediately and save with the skin.
 

--- a/assets/lua/selftest.lua
+++ b/assets/lua/selftest.lua
@@ -146,6 +146,23 @@ a:set_pitch(2, nil) ;              check("arpeggio:pitch nil empties", a:pitch(2
 a:set_cc(0, 74) ;                  eq("arpeggio:cc", a:cc(0), 74)
 a:set_ccval(0, 0, 100) ;           eq("arpeggio:ccval", a:ccval(0, 0), 100)
 
+-- ── midimacro :send + instrument CC envelopes ───────────────────────
+check("midimacro:send callable", type(zt.midimacro(0).send) == "function")
+eq("MAX_ENVELOPES", zt.MAX_ENVELOPES, 32)
+local env = zt.instrument(1):envelope(0)
+env.cc = 74 ;          eq("envelope.cc", env.cc, 74)
+env.kind = 0 ;         eq("envelope.kind", env.kind, 0)
+env.enabled = true ;   check("envelope.enabled", env.enabled == true)
+env.num_nodes = 2 ;    eq("envelope.num_nodes", env.num_nodes, 2)
+env.speed = 3 ;        eq("envelope.speed", env.speed, 3)
+env.loop_start = 0 ; env.loop_end = 1 ; eq("envelope.loop_end", env.loop_end, 1)
+env:set_node(0, 0, 64) ; env:set_node(1, 48, 127)
+local t0, v0 = env:node(0)
+eq("envelope:node tick", t0, 0) ; eq("envelope:node value", v0, 64)
+local t1, v1 = env:node(1)
+eq("envelope:node tick 1", t1, 48) ; eq("envelope:node value 1", v1, 127)
+eq("envelope.index", env.index, 0)
+
 -- ── notifiers (zt.on / zt.off / zt.fire) ─────────────────────────────
 local fired = 0
 zt.on("selftest_evt", function(x) fired = fired + (x or 1) end)

--- a/doc/lua-scripting.md
+++ b/doc/lua-scripting.md
@@ -156,6 +156,15 @@ ins.ccizer_bank = "microfreak.txt"
 local m = zt.midimacro(0)
 m.name = "Bank LSB"              ; print(m.empty, m.syx)
 m:set(0, 0xB0) ; m:set(1, 0x20) ; m:set(2, zt.MACRO_PARAM) ; m:set(3, zt.MACRO_END)
+m:send(0, 5)                    -- :send(device [,param]) fires it NOW (out of pattern)
+
+-- instrument CC/pitchbend envelopes (instrument:envelope(0..zt.MAX_ENVELOPES-1))
+local env = zt.instrument(0):envelope(0)
+env.cc, env.kind, env.enabled = 74, 0, true   -- kind 0=CC, 1=Pitchbend, 2=ChanPress
+env.num_nodes, env.speed = 2, 3
+env:set_node(0, 0, 64) ; env:set_node(1, 48, 127)   -- :set_node(i, tick, value)
+local tick, value = env:node(0)                     -- :node(i) -> tick, value
+-- also: loop_start/end, sustain_start/end, flags, index
 
 -- arpeggios (the Shift+F4 slots)
 local a = zt.arpeggio(0)

--- a/src/lua_engine.cpp
+++ b/src/lua_engine.cpp
@@ -398,6 +398,11 @@ static instrument *inst_at(int i)
     return song->instruments[i];
 }
 
+// instrument:envelope(n) -> zt.envelope object. Defined further down (it
+// needs the envelope metatable); forward-declared so inst_index can hand
+// out the method.
+static int inst_envelope_m(lua_State *L);
+
 static int l_instrument(lua_State *L)
 {
     int i = (int)luaL_optinteger(L, 1, cur_inst);
@@ -428,6 +433,7 @@ static int inst_index(lua_State *L)
     if (!strcmp(k, "default_length")){ lua_pushinteger(L, ins->default_length); return 1; }
     if (!strcmp(k, "flags"))         { lua_pushinteger(L, ins->flags); return 1; }
     if (!strcmp(k, "ccizer_bank"))   { lua_pushstring(L, ins->ccizer_bank); return 1; }
+    if (!strcmp(k, "envelope"))      { lua_pushcfunction(L, inst_envelope_m); return 1; }
     return luaL_error(L, "instrument has no field '%s' (try help('instrument'))", k);
 }
 
@@ -922,6 +928,39 @@ static int mm_set(lua_State *L)   // mm:set(step, value)
     if (m && s >= 0 && s < ZTM_MIDIMACRO_MAXLEN) { m->data[s] = (unsigned short)v; need_refresh++; }
     return 0;
 }
+// mm:send(device [, param]) -- fire the macro out NOW (not via a pattern).
+// .syx macros send their cached file bytes; regular macros pack data[] into
+// MIDI messages (PARAM tokens -> param), exactly like the Z-effect.
+static int mm_send(lua_State *L)
+{
+    int i   = *(int *)luaL_checkudata(L, 1, ZT_MT_MIDIMACRO);
+    int dev = (int)luaL_checkinteger(L, 2);
+    int param = (int)luaL_optinteger(L, 3, 0);
+    midimacro *m = macro_at(i);
+    if (!m || !MidiOut) return 0;
+    if (name_is_syx(m->name)) {
+        if (m->syx_cache_bytes && m->syx_cache_len > 0)
+            MidiOut->sendSysEx((unsigned int)dev, m->syx_cache_bytes, m->syx_cache_len);
+        return 0;
+    }
+    unsigned int packed = 0;
+    int bc = 0;
+    for (int k = 0; k < ZTM_MIDIMACRO_MAXLEN; ++k) {
+        unsigned short v = m->data[k];
+        if (v == ZTM_MIDIMAC_END) break;
+        unsigned char b = (v == ZTM_MIDIMAC_PARAM1) ? (unsigned char)param : (unsigned char)v;
+        if (b & 0x80) {                       // status byte -> flush + restart
+            if (bc > 0) MidiOut->send((unsigned int)dev, packed);
+            packed = b; bc = 1;
+        } else {
+            if (bc == 0) continue;            // data with no running status -> skip
+            packed |= ((unsigned int)b) << (bc * 8); bc++;
+        }
+        if (bc == 3) { MidiOut->send((unsigned int)dev, packed); packed = 0; bc = 0; }
+    }
+    if (bc > 0) MidiOut->send((unsigned int)dev, packed);
+    return 0;
+}
 static int mm_index(lua_State *L)
 {
     int i = *(int *)luaL_checkudata(L, 1, ZT_MT_MIDIMACRO);
@@ -934,6 +973,7 @@ static int mm_index(lua_State *L)
     if (!strcmp(k, "syx"))   { lua_pushboolean(L, name_is_syx(m->name)); return 1; }
     if (!strcmp(k, "get"))   { lua_pushcfunction(L, mm_get); return 1; }
     if (!strcmp(k, "set"))   { lua_pushcfunction(L, mm_set); return 1; }
+    if (!strcmp(k, "send"))  { lua_pushcfunction(L, mm_send); return 1; }
     return luaL_error(L, "zt.midimacro has no field '%s' (try help('midimacro'))", k);
 }
 static int mm_newindex(lua_State *L)
@@ -1104,6 +1144,109 @@ static int l_arpeggio(lua_State *L)
     int *p = (int *)lua_newuserdatauv(L, sizeof(int), 0);
     *p = i;
     luaL_setmetatable(L, ZT_MT_ARPEGGIO);
+    return 1;
+}
+
+// ===========================================================================
+// zt.envelope — a per-instrument CC/pitchbend/chanpress envelope, reached
+// via instrument:envelope(n) (n = 0..MAX_ENVELOPES-1). Properties (rw):
+// cc, kind, flags, enabled, num_nodes, loop_start/end, sustain_start/end,
+// speed, index. Methods: :node(i) -> tick,value ; :set_node(i,tick,value).
+// ===========================================================================
+#define ZT_MT_ENVELOPE "zt.envelope"
+struct EnvRef { int inst; int env; };
+
+static inst_envelope *env_at(EnvRef *e)
+{
+    instrument *ins = inst_at(e->inst);
+    if (!ins || e->env < 0 || e->env >= ZTM_INST_MAX_ENVELOPES) return nullptr;
+    return &ins->envelopes[e->env];
+}
+static int env_node(lua_State *L)        // :node(i) -> tick, value
+{
+    EnvRef *e = (EnvRef *)luaL_checkudata(L, 1, ZT_MT_ENVELOPE);
+    int n = (int)luaL_checkinteger(L, 2);
+    inst_envelope *ev = env_at(e);
+    if (!ev || n < 0 || n >= ZTM_INST_ENV_MAX_NODES) { lua_pushnil(L); return 1; }
+    lua_pushinteger(L, ev->tick[n]);
+    lua_pushinteger(L, ev->value[n]);
+    return 2;
+}
+static int env_set_node(lua_State *L)    // :set_node(i, tick, value)
+{
+    EnvRef *e = (EnvRef *)luaL_checkudata(L, 1, ZT_MT_ENVELOPE);
+    int n    = (int)luaL_checkinteger(L, 2);
+    int tick = (int)luaL_checkinteger(L, 3);
+    int val  = (int)luaL_checkinteger(L, 4);
+    inst_envelope *ev = env_at(e);
+    if (ev && n >= 0 && n < ZTM_INST_ENV_MAX_NODES) {
+        ev->tick[n] = (unsigned short)tick;
+        ev->value[n] = (unsigned char)val;
+        need_refresh++;
+    }
+    return 0;
+}
+static int env_index(lua_State *L)
+{
+    EnvRef *e = (EnvRef *)luaL_checkudata(L, 1, ZT_MT_ENVELOPE);
+    const char *k = luaL_checkstring(L, 2);
+    if (!strcmp(k, "index")) { lua_pushinteger(L, e->env); return 1; }
+    inst_envelope *ev = env_at(e);
+    if (!ev) return luaL_error(L, "envelope %d not available", e->env);
+    if (!strcmp(k, "cc"))            { lua_pushinteger(L, ev->cc); return 1; }
+    if (!strcmp(k, "kind"))          { lua_pushinteger(L, ev->kind); return 1; }
+    if (!strcmp(k, "flags"))         { lua_pushinteger(L, ev->flags); return 1; }
+    if (!strcmp(k, "enabled"))       { lua_pushboolean(L, (ev->flags & ZTM_INSTENVF_ENABLED) != 0); return 1; }
+    if (!strcmp(k, "num_nodes"))     { lua_pushinteger(L, ev->num_nodes); return 1; }
+    if (!strcmp(k, "loop_start"))    { lua_pushinteger(L, ev->loop_start); return 1; }
+    if (!strcmp(k, "loop_end"))      { lua_pushinteger(L, ev->loop_end); return 1; }
+    if (!strcmp(k, "sustain_start")) { lua_pushinteger(L, ev->sustain_start); return 1; }
+    if (!strcmp(k, "sustain_end"))   { lua_pushinteger(L, ev->sustain_end); return 1; }
+    if (!strcmp(k, "speed"))         { lua_pushinteger(L, ev->speed); return 1; }
+    if (!strcmp(k, "node"))          { lua_pushcfunction(L, env_node); return 1; }
+    if (!strcmp(k, "set_node"))      { lua_pushcfunction(L, env_set_node); return 1; }
+    return luaL_error(L, "zt.envelope has no field '%s' (try help('envelope'))", k);
+}
+static int env_newindex(lua_State *L)
+{
+    EnvRef *e = (EnvRef *)luaL_checkudata(L, 1, ZT_MT_ENVELOPE);
+    const char *k = luaL_checkstring(L, 2);
+    inst_envelope *ev = env_at(e);
+    if (!ev) return luaL_error(L, "envelope %d not available", e->env);
+    if (!strcmp(k, "enabled")) {
+        if (lua_toboolean(L, 3)) ev->flags |= ZTM_INSTENVF_ENABLED;
+        else                     ev->flags &= ~ZTM_INSTENVF_ENABLED;
+        need_refresh++; return 0;
+    }
+    int v = (int)luaL_checkinteger(L, 3);
+    if (!strcmp(k, "cc"))            { ev->cc            = (unsigned char)v; need_refresh++; return 0; }
+    if (!strcmp(k, "kind"))          { ev->kind          = (unsigned char)v; need_refresh++; return 0; }
+    if (!strcmp(k, "flags"))         { ev->flags         = (unsigned char)v; need_refresh++; return 0; }
+    if (!strcmp(k, "num_nodes"))     { if (v < 0) v = 0; if (v > ZTM_INST_ENV_MAX_NODES) v = ZTM_INST_ENV_MAX_NODES; ev->num_nodes = (unsigned char)v; need_refresh++; return 0; }
+    if (!strcmp(k, "loop_start"))    { ev->loop_start    = (unsigned char)v; need_refresh++; return 0; }
+    if (!strcmp(k, "loop_end"))      { ev->loop_end      = (unsigned char)v; need_refresh++; return 0; }
+    if (!strcmp(k, "sustain_start")) { ev->sustain_start = (unsigned char)v; need_refresh++; return 0; }
+    if (!strcmp(k, "sustain_end"))   { ev->sustain_end   = (unsigned char)v; need_refresh++; return 0; }
+    if (!strcmp(k, "speed"))         { ev->speed         = (unsigned short)(v < 1 ? 1 : v); need_refresh++; return 0; }
+    return luaL_error(L, "zt.envelope has no writable field '%s'", k);
+}
+static int env_tostring(lua_State *L)
+{
+    EnvRef *e = (EnvRef *)luaL_checkudata(L, 1, ZT_MT_ENVELOPE);
+    inst_envelope *ev = env_at(e);
+    lua_pushfstring(L, "zt.envelope(inst %d, %d) cc=%d nodes=%d", e->inst, e->env,
+                    ev ? ev->cc : -1, ev ? ev->num_nodes : 0);
+    return 1;
+}
+static int inst_envelope_m(lua_State *L)   // instrument:envelope(n)
+{
+    int i = *(int *)luaL_checkudata(L, 1, ZT_MT_INSTRUMENT);
+    int n = (int)luaL_checkinteger(L, 2);
+    if (n < 0 || n >= ZTM_INST_MAX_ENVELOPES)
+        return luaL_error(L, "envelope index %d out of range (0..%d)", n, ZTM_INST_MAX_ENVELOPES - 1);
+    EnvRef *e = (EnvRef *)lua_newuserdatauv(L, sizeof(EnvRef), 0);
+    e->inst = i; e->env = n;
+    luaL_setmetatable(L, ZT_MT_ENVELOPE);
     return 1;
 }
 
@@ -1283,8 +1426,9 @@ bool ZtLuaEngine::init()
         "    transport = 'zt.transport  prop: playing;  methods: :play(), :stop(), :play_pattern(), :panic()',\n"
         "    cell = 'zt.cell(track,row[,pat]) / pattern:cell(t,r) / track:cell(r)  props (rw): note, instrument, volume, length, effect, effect_data;  ro: name, empty, pattern, track, row;  method :clear()',\n"
         "    orders = 'zt.orders  array: zt.orders[i] = pattern (rw), .count, #zt.orders;  pattern markers zt.BREAK / zt.SKIP',\n"
-        "    midimacro = 'zt.midimacro(i)  props: name (rw), empty, syx, index;  methods :get(step), :set(step,value)  (tokens zt.MACRO_END / zt.MACRO_PARAM)',\n"
+        "    midimacro = 'zt.midimacro(i)  props: name (rw), empty, syx, index;  methods :get(step), :set(step,value), :send(device[,param])  (tokens zt.MACRO_END / zt.MACRO_PARAM)',\n"
         "    arpeggio = 'zt.arpeggio(i)  props (rw): name, speed, length, repeat_pos, num_cc;  methods :pitch(s)/:set_pitch(s,off), :cc(l)/:set_cc(l,n), :ccval(l,s)/:set_ccval(l,s,v)',\n"
+        "    envelope = 'instrument:envelope(n)  props (rw): cc, kind, flags, enabled, num_nodes, loop_start/end, sustain_start/end, speed;  methods :node(i)->tick,value / :set_node(i,tick,value)',\n"
         "  }\n"
         "  function help(what)\n"
         "    if what == nil then\n"
@@ -1300,6 +1444,7 @@ bool ZtLuaEngine::init()
         "      print('  ' .. objdocs.orders)\n"
         "      print('  ' .. objdocs.midimacro)\n"
         "      print('  ' .. objdocs.arpeggio)\n"
+        "      print('  ' .. objdocs.envelope)\n"
         "      print('Helpers: zt.note_name(60)->\"C-5\", zt.note_value(\"C-5\")->60 ; zt.load(path), zt.save(path)')\n"
         "      print('Notifiers: zt.on(event,fn) / zt.off(event) / zt.fire(event[,arg]).  events: idle, play, stop, row')\n"
         "      print('Consts: zt.MAX_PATTERNS/TRACKS/INSTRUMENTS/ORDERS/MIDIMACROS/ARPEGGIOS, NOTE_*, MIDDLE_C, BREAK, SKIP, MACRO_END/PARAM')\n"
@@ -1502,6 +1647,12 @@ void ZtLuaEngine::registerBindings()
     lua_pushcfunction(L, arp_tostring); lua_setfield(L, -2, "__tostring");
     lua_pop(L, 1);
 
+    luaL_newmetatable(L, ZT_MT_ENVELOPE);
+    lua_pushcfunction(L, env_index);    lua_setfield(L, -2, "__index");
+    lua_pushcfunction(L, env_newindex); lua_setfield(L, -2, "__newindex");
+    lua_pushcfunction(L, env_tostring); lua_setfield(L, -2, "__tostring");
+    lua_pop(L, 1);
+
     // Constructors: zt.instrument(i) / zt.pattern(p) / zt.track(t [,p]) /
     // zt.cell(track,row[,pattern]) + the note-name helpers.
     lua_pushcfunction(L, l_instrument);   lua_setfield(L, -2, "instrument");
@@ -1542,6 +1693,7 @@ void ZtLuaEngine::registerBindings()
     lua_pushinteger(L, 0x101);             lua_setfield(L, -2, "SKIP");
     lua_pushinteger(L, ZTM_MAX_MIDIMACROS);lua_setfield(L, -2, "MAX_MIDIMACROS");
     lua_pushinteger(L, ZTM_MAX_ARPEGGIOS); lua_setfield(L, -2, "MAX_ARPEGGIOS");
+    lua_pushinteger(L, ZTM_INST_MAX_ENVELOPES); lua_setfield(L, -2, "MAX_ENVELOPES");
     lua_pushinteger(L, ZTM_MIDIMAC_END);   lua_setfield(L, -2, "MACRO_END");
     lua_pushinteger(L, ZTM_MIDIMAC_PARAM1);lua_setfield(L, -2, "MACRO_PARAM");
 


### PR DESCRIPTION
## Summary

The last Lua niceties.

- **`zt.midimacro(i):send(device [, param])`** — fire a macro out *now*, outside a pattern. `.syx` macros send their cached file bytes; regular macros pack `data[]` into MIDI messages (PARAM tokens → param) exactly like the Z-effect, via `MidiOut->send`/`sendSysEx`.
- **`instrument:envelope(n)`** → a `zt.envelope` object for the per-instrument CC/pitchbend/chanpress curves (`n = 0..zt.MAX_ENVELOPES-1`). Properties (rw): `cc, kind, flags, enabled, num_nodes, loop_start/end, sustain_start/end, speed, index`. Methods: `:node(i) -> tick, value` and `:set_node(i, tick, value)`. New constant `zt.MAX_ENVELOPES` (32).

## Docs
- `help()` + `doc/lua-scripting.md` document both.
- **`README.md`** — the Lua Console section is rewritten to describe the full scripting API (objects, introspection, notifiers, self-test) instead of the old one-liner.

## Test plan
- [x] `selftest.lua` gains macro:send + envelope checks → **103/103**.
- [x] `ctest` 13/13 (the `lua_api` test runs the full self-test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
