### PR TITLE
Headless harness: synthetic mouse injection + screenshot-mode docs

### DIFF
--- a/.claude/skills/ztrackerprime/SKILL.md
+++ b/.claude/skills/ztrackerprime/SKILL.md
@@ -42,12 +42,49 @@ ctest --output-on-failure      # unit-test harness (Linux CI runs this)
 
 `scripts/zt-screenshot.sh` (macOS) launches zt.app and captures F1/F2/F3/F11/F12/Ctrl+F12 via `screencapture -R` + AppleScript. Output at `/tmp/zt-shots/`. Use it to self-verify layout changes.
 
-### Headless screenshot recipe (verified macOS, no extra deps)
+### Headless framebuffer screenshots
 
-When `zt-screenshot.sh` can't be used (e.g. it relies on the `Quartz`
-Python module, which is **not** present in the system `python3` on a
-stock Mac — `ModuleNotFoundError: No module named 'Quartz'`), this
-dependency-free sequence reliably captures zt's actual rendering:
+zt has a **built-in windowless renderer** that dumps its real framebuffer to a
+PNG — no window, no compositor, no screen-recording permission. This is the
+most reliable way to verify page layout and the only method that works in
+headless / remote / CI contexts.
+
+```sh
+# Script = one command per line. Commands:
+#   key <chord>        e.g. key F11, key shift+F3, key ctrl+s, key space
+#   mousemove <x> <y>  /  mousedown <x> <y>  /  mouseup <x> <y>
+#   click <x> <y>      full left click (DOWN then UP on separate frames)
+#   wait <ms>          let update()/draw() run a few frames
+#   shot <path>        dump the current framebuffer to PNG
+#   quit               tear down cleanly (always end with this)
+# Coords are internal-resolution pixels — the col()/row() space, col(N)=N*8.
+cat > /tmp/f11.script <<'EOF'
+wait 400
+key F11
+wait 400
+shot /tmp/f11.png
+quit
+EOF
+build/Program/zt.app/Contents/MacOS/zt --headless --script /tmp/f11.script
+# then Read /tmp/f11.png to eyeball it
+```
+
+`--headless` sets `SDL_HINT_VIDEO_DRIVER=dummy`, so it runs anywhere (no
+display needed). The binary reads `zt.conf` relative to its location
+(`Contents/Resources/zt.conf` for a `.app`) — edit that file to set up
+preconditions (enabled flags, loaded song, etc.) before driving the UI.
+
+**Mouse injection** (commands above) makes mouse-only controls testable. Many
+F11 checkboxes/sliders are NOT in the keyboard Tab cycle (F11's Tab only toggles
+title↔order-list), so drive them with `click <x> <y>`. Coordinates are
+internal-resolution pixels — the same `col(N)=N*8` / `row(M)=M*8` space the
+widgets use — so a checkbox the page positions at `cb->x`/`cb->y` is clicked at
+`click <cb->x * 8> <cb->y * 8>` (aim a pixel or two inside it). Capture a `shot`
+before and after to diff the resulting state change. Because `click` defers its
+button-up to the next pump, a checkbox latches on DOWN and toggles on UP exactly
+as it does under a real click.
+`click` spans two frames (widgets latch on DOWN, act on UP), so a `wait` after
+it before `shot` is good practice.
 
 ```sh
 # 1. Relaunch a fresh binary (kill the old instance first, or you screenshot stale pixels)
@@ -224,7 +261,7 @@ These rules are non-negotiable. Every one of them was learned the hard way durin
 
 7. **Pages whose own ESC handler matters add their `STATE_*` to the global ESC exclusion list** in `main.cpp::global_keys` (the list with `STATE_HELP / ABOUT / LUA_CONSOLE / SONG_MESSAGE / KEYBINDINGS`). Otherwise the global handler eats ESC first and the page's "ESC cancels capture" hint is a lie. PR #95 was a one-line fix for `STATE_KEYBINDINGS`.
 
-8. **Visual verification before claiming done.** Build green + ctest green ≠ "the page works." Launch the binary, send the F-key, capture the window, drive each user-visible key (arrow, Tab, Space, Enter, Esc, click), diff the screenshots. If you cannot do that step, say so explicitly — don't ship hope.
+8. **Visual verification before claiming done.** Build green + ctest green ≠ "the page works." Use the **headless framebuffer screenshots** (`--headless --script ... shot`, see "Launching the app") when you need to visually verify features. Drive each user-visible control: `key` for F-keys / arrows / Tab / Space / Enter / Esc, and `click <x> <y>` for mouse-only widgets, then `shot` and `Read` the PNG.  If you genuinely cannot do it, say so explicitly — don't ship hope.
 
 The full list-pane construction pattern (with code) lives in [`references/list-pane-idiom.md`](references/list-pane-idiom.md). Read it before adding any new page that has a list, a grid, or both.
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3008,6 +3008,31 @@ void mousedownbuttonhandler(SDL_MouseButtonEvent *e) {
     MousePressY = LastY;
 }
 
+// Synthetic mouse injection for the headless script driver (zt_headless.cpp).
+// Moves the cursor to (x, y) in internal-resolution pixels and, if button !=
+// 0, queues a left-button DOWN (down=1) or UP (down=0) into the same Keys FIFO
+// and bMouseIsDown / MousePress* state the real SDL handlers use -- so widgets
+// can't tell a scripted click from a hardware one. With button == 0 it only
+// moves the cursor (for hover / drag-path setup).
+void zt_inject_mouse(int down, int button, int x, int y) {
+    if (x < 0) x = 0;
+    if (y < 0) y = 0;
+    if (x >= INTERNAL_RESOLUTION_X) x = INTERNAL_RESOLUTION_X - 1;
+    if (y >= INTERNAL_RESOLUTION_Y) y = INTERNAL_RESOLUTION_Y - 1;
+    LastX = x;
+    LastY = y;
+    if (!button) return;
+    if (down) {
+        Keys.insert((unsigned int)((SDL_EVENT_MOUSE_BUTTON_DOWN << 8) | SDL_BUTTON_LEFT));
+        bMouseIsDown = true;
+    } else {
+        Keys.insert((unsigned int)((SDL_EVENT_MOUSE_BUTTON_UP << 8) | SDL_BUTTON_LEFT));
+        bMouseIsDown = false;
+    }
+    MousePressX = LastX;
+    MousePressY = LastY;
+}
+
 void mousewheelhandler(SDL_MouseWheelEvent *e) {
     if (!e) {
         return;

--- a/src/zt_headless.cpp
+++ b/src/zt_headless.cpp
@@ -21,9 +21,12 @@
 
 // Pulled from main.cpp -- the global key ring and the "user requested
 // quit" flag. We don't pull main.cpp's full surface in here; just the
-// two symbols the script driver needs to talk to.
+// symbols the script driver needs to talk to.
 extern KeyBuffer Keys;
 extern int       do_exit;
+// Synthetic mouse injection (defined in main.cpp). Reuses the exact Keys /
+// bMouseIsDown / MousePress* path the real SDL handlers use.
+extern void      zt_inject_mouse(int down, int button, int x, int y);
 
 // ---------------------------------------------------------------------------
 // Module-local state.
@@ -38,6 +41,15 @@ static bool        g_script_done      = false;
 // SDL_GetTicks so it tracks wall time, not frame count -- robust against
 // frame-rate changes.
 static Uint64      g_wait_until_ms    = 0;
+
+// A `click` must span two frames: the page's update() processes the DOWN on
+// one frame and the UP on the next (a real click is never down+up within a
+// single frame, and widgets like CheckBox latch on DOWN then act on UP). So
+// `click` injects DOWN immediately and defers the matching UP to the next
+// pump via this pending state.
+static bool        g_pending_click_up = false;
+static int         g_click_up_x       = 0;
+static int         g_click_up_y       = 0;
 
 // ---------------------------------------------------------------------------
 // CLI plumbing.
@@ -202,6 +214,31 @@ static void exec_command(SDL_Surface *frame_surface, const char *cmd, char *args
         Keys.insert(k, m, 0, 0);
         return;
     }
+    // Mouse commands. All take pixel coordinates in zt's internal resolution
+    // (the same space col()/row() produce: col(N)=N*8, row(N)=N*8).
+    //   mousemove <x> <y>   move the cursor (hover / drag-path setup)
+    //   mousedown <x> <y>   press left button at (x,y)
+    //   mouseup   <x> <y>   release left button at (x,y)
+    //   click     <x> <y>   move + DOWN now, UP next frame (a full click)
+    if (!strcmp(cmd, "mousemove") || !strcmp(cmd, "mousedown") ||
+        !strcmp(cmd, "mouseup")   || !strcmp(cmd, "click")) {
+        int x = 0, y = 0;
+        if (sscanf(args, "%d %d", &x, &y) != 2) {
+            fprintf(stderr, "zt: --script: '%s' needs '<x> <y>' on line %d\n",
+                    cmd, g_script_lineno);
+            return;
+        }
+        if      (!strcmp(cmd, "mousemove")) zt_inject_mouse(0, 0, x, y);
+        else if (!strcmp(cmd, "mousedown")) zt_inject_mouse(1, 1, x, y);
+        else if (!strcmp(cmd, "mouseup"))   zt_inject_mouse(0, 1, x, y);
+        else { // click: DOWN now, UP deferred to next frame
+            zt_inject_mouse(1, 1, x, y);
+            g_pending_click_up = true;
+            g_click_up_x = x;
+            g_click_up_y = y;
+        }
+        return;
+    }
     // `wait <ms>`
     if (!strcmp(cmd, "wait")) {
         long ms = strtol(args, NULL, 10);
@@ -235,6 +272,11 @@ static void exec_command(SDL_Surface *frame_surface, const char *cmd, char *args
 
 void zt_headless_pump(SDL_Surface *frame_surface) {
     if (!g_active || g_script_done || !g_script_fp) return;
+    if (g_pending_click_up) {
+        g_pending_click_up = false;
+        zt_inject_mouse(0, 1, g_click_up_x, g_click_up_y);
+        return;
+    }
     if (g_wait_until_ms && SDL_GetTicks() < g_wait_until_ms) return;
     g_wait_until_ms = 0;
 
@@ -263,7 +305,9 @@ void zt_headless_pump(SDL_Surface *frame_surface) {
 
         exec_command(frame_surface, p, args);
 
-        if (g_wait_until_ms || g_script_done) return;
+        // `click` queues the DOWN and sets g_pending_click_up; return so this
+        // frame processes the DOWN before we inject the UP next pump.
+        if (g_wait_until_ms || g_script_done || g_pending_click_up) return;
     }
 
     // EOF: stop driving the loop. The main loop continues to render

--- a/src/zt_headless.h
+++ b/src/zt_headless.h
@@ -17,6 +17,16 @@
 //                                                   key ctrl+s,
 //                                                   key down, key tab,
 //                                                   key space, key return)
+//                       mousemove <x> <y>    move the cursor to pixel (x,y)
+//                       mousedown <x> <y>    press left button at (x,y)
+//                       mouseup   <x> <y>    release left button at (x,y)
+//                       click     <x> <y>    full left click at (x,y); the
+//                                            DOWN and UP land on separate
+//                                            frames like a real click, so
+//                                            widgets (checkboxes, sliders,
+//                                            buttons) respond. Coordinates are
+//                                            zt internal-resolution pixels
+//                                            (col(N)=row(N)=N*8).
 //                       wait <ms>            sleep this thread for <ms>
 //                                            milliseconds (lets the page's
 //                                            update() / draw() run a few


### PR DESCRIPTION
## Summary
Adds synthetic mouse injection to the `--headless --script` driver so mouse-only
UI (F11 checkboxes/sliders, buttons — not in the keyboard Tab cycle) is
scriptable and CI-verifiable, alongside the existing `key` and `shot` commands.
Also documents the headless framebuffer screenshot mode in the contributor skill.

## What
New script commands:
- `mousemove <x> <y>`, `mousedown <x> <y>`, `mouseup <x> <y>`
- `click <x> <y>` — full left click (DOWN one frame, UP the next, so a widget
  that latches on DOWN and acts on UP behaves exactly as under a real click)

`zt_inject_mouse()` (main.cpp) sets `LastX/LastY` in internal-resolution pixels
and queues the button event through the same `Keys` FIFO / `bMouseIsDown` /
`MousePress*` state the real SDL handlers use — widgets can't tell a scripted
click from hardware. Only ever called from the headless script driver, so normal
runs are unaffected.

## Test plan
- [x] Builds clean on master; 13/13 ctest
- [x] Headless smoke: `--headless --script` with `key F11` + `click` + `shot` exits 0
- [x] No behavior change to non-headless operation (`zt_inject_mouse` is headless-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
