### PR TITLE
Ableton Link tempo + transport sync

### DIFF
--- a/.github/scripts/fetch-ableton-link.sh
+++ b/.github/scripts/fetch-ableton-link.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# fetch-ableton-link.sh
+#
+# Populate extlibs/link/ with the Ableton Link source tree that CMakeLists.txt
+# links against when ZT_ENABLE_ABLETON_LINK is ON. Like libpng/zlib (see
+# fetch-extlibs.sh), the Link sources are NOT committed to this repo -- CI (and
+# a local developer who wants Link) fetches them on demand.
+#
+# Link bundles asio as a git submodule (modules/asio-standalone), so this MUST
+# be a recursive clone, not a flat tarball -- the tarball does not include
+# submodule contents and the build would fail with missing <asio.hpp>.
+#
+# Pinned to a release tag so builds are reproducible. Bump LINK_VERSION to
+# move to a newer Link.
+#
+# Env vars (with sane defaults):
+#   LINK_VERSION   default Link-4.0   (a tag in github.com/Ableton/link)
+#
+# Layout produced:
+#   extlibs/link/AbletonLinkConfig.cmake
+#   extlibs/link/include/ableton/Link.hpp
+#   extlibs/link/modules/asio-standalone/asio/include/asio.hpp
+
+set -euo pipefail
+
+: "${LINK_VERSION:=Link-4.0}"
+
+root="$(pwd)"
+dest="$root/extlibs/link"
+repo="https://github.com/Ableton/link.git"
+
+# If a valid tree is already present (developer already fetched, or a cached
+# CI checkout), don't re-clone.
+if [ -f "$dest/AbletonLinkConfig.cmake" ] \
+   && [ -f "$dest/include/ableton/Link.hpp" ] \
+   && [ -f "$dest/modules/asio-standalone/asio/include/asio.hpp" ]; then
+  echo "=== Ableton Link already present ($LINK_VERSION); skipping fetch ==="
+  exit 0
+fi
+
+echo "=== Fetching Ableton Link $LINK_VERSION (with submodules) ==="
+rm -rf "$dest"
+
+ok=0
+for attempt in 1 2 3; do
+  echo "  clone attempt $attempt ..."
+  if git clone --depth 1 --branch "$LINK_VERSION" \
+        --recurse-submodules --shallow-submodules \
+        "$repo" "$dest"; then
+    ok=1
+    break
+  fi
+  rm -rf "$dest"
+  sleep 5
+done
+
+if [ "$ok" -ne 1 ]; then
+  echo "ERROR: failed to clone Ableton Link after 3 attempts" >&2
+  exit 1
+fi
+
+required=(
+  extlibs/link/AbletonLinkConfig.cmake
+  extlibs/link/include/ableton/Link.hpp
+  extlibs/link/modules/asio-standalone/asio/include/asio.hpp
+)
+missing=0
+for f in "${required[@]}"; do
+  if [ ! -f "$root/$f" ]; then
+    echo "  MISSING: $f" >&2
+    missing=1
+  fi
+done
+if [ "$missing" -ne 0 ]; then
+  echo "ERROR: required Ableton Link files missing after clone" >&2
+  exit 1
+fi
+
+echo "=== Ableton Link OK ($LINK_VERSION) ==="

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,12 @@ jobs:
           set -euo pipefail
           bash .github/scripts/fetch-extlibs.sh
 
+      - name: Fetch Ableton Link
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash .github/scripts/fetch-ableton-link.sh
+
       - name: Cache SDL3 source tarball
         id: cache-sdl3-src
         uses: actions/cache@v4
@@ -201,6 +207,12 @@ jobs:
           set -euo pipefail
           bash .github/scripts/fetch-extlibs.sh
 
+      - name: Fetch Ableton Link
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash .github/scripts/fetch-ableton-link.sh
+
       - name: Configure
         run: |
           cmake -S . -B build -G Ninja \
@@ -287,6 +299,12 @@ jobs:
         run: |
           set -euo pipefail
           bash .github/scripts/fetch-extlibs.sh
+
+      - name: Fetch Ableton Link
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash .github/scripts/fetch-ableton-link.sh
 
       - name: Configure
         run: |
@@ -435,6 +453,7 @@ jobs:
           cmake -S . -B build -G Ninja \
             -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchain-mingw-i686.cmake" \
             -DCMAKE_BUILD_TYPE=Release \
+            -DZT_ENABLE_ABLETON_LINK=OFF \
             -DSDL3_INCLUDE_DIR="${{ steps.sdl3.outputs.include }}" \
             -DSDL3_LIBRARY="${{ steps.sdl3.outputs.lib }}"
 
@@ -529,8 +548,13 @@ jobs:
       - name: Configure (MSVC x64)
         shell: pwsh
         run: |
+          # Ableton Link OFF on Windows for now (no Link fetch step on this
+          # job; the wrapper builds as a stub). Enabling Link on MSVC x64 is a
+          # follow-up — Link supports it, but it needs CI verification we can't
+          # do from the macOS dev box.
           cmake -S . -B build -A x64 `
             -DCMAKE_BUILD_TYPE=Release `
+            -DZT_ENABLE_ABLETON_LINK=OFF `
             -DSDL3_INCLUDE_DIR="${{ steps.sdl3.outputs.include }}" `
             -DSDL3_LIBRARY="${{ steps.sdl3.outputs.lib }}"
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ __pycache__/
 /sdl3-mingw/
 /toolchain-mingw-i686-macos.cmake
 /dist/ztrackerprime-windows-x86-xp/
+# Ableton Link source tree — fetched on demand by
+# .github/scripts/fetch-ableton-link.sh, never committed (same policy as the
+# libpng/zlib extlibs). Keeps the ~2k-file Link+asio checkout out of git.
+/extlibs/link/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,14 @@ For deeper material — recipes, foot-gun details, effect reference, glossary, c
 
 ---
 
+# Coding Standards
+
+- **Zero-noise comments:** Do not comment on obvious code, functions, or variable names.
+- **Comment limits:** Only add comments if a block contains complex, non-obvious algorithmic logic or tricky workarounds.
+- **Refactoring:** If the code is so weird it needs a paragraph of explanation, refactor it to be self-documenting instead.
+
+---
+
 ## Repository overview
 
 **zTracker Prime** (m6502/ztrackerprime) is Manuel Montoto's maintained fork of zTracker — an Impulse-Tracker-inspired MIDI tracker originally by Christopher Micali (2000–2001) with contributions from Daniel Kahlin. Manuel brought it to SDL 3 and cross-platform (Windows XP through 11, macOS, Linux).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,13 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(ZT_ENABLE_SANITIZERS "Enable AddressSanitizer + UndefinedBehaviorSanitizer (GCC/Clang)" OFF)
 
+# Sync tempo/transport with Ableton Link peers on the LAN. When ON and the
+# vendored Link source tree is present (extlibs/link/, fetched by
+# .github/scripts/fetch-ableton-link.sh), zt links Ableton::Link and compiles
+# the real wrapper. When OFF or the tree is absent, the wrapper builds as a
+# safe stub so the binary still works without Link.
+option(ZT_ENABLE_ABLETON_LINK "Sync tempo/transport with Ableton Link peers on the LAN" ON)
+
 set(ZT_WINDOWS_LIB_DIR "${CMAKE_SOURCE_DIR}/extlibs" CACHE PATH "Directory containing Windows SDL libraries (.lib/.dll)")
 set(SDL3_INCLUDE_DIR "" CACHE PATH "Path containing SDL3/SDL.h (or SDL.h with SDL3 include root)")
 set(SDL3_LIBRARY "" CACHE FILEPATH "Full path to SDL3 library (libSDL3*.a/.so/.dylib or SDL3.lib)")
@@ -154,6 +161,7 @@ set(ZT_SOURCES
   src/sysex_macro.cpp
   src/ccenv_io.cpp
   src/CUI_CCEnvelopeEditor.cpp
+  src/ableton_link.cpp
   src/zt_headless.cpp
 )
 
@@ -185,6 +193,24 @@ else()
 endif()
 target_include_directories(zt PRIVATE src extlibs/libpng extlibs/zlib extlibs/lua)
 target_link_libraries(zt PRIVATE lua_static zt_zlib_static)
+
+# --- Ableton Link ------------------------------------------------------------
+# Link ships an Ableton::Link IMPORTED INTERFACE target via AbletonLinkConfig
+# .cmake that carries include dirs, per-platform compile defs, and link libs.
+# We link it only when ZT_ENABLE_ABLETON_LINK is ON AND the source tree is
+# present. ZT_HAS_ABLETON_LINK then flips src/ableton_link.cpp from its
+# stub to the real implementation. MinGW is excluded: the XP target pins
+# _WIN32_WINNT=0x0501 and asio's Windows backend needs Vista+ APIs.
+set(ZT_ABLETON_LINK_AVAILABLE OFF)
+if(ZT_ENABLE_ABLETON_LINK AND NOT MINGW
+   AND EXISTS "${CMAKE_SOURCE_DIR}/extlibs/link/AbletonLinkConfig.cmake")
+  include("${CMAKE_SOURCE_DIR}/extlibs/link/AbletonLinkConfig.cmake")
+  target_link_libraries(zt PRIVATE Ableton::Link)
+  target_compile_definitions(zt PRIVATE ZT_HAS_ABLETON_LINK)
+  set(ZT_ABLETON_LINK_AVAILABLE ON)
+endif()
+message(STATUS "Ableton Link: ${ZT_ABLETON_LINK_AVAILABLE}")
+# -----------------------------------------------------------------------------
 
 # Linux release artifacts bundle libSDL3.so.0 next to the binary (Ubuntu 24.04
 # apt has no libsdl3-dev yet). Without $ORIGIN in the rpath, the dynamic linker

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,14 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_06_09 (Ableton Link support)
+----------------------------------------------------------------------------
+
+        + Ableton Link support. zt can join a Link session on the local
+          network and keep tempo and transport in sync with
+          Ableton Live and other Link-aware apps. OFF by default; toggle from
+          F11 (Song Configuration). See the "Ableton Link" section in F1 help.
+
 zt 2026_05_31 (AltGr behaves like Alt for keyboard shortcuts)
 ----------------------------------------------------------------------------
 

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -268,6 +268,25 @@
    zt --midi-in "IAC Driver Bus 1"
    zt --midi-clock 0 mysong.zt
 
+|L|%==|H|Ableton Link|L|==%|U|
+
+ Ableton Link keeps zTracker's tempo in sync with other Link-aware
+ apps on the same network (Ableton Live, etc). It is OFF by default.
+ Toggle it from F11 (Song Configuration):
+
+   Ableton Link    : Join the Link session. While on, zt's BPM follows
+                     the shared session tempo (even while stopped, so you
+                     press play already in sync), and changing BPM in F11
+                     proposes that tempo to every peer.
+   Link Start/Stop : (on by default) Also share transport.
+   Link Offset ms  : Play this many ms EARLY (0-500, default 0). A DAW
+                     monitoring zt's MIDI through its audio chain renders
+                     the notes late by its audio latency (Live:
+                     Preferences > Audio > Overall Latency), and Link has
+                     no way to discover that value. Set it here once and
+                     zt's notes SOUND on the grid - no track delay or
+                     reduced-latency mode needed in the DAW.
+
 |L|%==|H|Troubleshooting|L|==%|U|
 
  Timing issues:

--- a/src/CUI_Page.h
+++ b/src/CUI_Page.h
@@ -95,6 +95,8 @@ class CUI_Songconfig : public CUI_Page {
         int rev_tpb_tab[97];
         int tpb_tab[9];// = ;
 
+        int last_bpm_seen;
+
         CUI_Songconfig();
 
         void enter(void);

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -1,6 +1,7 @@
 
 #include "zt.h"
 #include "OrderEditor.h"
+#include "ableton_link.h"
 
 CUI_Songconfig::CUI_Songconfig(void) {
     ValueSlider *vs;
@@ -11,6 +12,8 @@ CUI_Songconfig::CUI_Songconfig(void) {
 //    CommentEditor *ce;
 
     int base_y = TRACKS_ROW_Y;
+
+    last_bpm_seen = -1;
 
     tpb_tab[0] = 2;
     tpb_tab[1] = 4;
@@ -50,8 +53,8 @@ CUI_Songconfig::CUI_Songconfig(void) {
         vs->x = 20; 
         vs->y = base_y+2; 
         vs->xsize=28;
-        vs->min = 60;
-        vs->max = 240;
+        vs->min = 20;
+        vs->max = 500;
         vs->value = song->bpm;
     // END Test Slider
     /* Initialize TPB Slider 2 */
@@ -159,6 +162,33 @@ CUI_Songconfig::CUI_Songconfig(void) {
         vs->max = ZT_NAS_EDITSTEP;
         vs->value = zt_config_globals.note_audition_step_mode;
 
+        // Ableton Link
+        cb = new CheckBox;
+        UI->add_element(cb, 11);
+        cb->frame = 0;
+        cb->x = 20;
+        cb->y = base_y + 16;
+        cb->xsize = 3;
+        cb->value = &zt_config_globals.ableton_link_enable;
+
+        cb = new CheckBox;
+        UI->add_element(cb, 12);
+        cb->frame = 0;
+        cb->x = 20;
+        cb->y = base_y + 17;
+        cb->xsize = 3;
+        cb->value = &zt_config_globals.ableton_link_start_stop_sync;
+
+        vs = new ValueSlider;
+        UI->add_element(vs, 13);
+        vs->frame = 0;
+        vs->x = 20;
+        vs->y = base_y + 18;
+        vs->xsize = 28;
+        vs->min = 0;
+        vs->max = 500;
+        vs->value = zt_config_globals.ableton_link_offset_ms;
+
         oe = new OrderEditor;
         UI->add_element(oe,9);
         oe->x = 59;
@@ -172,6 +202,7 @@ void CUI_Songconfig::enter(void) {
     need_refresh = 1;
     vs = (ValueSlider *)UI->get_element(1);
     vs->value = song->bpm;
+    last_bpm_seen = song->bpm;   // baseline the user-vs-external BPM disambiguator
     vs = (ValueSlider *)UI->get_element(2);
     vs->value = rev_tpb_tab[song->tpb];
 
@@ -188,6 +219,8 @@ void CUI_Songconfig::enter(void) {
     // hand-editing zt.conf and reloading).
     vs = (ValueSlider *)UI->get_element(10);
     if (vs) vs->value = zt_config_globals.note_audition_step_mode;
+    vs = (ValueSlider *)UI->get_element(13);
+    if (vs) vs->value = zt_config_globals.ableton_link_offset_ms;
 
     // F11 toggle: pressing F11 while already on Songconfig flips focus
     // between OrderEditor (id 9) and Title (id 0) on every press, so the
@@ -235,7 +268,7 @@ void CUI_Songconfig::update()
     UI->update();
     vs = (ValueSlider *)UI->get_element(1);
     if (vs->from_input) vs->from_input = 0;  // BPM slider takes any [min,max]; clamp already applied
-    if (vs->value != song->bpm) {
+    if (vs->value != last_bpm_seen) {
         song->bpm = vs->value;
         ztPlayer->set_speed();
 
@@ -243,9 +276,17 @@ void CUI_Songconfig::update()
             zt_config_globals.highlight_increment = song->tpb;
         if(!zt_config_globals.lowlight_increment)
             zt_config_globals.lowlight_increment = song->tpb >> 1 / song->tpb / 2;
-       
+
         file_changed++;
+    } else if (song->bpm != vs->value) {
+        // song->bpm changed underneath us (the Ableton Link tempo pump in the
+        // main loop follows the session tempo) -> move the slider to match so
+        // the F11 BPM display tracks Ableton instead of snapping it back.
+        vs->value = song->bpm;
+        vs->need_redraw++;
+        need_refresh++;
     }
+    last_bpm_seen = vs->value;
     vs = (ValueSlider *)UI->get_element(2);
     if (vs->from_input) {
         // Typed-numeric path. vs->input_value holds the raw number the
@@ -289,6 +330,14 @@ void CUI_Songconfig::update()
     } else if (vs) {
         vs->value = zt_config_globals.highlight_increment;
     }
+    vs = (ValueSlider *)UI->get_element(13);
+    if (vs && vs->from_input) vs->from_input = 0;
+    if (vs && vs->value != zt_config_globals.ableton_link_offset_ms) {
+        zt_config_globals.ableton_link_offset_ms = vs->value;
+    } else if (vs) {
+        vs->value = zt_config_globals.ableton_link_offset_ms;
+    }
+
     vs = (ValueSlider *)UI->get_element(6);
     if (vs && vs->from_input) vs->from_input = 0;
     if (vs && vs->value != zt_config_globals.lowlight_increment) {
@@ -297,12 +346,61 @@ void CUI_Songconfig::update()
         vs->value = zt_config_globals.lowlight_increment;
     }
     {
-        CheckBox *cb = (CheckBox *)UI->get_element(7);
-        if (cb && cb->changed)
-            zt_config_globals.midi_in_sync = *(cb->value);
-        cb = (CheckBox *)UI->get_element(8);
-        if (cb && cb->changed)
-            zt_config_globals.midi_in_sync_chase_tempo = *(cb->value);
+
+        static int prev_link = -1;
+        static int prev_sync = -1;
+        int link_now = zt_config_globals.ableton_link_enable;
+        int sync_now = zt_config_globals.midi_in_sync;
+
+        if (prev_link >= 0 && link_now != prev_link) {
+            if (link_now && !zt_ableton_link_available()) {
+                // Stub build: nothing to enable. Snap the toggle back off.
+                zt_config_globals.ableton_link_enable = link_now = 0;
+                statusmsg = (char*)"Ableton Link not compiled in this build";
+            } else if (link_now) {
+                // Disable MIDI In Sync (don't want both on at same time)
+                zt_config_globals.midi_in_sync = 0;
+                zt_config_globals.midi_in_sync_chase_tempo = 0;
+                sync_now = 0;
+                UI->get_element(7)->need_redraw++;
+                UI->get_element(8)->need_redraw++;
+                statusmsg = (char*)"Ableton Link enabled";
+            } else {
+                statusmsg = (char*)"Ableton Link disabled";
+            }
+            status_change = 1;
+            need_refresh++;
+        }
+
+        if (prev_sync >= 0 && sync_now != prev_sync && sync_now) {
+            // Mutual exclusion the other way: MIDI-In-Sync on kicks Link off.
+            if (zt_config_globals.ableton_link_enable) {
+                zt_config_globals.ableton_link_enable = link_now = 0;
+                UI->get_element(11)->need_redraw++;   // cross-cleared checkbox
+                statusmsg = (char*)"Ableton Link disabled (MIDI-In Sync took over)";
+                status_change = 1;
+                need_refresh++;
+            }
+        }
+
+        prev_link = zt_config_globals.ableton_link_enable;
+        prev_sync = zt_config_globals.midi_in_sync;
+
+        // Live status: peer count / session tempo move asynchronously as peers
+        // join, leave, or retempo. update() runs every frame but draw() only
+        // repaints when need_refresh != 0 — so bump it when a value we display
+        // actually changed (invariant: background state change -> need_refresh++).
+        if (zt_config_globals.ableton_link_enable) {
+            static size_t last_peers = (size_t)-1;
+            static int    last_bpm10 = -1;
+            size_t peers = zt_ableton_link_num_peers();
+            int    bpm10 = (int)(zt_ableton_link_get_tempo() * 10.0 + 0.5);
+            if (peers != last_peers || bpm10 != last_bpm10) {
+                last_peers = peers;
+                last_bpm10 = bpm10;
+                need_refresh++;
+            }
+        }
     }
     vs = (ValueSlider *)UI->get_element(10);
     if (vs) {
@@ -355,6 +453,31 @@ void CUI_Songconfig::draw(Drawable *S) {
         // colliding with the on-slider digits.
         print(row(2),col(base_y+13),"4/8 Audition Step",COLORS.Text,S);
         print(row(20),col(base_y+14),"0=stay  1=row  2=editstep",COLORS.Text,S);
+
+        // Ableton Link block. Labels right-align to col 18 like the rest.
+        print(row(6),col(base_y+16),"Ableton Link",COLORS.Text,S);
+        print(row(3),col(base_y+17),"Link Start/Stop",COLORS.Text,S);
+        print(row(4),col(base_y+18),"Link Offset ms",COLORS.Text,S);
+        {
+            char linkstat[96];
+            if (!zt_ableton_link_available()) {
+                snprintf(linkstat, sizeof(linkstat), "(not compiled in)");
+            } else if (zt_config_globals.ableton_link_enable) {
+                size_t peers = zt_ableton_link_num_peers();
+                snprintf(linkstat, sizeof(linkstat), "%d peer%s \xb3 %.1f BPM",
+                         (int)peers, peers == 1 ? "" : "s", zt_ableton_link_get_tempo());
+            } else {
+                snprintf(linkstat, sizeof(linkstat), "off");
+            }
+            // Pad to a fixed width and draw with a background fill so a shorter
+            // status (e.g. "off") fully erases the previous longer one
+            // ("N peers ... BPM"). print() only paints glyph pixels — without
+            // this the old text shows through the new, garbled. 28 cols span
+            // col 24..51, clear of the Order List at col 59.
+            char linkstat_field[40];
+            snprintf(linkstat_field, sizeof(linkstat_field), "%-28s", linkstat);
+            printBG(row(24),col(base_y+16),linkstat_field,COLORS.Highlight,COLORS.Background,S);
+        }
         // Order List label aligned to the OE x-origin (col 59) — NOT shifted.
         print(row(59),col(11),"Order List",COLORS.Text,S);
         printchar(row(20 + 27) + 1,col(base_y+2),0x84,COLORS.Highlight,S);

--- a/src/OrderEditor.cpp
+++ b/src/OrderEditor.cpp
@@ -1,7 +1,6 @@
 #include "OrderEditor.h"
 #include "zt.h"
 
-
 // ------------------------------------------------------------------------------------------------
 //
 //
@@ -60,7 +59,9 @@ int OrderEditor::mouseupdate(int cur_element) {
                 cursor_x = clicked_col - 4;
             }
             cur_edit_order = new_order;
-            cur_edit_pattern = song->orderlist[new_order];
+            if (song->orderlist[new_order] < 0x100) {
+                cur_edit_pattern = song->orderlist[new_order];
+            }
             Keys.getkey();
             need_redraw++;
             need_refresh++;
@@ -149,8 +150,9 @@ int OrderEditor::update() {
                     if(cur_edit_order < 255 && song->orderlist[cur_edit_order + 1] != 0x100)
                     {
                         cur_edit_order++;
-                        cur_edit_pattern = song->orderlist[cur_edit_order];
-                            need_refresh++;
+                        if (song->orderlist[cur_edit_order] < 0x100)
+                            cur_edit_pattern = song->orderlist[cur_edit_order];
+                        need_refresh++;
                         need_redraw++;
                     }
                     break;
@@ -167,8 +169,9 @@ int OrderEditor::update() {
                     if(cur_edit_order > 0 && song->orderlist[cur_edit_order -1] != 0x100)
                     {
                         cur_edit_order--;
-                        cur_edit_pattern = song->orderlist[cur_edit_order];
-                            need_refresh++;
+                        if (song->orderlist[cur_edit_order] < 0x100)
+                            cur_edit_pattern = song->orderlist[cur_edit_order];
+                        need_refresh++;
                         need_redraw++;
                     }
                     break;

--- a/src/ableton_link.cpp
+++ b/src/ableton_link.cpp
@@ -1,0 +1,500 @@
+/*************************************************************************
+ * ableton_link.cpp
+ *
+ * Implementation for Ableton Link support
+ *************************************************************************/
+
+#include "ableton_link.h"
+
+#include <cmath>   // lround
+
+#ifdef ZT_HAS_ABLETON_LINK
+#include <memory>
+// asio (vendored under Link) is noisy under -Wall -Wextra -Wpedantic. We don't
+// own it; silence locally so the rest of the tree's build output stays clean.
+// This block must precede the zt.h include below: on Windows asio needs
+// winsock2.h before anything drags in windows.h.
+#if defined(__clang__) || defined(__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wpedantic"
+#  pragma GCC diagnostic ignored "-Wunused-parameter"
+#  pragma GCC diagnostic ignored "-Wshadow"
+#endif
+#include <ableton/Link.hpp>
+#if defined(__clang__) || defined(__GNUC__)
+#  pragma GCC diagnostic pop
+#endif
+#endif // ZT_HAS_ABLETON_LINK
+
+#ifdef ZT_TEST_NO_SDL
+#include "zt_link_stub.h"   // tests/: fake player, song, conf, globals
+#else
+#include "zt.h"             // ztPlayer, song, statusmsg, need_refresh,
+                            // zt_config_globals, cur_edit_pattern
+#endif
+
+// ---------------------------------------------------------------------------
+// State shared by both backends. g_cached_bpm survives shutdown — it is the
+// caller's tempo source of truth (seeded into a fresh Link on init), not
+// Link's. The "last" values drive the change-dedupe / edge-detect below.
+
+static double g_cached_bpm      = 120.0;
+static double g_quantum         = 4.0;
+static int    g_last_pumped_bpm = -1;   // last int BPM reported by link_pump_tempo
+static int    g_last_transport  = -1;   // last transport state seen by link_poll_transport
+
+static double clamp_bpm(double bpm) {
+    if (bpm < 20.0)  return 20.0;
+    if (bpm > 999.0) return 999.0;
+    return bpm;
+}
+
+// ---------------------------------------------------------------------------
+// Backend primitives: the only real-vs-stub divergence.
+
+#ifdef ZT_HAS_ABLETON_LINK
+
+static std::unique_ptr<ableton::Link> g_link;
+
+static void   be_init(void)            { if (!g_link) g_link.reset(new ableton::Link(clamp_bpm(g_cached_bpm))); }
+static void   be_shutdown(void)        { if (g_link) { g_link->enable(false); g_link.reset(); } }
+static void   be_enable(bool e)        { if (g_link) g_link->enable(e); }
+static bool   be_enabled(void)         { return g_link && g_link->isEnabled(); }
+static size_t be_peers(void)           { return g_link ? g_link->numPeers() : 0; }
+
+static double be_tempo(void) {
+    if (g_link && g_link->isEnabled())
+        return g_link->captureAppSessionState().tempo();
+    return g_cached_bpm;
+}
+
+static void be_set_tempo(double bpm) {
+    if (g_link) {
+        auto state = g_link->captureAppSessionState();
+        state.setTempo(bpm, g_link->clock().micros());
+        g_link->commitAppSessionState(state);
+    }
+}
+
+// Beat phase within the quantum, in [0, quantum): position inside the current
+// bar, 0 = downbeat. -1 when not enabled (no shared grid to align to).
+static double be_phase(void) {
+    if (!g_link || !g_link->isEnabled()) return -1.0;
+    auto state = g_link->captureAppSessionState();
+    return state.phaseAtTime(g_link->clock().micros(), g_quantum);
+}
+
+// Absolute session beat timeline (monotonic while the session runs). The
+// phase chase anchors against this. -1 when not enabled.
+static double be_beats(void) {
+    if (!g_link || !g_link->isEnabled()) return -1.0;
+    auto state = g_link->captureAppSessionState();
+    return state.beatAtTime(g_link->clock().micros(), g_quantum);
+}
+
+static void be_sss_enable(bool e)      { if (g_link) g_link->enableStartStopSync(e); }
+static bool be_sss_enabled(void)       { return g_link && g_link->isStartStopSyncEnabled(); }
+
+static void be_set_playing(bool play) {
+    if (!g_link) return;
+    auto state = g_link->captureAppSessionState();
+    auto now   = g_link->clock().micros();
+    if (play) {
+        // Pin beat 0 to the next quantum boundary so peers launch bar-aligned.
+        state.setIsPlayingAndRequestBeatAtTime(true, now, 0.0, g_quantum);
+    } else {
+        state.setIsPlaying(false, now);
+    }
+    g_link->commitAppSessionState(state);
+}
+
+static bool be_playing(void) {
+    return g_link && g_link->captureAppSessionState().isPlaying();
+}
+
+#else  // ---- STUB backend (no ZT_HAS_ABLETON_LINK) -------------------------
+
+// Cached flags stand in for the session. In production stub builds none of
+// the enabled paths are ever reached — zt_ableton_link_available() returns 0
+// so startup() snaps the conf flag off and the pump never enables — but the
+// flags are real enough that the unit test can drive the full pump logic.
+static bool   g_stub_enabled = false;
+static bool   g_stub_sss     = false;
+static bool   g_stub_playing = false;
+static double g_stub_phase   = -1.0;   // pokable by the unit test
+
+static double g_stub_beats   = 0.0;    // pokable by the unit test
+
+static void   be_init(void)            {}
+static void   be_shutdown(void)        { g_stub_enabled = false; }
+static void   be_enable(bool e)        { g_stub_enabled = e; }
+static bool   be_enabled(void)         { return g_stub_enabled; }
+static size_t be_peers(void)           { return 0; }
+static double be_tempo(void)           { return g_cached_bpm; }
+static void   be_set_tempo(double)     {}
+static double be_phase(void)           { return g_stub_phase; }
+static double be_beats(void)           { return g_stub_beats; }
+static void   be_sss_enable(bool e)    { g_stub_sss = e; }
+static bool   be_sss_enabled(void)     { return g_stub_sss; }
+static void   be_set_playing(bool p)   { g_stub_playing = p; }
+static bool   be_playing(void)         { return g_stub_playing; }
+
+#endif // ZT_HAS_ABLETON_LINK
+
+// ---------------------------------------------------------------------------
+// Shared contract logic — one copy for both backends (the unit test's
+// subject). The dedupe/edge "last" sentinels keep callers from re-acting on
+// unchanged session state every frame.
+
+static void link_init(void) {
+    be_init();
+    g_last_pumped_bpm = -1;
+    g_last_transport  = -1;
+}
+
+// zt -> session: propose a tempo (every peer adopts it). Caches the clamped
+// value so it also seeds the next link_init().
+static void link_set_tempo(double bpm) {
+    bpm = clamp_bpm(bpm);
+    g_cached_bpm = bpm;
+    be_set_tempo(bpm);
+}
+
+// session -> zt: reads the session tempo, rounds to int BPM, and returns true
+// (writing *bpm_out) ONLY when the rounded value changed since the last
+// successful pump — feedable straight to song->bpm without oscillation.
+static bool link_pump_tempo(int *bpm_out) {
+    if (!be_enabled()) return false;
+    double tempo = be_tempo();
+    g_cached_bpm = tempo;
+    int rounded = (int)lround(tempo);
+    if (rounded != g_last_pumped_bpm) {
+        g_last_pumped_bpm = rounded;
+        if (bpm_out) *bpm_out = rounded;
+        return true;
+    }
+    return false;
+}
+
+static void link_set_quantum(double quantum) {
+    if (quantum < 1.0)  quantum = 1.0;
+    if (quantum > 16.0) quantum = 16.0;
+    g_quantum = quantum;
+}
+
+// Edge-detected peer transport follow: true ONLY when the shared transport
+// state changed since the last poll (writing *want_play = 1/0), so a peer
+// hitting play/stop is mirrored once instead of every frame.
+static bool link_poll_transport(int *want_play) {
+    int cur = be_playing() ? 1 : 0;
+    if (cur != g_last_transport) {
+        g_last_transport = cur;
+        if (want_play) *want_play = cur;
+        return true;
+    }
+    return false;
+}
+
+// Re-baseline the edge detector to the CURRENT session state so the next poll
+// reports no edge — call when (re)joining or when sss is freshly enabled,
+// otherwise a stale sentinel replays an old peer start/stop as a fresh edge.
+static void link_prime_transport(void) {
+    g_last_transport = be_playing() ? 1 : 0;
+}
+
+// ---------------------------------------------------------------------------
+// App integration.
+
+// Quantized-start state: player::play() arms a downbeat-aligned start that
+// the pump fires (via play_immediately) when the Link phase wraps past the bar
+// boundary.
+static bool   g_play_armed = false;
+static int    g_play_row = 0, g_play_pat = 0, g_play_pm = 0;
+static double g_play_phase = 0.0;
+// Last BPM reconciled with the session, so the pump tells a zt-side tempo
+// change (push to peers) from a peer-side one (follow).
+static int    g_last_synced_bpm = -1;
+// Phase chase: the session beat at which the playing engine's subtick 0
+// occurred. Anchored at the quantized fire (which bakes the Link Offset
+// into the setpoint), re-derived whenever the chase resumes.
+static double g_chase_anchor = 0.0;
+static bool   g_chase_valid  = false;
+
+static void link_notify_transport(bool playing) {
+    if (zt_config_globals.ableton_link_enable &&
+        zt_config_globals.ableton_link_start_stop_sync &&
+        be_enabled())
+        be_set_playing(playing);
+}
+
+static void link_arm_play(int row, int pattern, int pm) {
+    g_play_row = row; g_play_pat = pattern; g_play_pm = pm;
+    g_play_armed = true;
+    double ph = be_phase();
+    g_play_phase = (ph >= 0.0) ? ph : 0.0;
+    statusmsg = "Link: waiting for downbeat...";
+    status_change = 1;   // the status-line repaint is gated on this
+    need_refresh++;
+}
+
+// Fire an armed start when the phase wraps past the downbeat (or immediately
+// if Link was disabled while waiting). play_immediately, not play: play() would defer
+// right back to us.
+//
+// ableton_link_offset_ms fires that many ms BEFORE the downbeat: a peer
+// monitoring zt through an audio chain (Live's Overall Latency) renders our
+// notes that much late, and Link cannot discover a peer's local latency, so
+// the user dials the rig's value once and zt's whole timeline runs early by
+// exactly that amount -- the notes then SOUND on the grid.
+static void link_fire_quantized(void) {
+    if (!g_play_armed) return;
+    if (!be_enabled()) {
+        ztPlayer->play_immediately(g_play_row, g_play_pat, g_play_pm);
+        g_play_armed = false; need_refresh++;
+        return;
+    }
+    double ph = be_phase();
+    if (ph < 0.0) return;
+    bool fire = (ph < g_play_phase);   // wrapped past the downbeat
+    int offset_ms = zt_config_globals.ableton_link_offset_ms;
+    if (!fire && offset_ms > 0) {
+        double tempo = be_tempo();
+        if (tempo > 0.0) {
+            double remaining_ms = (g_quantum - ph) * 60000.0 / tempo;
+            fire = (remaining_ms <= (double)offset_ms);
+        }
+    }
+    if (fire) {
+        ztPlayer->play_immediately(g_play_row, g_play_pat, g_play_pm);
+        g_play_armed = false; need_refresh++;
+        // Anchor the chase on the DOWNBEAT this start aimed at (we are
+        // firing offset_ms before it), not on the fire moment itself: the
+        // chase re-applies the CURRENT offset every frame, which makes the
+        // F11 slider live -- drag it while playing and the loop slews the
+        // engine to the new offset.
+        double tempo = be_tempo();
+        double off_beats = (tempo > 0.0)
+            ? (double)zt_config_globals.ableton_link_offset_ms * tempo / 60000.0
+            : 0.0;
+        g_chase_anchor = be_beats() + off_beats;
+        g_chase_valid  = true;
+    }
+    g_play_phase = ph;
+}
+
+// Closed-loop phase lock of the playing engine to Link's beat timeline.
+// Rate-following alone (what the MIDI-clock chase does) still drifts:
+// fractional session tempos round to int BPM, set_speed() truncates the
+// subtick to whole us, and a peer on another machine runs its own crystal.
+// Here any residual rate error integrates into POSITION error against
+// be_beats(), and the loop cancels it by slewing the subtick length:
+//   skew = (exact subtick for the fractional session tempo - the engine's
+//           nominal average) - bounded P feedback on the position error.
+// The feedback bound (0.3% of a subtick) is far below audibility; the total
+// is clamped to 2% so no state can audibly warp playback. While zt's rate
+// deliberately diverges from the session (Fxx tempo effect, local edit not
+// yet pushed) the chase pauses and re-anchors when the rates agree again --
+// re-deriving the anchor from the current position, never jumping it.
+static void link_chase_phase(void) {
+    if (!ztPlayer) return;
+    if (!be_enabled() || !ztPlayer->playing) {
+        ztPlayer->chase_skew_us = 0;
+        return;
+    }
+    double tempo = be_tempo();
+    bool rates_agree = (tempo >= 20.0 &&
+                        tempo - (double)ztPlayer->bpm < 1.0 &&
+                        (double)ztPlayer->bpm - tempo < 1.0);
+    if (!rates_agree) {
+        ztPlayer->chase_skew_us = 0;
+        g_chase_valid = false;
+        return;
+    }
+    double beats = be_beats();
+    if (beats < 0.0) return;
+    // The offset enters the setpoint HERE, from the live conf value, so
+    // dragging the F11 slider during playback shifts the target and the
+    // loop slews onto it.
+    double off_beats = (double)zt_config_globals.ableton_link_offset_ms * tempo / 60000.0;
+    int played = ztPlayer->played_subticks;   // one advisory read
+    if (!g_chase_valid) {
+        g_chase_anchor = beats - played / 96.0 + off_beats;
+        g_chase_valid  = true;
+        return;
+    }
+    double exact_us   = 60000000.0 / (96.0 * tempo);
+    double expected   = (beats - g_chase_anchor + off_beats) * 96.0;   // subticks
+    // pos_err, not err_us: <mach/error.h> (via CoreMIDI) #defines err_us.
+    double pos_err    = (expected - (double)played) * exact_us;
+    double nominal_us = (double)(ztPlayer->subtick_len_ms + ztPlayer->subtick_len_mms);
+    double feedback   = pos_err / 64.0;
+    // Tiered authority: |error| beyond 10 ms is a deliberate move (offset
+    // slider, tempo step) and may slew at 12% of real time -- the output is
+    // MIDI, so a brief rush/drag while the user turns a knob is harmless,
+    // and even a full-scale 500 ms move locks in ~4 s (171 ms in ~1.4 s).
+    // Inside 10 ms (steady-state lock) corrections stay at 0.3%, far below
+    // audibility.
+    double fb_max     = exact_us * ((pos_err > 10000.0 || pos_err < -10000.0) ? 0.12 : 0.003);
+    if (feedback >  fb_max) feedback =  fb_max;
+    if (feedback < -fb_max) feedback = -fb_max;
+    // Positive error = engine behind = needs a SHORTER subtick.
+    double skew = (exact_us - nominal_us) - feedback;
+    double skew_max = exact_us * 0.15;
+    if (skew >  skew_max) skew =  skew_max;
+    if (skew < -skew_max) skew = -skew_max;
+    ztPlayer->chase_skew_us = (int)lround(skew);
+}
+
+// Does NOT join the session here -- the first zt_ableton_link_pump() does,
+// via its enable-reconcile branch. startup() runs inside initSDL(), BEFORE
+// the autoload/CLI song load; joining now would seed the session with the
+// default song's tempo, and the first pump would then "follow" that stale
+// seed and silently revert the loaded song's BPM. The first pump runs after
+// the load, so the join always seeds the real song tempo.
+void zt_ableton_link_startup(void) {
+    link_init();
+    link_set_tempo((double)song->bpm);
+    if (!zt_ableton_link_available())
+        zt_config_globals.ableton_link_enable = 0;   // stub build can't join
+}
+
+void zt_ableton_link_teardown(void) { be_shutdown(); }
+
+int zt_ableton_link_defer_play(int row, int pattern, int pm) {
+    if (!be_enabled())
+        return 0;   // play() proceeds; the pump's start edge tells peers
+    link_notify_transport(true);
+    link_prime_transport();   // swallow our own start edge
+    link_arm_play(row, pattern, pm);
+    return 1;
+}
+
+int zt_ableton_link_available(void) {
+#ifdef ZT_HAS_ABLETON_LINK
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+size_t zt_ableton_link_num_peers(void) { return be_peers(); }
+double zt_ableton_link_get_tempo(void) { return be_tempo(); }
+
+// Everything behind the pump's availability gate. Separate from the public
+// entry so the unit test (where available() is compile-time 0) can drive it.
+static void link_pump_body(void) {
+    // Observe the player and song instead of requiring every call site to
+    // tell us about transport changes. player::stop() can run on the counter
+    // thread (song end) and inside prepare_play's restart, so the player just
+    // counts stops; module::init() bumps the song generation. All Link calls
+    // and the armed-start bookkeeping stay here, on the main thread.
+    static int prev_playing    = -1;
+    static int last_stop_count = -1;
+    static int last_song_gen   = -1;
+    int  playing_now  = (ztPlayer && ztPlayer->playing) ? 1 : 0;
+    int  stop_now     = ztPlayer ? ztPlayer->stop_count : 0;
+    bool started      = (prev_playing == 0 && playing_now == 1);
+    bool stopped      = (prev_playing == 1 && playing_now == 0);
+    bool stop_intent  = (last_stop_count >= 0 && stop_now != last_stop_count);
+    bool song_changed = (last_song_gen >= 0 && zt_song_generation != last_song_gen);
+    prev_playing    = playing_now;
+    last_stop_count = stop_now;
+    last_song_gen   = zt_song_generation;
+    // A stop from any path, a play that started outside the defer, or a song
+    // rebuild (File > New / load) all invalidate a pending quantized start.
+    if (stop_intent || song_changed || started)
+        g_play_armed = false;
+    // A start that didn't come from the quantized fire has no known beat
+    // anchor -- the chase re-derives one from the current position.
+    if (started)
+        g_chase_valid = false;
+
+    // Conf reconcile: quantum, session enable, start/stop sync.
+    static int last_quantum = -1;
+    if (zt_config_globals.ableton_link_quantum != last_quantum) {
+        last_quantum = zt_config_globals.ableton_link_quantum;
+        link_set_quantum((double)last_quantum);
+    }
+    bool want_enabled = zt_config_globals.ableton_link_enable != 0;
+    if (want_enabled != be_enabled()) {
+        be_enable(want_enabled);
+        if (want_enabled) {
+            // Re-seed our tempo proposal: a solo session keeps song->bpm
+            // (instead of whatever stale value we last cached), and when
+            // joining an established session Link's merge still adopts the
+            // session's tempo -- the pull below then follows it.
+            link_set_tempo((double)song->bpm);
+            g_last_synced_bpm = song->bpm;
+            // Re-baseline the transport edge detector so the act of joining
+            // can't replay a stale peer start/stop as a fresh edge.
+            link_prime_transport();
+        }
+    }
+    bool want_sss = zt_config_globals.ableton_link_start_stop_sync != 0;
+    if (want_sss != be_sss_enabled()) {
+        be_sss_enable(want_sss);
+        if (want_sss) link_prime_transport();
+    }
+    // Bidirectional tempo. PULL: a peer's change follows into song->bpm (even
+    // stopped) -- not a file edit. PUSH: zt's own change proposes to peers.
+    // g_last_synced_bpm tells them apart; link_pump_tempo's rounded dedupe
+    // prevents ping-pong.
+    if (be_enabled() && ztPlayer) {
+        int link_bpm = 0;
+        if (link_pump_tempo(&link_bpm) && link_bpm) {
+            if (link_bpm > 500) link_bpm = 500;
+            if (link_bpm < 20)  link_bpm = 20;
+            if (link_bpm != song->bpm) {
+                song->bpm = link_bpm; ztPlayer->set_speed(); need_refresh++;
+            }
+            g_last_synced_bpm = song->bpm;
+        } else if (song->bpm != g_last_synced_bpm) {
+            link_set_tempo((double)song->bpm);
+            g_last_synced_bpm = song->bpm;
+        }
+    }
+    link_fire_quantized();
+    link_chase_phase();
+    // Follow a peer's transport: a peer start arms a quantized launch (same as
+    // local), a peer stop stops us. link_prime_transport swallows our own
+    // edges.
+    if (be_enabled() &&
+        zt_config_globals.ableton_link_start_stop_sync && ztPlayer) {
+        int want_play = -1;
+        if (link_poll_transport(&want_play)) {
+            if (want_play == 1) {
+                if (!ztPlayer->playing && !g_play_armed &&
+                    song->orderlist[0] != 0x100)
+                    link_arm_play(0, cur_edit_pattern, 1);
+            } else if (want_play == 0) {
+                g_play_armed = false;
+                if (ztPlayer->playing) { ztPlayer->stop(); need_refresh++; }
+            }
+        }
+    }
+    // Share transport changes the defer didn't initiate (song-end stop, F8
+    // pressed while armed, any direct ztPlayer->play/stop). Defer-initiated
+    // changes already notified at arm/follow time, so gate on the session's
+    // current state to avoid double commits.
+    if (be_enabled() &&
+        zt_config_globals.ableton_link_start_stop_sync) {
+        if (started && !be_playing())
+            be_set_playing(true);
+        if ((stopped || (stop_intent && !playing_now)) &&
+            be_playing())
+            be_set_playing(false);
+    }
+
+    // Re-sample after our own actions (the quantized fire, the peer-follow
+    // stop) so they never echo back as observed edges on the next pump --
+    // only transitions that happen OUTSIDE the pump count. Without this, our
+    // own fire's start edge replays one frame later and can override a peer
+    // stop that landed in between.
+    prev_playing    = (ztPlayer && ztPlayer->playing) ? 1 : 0;
+    last_stop_count = ztPlayer ? ztPlayer->stop_count : 0;
+}
+
+void zt_ableton_link_pump(void) {
+    if (!zt_ableton_link_available()) return;
+    link_pump_body();
+}

--- a/src/ableton_link.h
+++ b/src/ableton_link.h
@@ -1,0 +1,57 @@
+/*************************************************************************
+ * ableton_link.h
+ *
+ * zt <-> Ableton Link integration.
+ *
+ * Ableton Link (https://github.com/Ableton/link) keeps musical tempo — and
+ * optionally transport (play/stop) — in sync across applications on a local
+ * network (Ableton Live, and most modern DAWs / mobile music apps speak it).
+ * zTracker uses it to follow / drive a shared session tempo so it can jam
+ * alongside Live without a MIDI-clock cable.
+ *
+ * DESIGN: the integration OBSERVES the app instead of being notified by it.
+ * The per-frame pump watches the player (playing, stop_count) and the song
+ * generation, so plain ztPlayer->play()/stop() calls anywhere are shared
+ * with peers and a pending quantized start is cancelled when the context
+ * changes — call sites need no Link code. The one exception is
+ * zt_ableton_link_defer_play(), called by player::play() itself to arm a
+ * downbeat-quantized start when Link is enabled.
+ *
+ * THREADING: every function here must be called from the main/UI thread
+ * (the per-frame loop + UI handlers). The player's stop_count exists
+ * precisely so other threads never need to call in.
+ *************************************************************************/
+
+#ifndef ZT_ABLETON_LINK_H
+
+#define ZT_ABLETON_LINK_H
+
+#include <stddef.h>
+
+/* Call on zt startup */
+void   zt_ableton_link_startup(void);
+
+/* Leave the session and tear down. */
+void   zt_ableton_link_teardown(void);
+
+/* Call once per main loop. */
+void   zt_ableton_link_pump(void);
+
+/* Called by player::play() only: when Link is enabled, arm a start quantized
+ * to the next downbeat and return nonzero (play() returns; the pump fires
+ * play_immediately() at the downbeat). Returns 0 when Link is off: play() proceeds. */
+int    zt_ableton_link_defer_play(int row, int pattern, int pm);
+
+/* 1 when this build has Link compiled in, 0 for the stub. Lets the UI show
+ * "(not compiled in)" instead of a dead toggle. */
+int    zt_ableton_link_available(void);
+
+/* Remote peers currently in the session (excludes self). For the F11 status
+ * line. 0 in the stub / when not enabled. */
+size_t zt_ableton_link_num_peers(void);
+
+/* Current session tempo (cached value when not enabled). For the F11 status
+ * line. */
+double zt_ableton_link_get_tempo(void);
+
+#endif /* ZT_ABLETON_LINK_H */

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -219,6 +219,10 @@ ZTConf::ZTConf() {
     work_directory[0] = '\0';
     midi_in_sync = 0; // flag_midiinsync
     midi_in_sync_chase_tempo = 0; // off by default; requires midi_in_sync
+    ableton_link_enable = 0;            // Ableton Link off by default (no surprise LAN traffic)
+    ableton_link_start_stop_sync = 1;   // transport (play/stop) sharing on by default; only takes effect once ableton_link_enable is on
+    ableton_link_quantum = 4;           // one bar of 4/4
+    ableton_link_offset_ms = 0;         // fire quantized starts early by this much
     auto_send_panic = 1; // flag_autosendpanic
     highlight_increment = 8;
     lowlight_increment = 8;
@@ -353,6 +357,21 @@ int ZTConf::load()
   if (Config->get("send_panic_on_stop"))              auto_send_panic = getFlag("send_panic_on_stop");
   if (Config->get("midi_in_sync"))                    midi_in_sync = getFlag("midi_in_sync");
   if (Config->get("midi_in_sync_chase_tempo"))        midi_in_sync_chase_tempo = getFlag("midi_in_sync_chase_tempo");
+  if (Config->get("ableton_link_enable"))             ableton_link_enable = getFlag("ableton_link_enable");
+  if (Config->get("ableton_link_start_stop_sync"))    ableton_link_start_stop_sync = getFlag("ableton_link_start_stop_sync");
+  if (Config->get("ableton_link_quantum"))            ableton_link_quantum = atoi(Config->get("ableton_link_quantum"));
+  if (Config->get("ableton_link_offset_ms"))          ableton_link_offset_ms = atoi(Config->get("ableton_link_offset_ms"));
+
+  // Ableton Link wins if both Link and MIDI Sync are enabled
+  if (ableton_link_enable) {
+    midi_in_sync = 0;
+    midi_in_sync_chase_tempo = 0;
+  }
+
+  if (ableton_link_quantum < 1)  ableton_link_quantum = 4;
+  if (ableton_link_quantum > 16) ableton_link_quantum = 16;
+  if (ableton_link_offset_ms < 0)   ableton_link_offset_ms = 0;
+  if (ableton_link_offset_ms > 500) ableton_link_offset_ms = 500;
   
   full_screen = getFlag("fullscreen");                
   step_editing = getFlag("step_editing");
@@ -512,6 +531,13 @@ int ZTConf::save() {
         Config->set("midi_in_sync_chase_tempo","yes");
     else
         Config->set("midi_in_sync_chase_tempo","no");
+
+    Config->set("ableton_link_enable", ableton_link_enable ? "yes" : "no");
+    Config->set("ableton_link_start_stop_sync", ableton_link_start_stop_sync ? "yes" : "no");
+    sprintf(s, "%d", ableton_link_quantum);
+    Config->set("ableton_link_quantum", s);
+    sprintf(s, "%d", ableton_link_offset_ms);
+    Config->set("ableton_link_offset_ms", s);
 
     if (full_screen)
         Config->set("fullscreen","yes");

--- a/src/conf.h
+++ b/src/conf.h
@@ -70,6 +70,21 @@ class ZTConf {
         int autoload_ztfile;
         int midi_in_sync; // flag_midiinsync
         int midi_in_sync_chase_tempo; // slave bpm to incoming 0xF8 MIDI Clock
+
+        // Enables joining Ableton Link sessions and follow tempo
+        int ableton_link_enable;
+        int ableton_link_start_stop_sync;
+        // Bar length in beats (4 = one bar of 4/4) used for beat-phase alignment
+        // and quantized (bar-aligned) launch.
+        int ableton_link_quantum;
+        // ableton_link_offset_ms fires the quantized start that many ms
+        // BEFORE the Link downbeat, so notes rendered through a peer's
+        // monitored audio chain (e.g. Live's Overall Latency) SOUND on the
+        // grid. Link has no way to discover a peer's local audio latency, so
+        // this is a one-time per-rig setting.
+        // 0 = fire exactly on the beat.
+        // Recommended to set this to the audio latency value shown in Live settings
+        int ableton_link_offset_ms;
         int auto_send_panic; // flag_autosendpanic
         int highlight_increment;
         int lowlight_increment;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,7 @@
 #include "zt_crash.h"
 #include "midi_mappings.h"
 #include "ccizer.h"
+#include "ableton_link.h"
 
 #ifdef __APPLE__
 extern "C" void zt_macos_disable_cmd_q(void);
@@ -2617,6 +2618,8 @@ int postAction ()
     if (MidiOut) MidiOut->panic();
     if (clipboard) delete clipboard;
 
+    zt_ableton_link_teardown();
+
     zt_timer_stop(keytimer);
 
     if (UI_Toolbar) {
@@ -3014,6 +3017,11 @@ void mousedownbuttonhandler(SDL_MouseButtonEvent *e) {
 // and bMouseIsDown / MousePress* state the real SDL handlers use -- so widgets
 // can't tell a scripted click from a hardware one. With button == 0 it only
 // moves the cursor (for hover / drag-path setup).
+//
+// Sets LastX/LastY DIRECTLY (not via zt_update_mouse_position) because the
+// script speaks internal-resolution pixels -- the same space col()/row() and
+// checkclick() use -- whereas zt_update_mouse_position scales from *window*
+// coords and would double-map under a non-1 zoom.
 void zt_inject_mouse(int down, int button, int x, int y) {
     if (x < 0) x = 0;
     if (y < 0) y = 0;
@@ -3437,6 +3445,9 @@ int action(Screen *S)
     // nothing is armed (walks a 64-slot array, skips empty entries).
     zt_audition_env_pump();
 
+    // Ableton Link sync if enabled
+    zt_ableton_link_pump();
+
 #ifdef DEBUG
     playbuff1_bg->setvalue(ztPlayer->play_buffer[0]->size);
     playbuff2_bg->setvalue(ztPlayer->play_buffer[1]->size);
@@ -3723,6 +3734,8 @@ int initSDL(void)
   song = new zt_module(zt_config_globals.default_tpb, zt_config_globals.default_bpm);
 
   ztPlayer = new player(1,zt_config_globals.prebuffer_rows, song); // 1ms resolution;
+
+  zt_ableton_link_startup();   // construct Link, apply saved quantum/tempo, join if enabled
 
     ///////////////////////////////////////////////////////////////////////
     // Here we set the highlight and lowlight according to either specific
@@ -4234,6 +4247,10 @@ int main(int argc, char *argv[])
           MidiIn->AddDevice(idx);
           zt_config_globals.midi_in_sync             = 1;
           zt_config_globals.midi_in_sync_chase_tempo = 1;
+          // Explicit CLI intent wins the two-tempo-masters exclusion: clear
+          // the conf's Link flag so the first Link pump never joins (the join
+          // happens in the pump, after this point).
+          zt_config_globals.ableton_link_enable      = 0;
           fprintf(stderr, "zt: opened MIDI clock source [%d] %s "
                           "(sync + tempo chase enabled)\n",
                   idx, MidiIn->midiInDev[idx]->szName);

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -769,9 +769,16 @@ zt_module::~zt_module() {
 
 
 
+// Bumped on every zt_module::init() -- i.e. whenever the song context is
+// rebuilt (startup, File > New, song load). Observers (the Ableton Link
+// glue's pump) watch it to invalidate state that refers to the old song,
+// e.g. a pending quantized start.
+int zt_song_generation = 0;
+
 void zt_module::init(void)
 {
     int i;
+    zt_song_generation++;
     memset(title,0,ZTM_SONGTITLE_MAXLEN);
     memset(filename,0,ZTM_FILENAME_MAXLEN);
     

--- a/src/module.h
+++ b/src/module.h
@@ -344,6 +344,10 @@ class songmsg
 };
 
 
+// Bumped on every zt_module::init() (startup / File > New / song load).
+// Lets per-frame observers notice the song context was rebuilt.
+extern int zt_song_generation;
+
 class zt_module
 {
     public:

--- a/src/playback.cpp
+++ b/src/playback.cpp
@@ -40,6 +40,7 @@
 #include "zt.h"
 #include "ccenv_advance.h"
 #include "sysex_macro.h"
+#include "ableton_link.h"
 #include <algorithm>
 #include <stdint.h>
 
@@ -72,7 +73,7 @@ void CALLBACK player_callback(UINT wTimerID, UINT msg, DWORD_PTR dwUser, DWORD_P
 
   ztPlayer->counter += ztPlayer->wTimerRes*1000;
 
-  if (ztPlayer->counter >= (ztPlayer->subtick_len_ms+ztPlayer->subtick_add)) {
+  if (ztPlayer->counter >= (ztPlayer->subtick_len_ms+ztPlayer->subtick_add+ztPlayer->chase_adj)) {
 
     if (zt_config_globals.midi_in_sync) {
 
@@ -92,6 +93,12 @@ void CALLBACK player_callback(UINT wTimerID, UINT msg, DWORD_PTR dwUser, DWORD_P
     }
 
     ztPlayer->counter = 0;
+    ztPlayer->played_subticks++;
+
+    ztPlayer->chase_err_us += ztPlayer->chase_skew_us;
+    if (ztPlayer->chase_err_us >= 1000)       { ztPlayer->chase_adj = 1000;  ztPlayer->chase_err_us -= 1000; }
+    else if (ztPlayer->chase_err_us <= -1000) { ztPlayer->chase_adj = -1000; ztPlayer->chase_err_us += 1000; }
+    else                                      { ztPlayer->chase_adj = 0; }
 
     if (ztPlayer->play_buffer[0]->ready_to_play && ztPlayer->play_buffer[1]->ready_to_play) SDL_Delay(0);
 
@@ -250,6 +257,11 @@ player::player(int res,int prebuffer_rows, zt_module *ztm) {
     this->song = ztm;
     this->wTimerRes = res;
     this->fillbuff = this->playing = this->counter = this->wTimerID = 0;
+    this->stop_count = 0;
+    this->played_subticks = 0;
+    this->chase_skew_us = 0;
+    this->chase_err_us = 0;
+    this->chase_adj = 0;
     this->ztTimerID = 0;
     this->playback_start_ms = 0;
 //  this->hr_timer = new hires_timer;
@@ -547,9 +559,13 @@ void player::prepare_play(int row, int pattern, int pm, int loopmode)
     cur_row = row-1;
     cur_pattern = pattern;
 
-    cur_subtick = 0;        
+    cur_subtick = 0;
     counter = 0;
     clock_count = 0;
+    played_subticks = 0;
+    chase_skew_us = 0;
+    chase_err_us = 0;
+    chase_adj = 0;
 
     mctr = 0;
 
@@ -608,14 +624,15 @@ void player::prepare_play(int row, int pattern, int pm, int loopmode)
 // ------------------------------------------------------------------------------------------------
 //
 //
-void player::play(int row, int pattern,int pm, int loopmode)
+void player::play(int row, int pattern, int pm, int loopmode)
 {
-// <Manu> esta comprobacion no es necesaria ? [EN: is this check unnecessary?]
+    if (zt_ableton_link_defer_play(row, pattern, pm))
+        return;   // armed: the Link glue calls play_immediately() at the next downbeat
+    play_immediately(row, pattern, pm, loopmode);
+}
 
-/*    if (song->orderlist[pattern] == 0x100) 
-        return;
-*/
-
+void player::play_immediately(int row, int pattern,int pm, int loopmode)
+{
 
   if(song->orderlist[pattern] == 0x101) {
 
@@ -631,12 +648,10 @@ void player::play(int row, int pattern,int pm, int loopmode)
 
   prepare_play(row,pattern,pm,loopmode);
 
-
   //  play_buffer[cur_buf]->reset();
   //  play_buffer[cur_buf]->insert(0,ET_MSTART,0); // First event is MIDI Start
 
   if(song->flag_SendMidiStopStart) MidiOut->sendGlobal(0xFA);
-  //SDL_Delay(20);
 
   starts = 1;
 
@@ -756,6 +771,7 @@ void player::play_current_note()
 //
 void player::stop(void)
 {
+    stop_count++;
     playing = 0;
     pinit = 0;
     lock_mutex(song->hEditMutex);

--- a/src/playback.h
+++ b/src/playback.h
@@ -187,6 +187,29 @@ class player {
         int subtick_mode,clock_mode;
 
         int playing;
+        // Monotonic count of stop() calls. Observers (the Ableton Link glue's
+        // per-frame pump) watch it to react to ANY stop -- including the
+        // counter-thread song-end stop and prepare_play's internal restart --
+        // without the player knowing about them. Plain int on purpose: bumped
+        // from the timer thread, read advisorily from the main thread.
+        int stop_count;
+        // Phase-chase observer surface, same contract as stop_count: the
+        // player stays sync-protocol-agnostic and just exposes its position
+        // plus one advisory knob. played_subticks counts subticks since
+        // play start (timer thread writes, pump reads); chase_skew_us is a
+        // signed per-subtick length adjustment in microseconds (pump writes,
+        // timer thread reads) that an external phase lock uses to slew the
+        // engine onto a shared timeline. 0 = run at nominal speed.
+        //
+        // The 1 ms timer can't resolve a sub-ms threshold change (the
+        // subtick delta-sigma would re-absorb it), so the skew accrues in
+        // chase_err_us per subtick and pays out as whole +/-1 ms quanta in
+        // chase_adj -- average added length == chase_skew_us exactly.
+        // chase_err_us/chase_adj are timer-thread-private.
+        int played_subticks;
+        int chase_skew_us;
+        int chase_err_us;
+        int chase_adj;
         int fillbuff;
         int light_counter;
         int skip;
@@ -218,6 +241,9 @@ class player {
         
         void prepare_play(int row, int pattern,int pm, int loopmode);
         void play(int row, int pattern, int pm, int loopmode=1);
+        // Immediate start, bypassing play()'s Ableton Link quantize defer.
+        // Only the Link glue's downbeat fire should call this directly.
+        void play_immediately(int row, int pattern, int pm, int loopmode=1);
         void play_current_row();
         void play_current_note();
         void stop(void);

--- a/src/zt_headless.cpp
+++ b/src/zt_headless.cpp
@@ -18,6 +18,7 @@
 #include <string.h>
 
 #include "keybuffer.h"
+#include "lua_engine.h"
 
 // Pulled from main.cpp -- the global key ring and the "user requested
 // quit" flag. We don't pull main.cpp's full surface in here; just the
@@ -211,7 +212,21 @@ static void exec_command(SDL_Surface *frame_surface, const char *cmd, char *args
         KBKey k = 0;
         KBMod m = 0;
         if (!parse_keychord(args, &k, &m)) return;
-        Keys.insert(k, m, 0, 0);
+        // Letters/digits also carry their scancode: note entry (keyjazz)
+        // and other layout-position paths match on Keys.getcode(), not the
+        // keycode, and a real SDL keydown always provides both.
+        unsigned int code = 0;
+        if (k >= 'a' && k <= 'z')      code = SDL_SCANCODE_A + (unsigned int)(k - 'a');
+        else if (k >= '1' && k <= '9') code = SDL_SCANCODE_1 + (unsigned int)(k - '1');
+        else if (k == '0')             code = SDL_SCANCODE_0;
+        Keys.insert(k, m, 0, code);
+        return;
+    }
+    // `lua <code>` -- run a line through the embedded Lua engine, same as
+    // typing it into the Ctrl+Alt+L console. Lets scripts set up state the
+    // key/mouse surface can't reach (e.g. zt.instrument(0).device = 1).
+    if (!strcmp(cmd, "lua")) {
+        g_lua.execute(args);
         return;
     }
     // Mouse commands. All take pixel coordinates in zt's internal resolution

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -147,6 +147,17 @@ target_include_directories(test_keyjazz_map PRIVATE
 target_compile_features(test_keyjazz_map PRIVATE cxx_std_17)
 add_test(NAME keyjazz_map COMMAND test_keyjazz_map)
 
+add_executable(test_ableton_link
+    test_ableton_link.cpp
+)
+target_include_directories(test_ableton_link PRIVATE
+    "${CMAKE_SOURCE_DIR}/src"
+    "${CMAKE_SOURCE_DIR}/tests"
+)
+target_compile_definitions(test_ableton_link PRIVATE ZT_TEST_NO_SDL)
+target_compile_features(test_ableton_link PRIVATE cxx_std_17)
+add_test(NAME ableton_link COMMAND test_ableton_link)
+
 # Full Lua API self-test. Unlike the SDL-free unit tests above, this drives
 # the REAL zt binary headless (--lua-test) against a scratch song, running
 # lua/selftest.lua and asserting exit 0 (every check passed). Covers the

--- a/tests/test_ableton_link.cpp
+++ b/tests/test_ableton_link.cpp
@@ -1,0 +1,477 @@
+// Unit tests for src/ableton_link.cpp.
+//
+// Compiled WITHOUT ZT_HAS_ABLETON_LINK and WITH ZT_TEST_NO_SDL, so the stub
+// backend compiles against the fake app environment in zt_link_stub.h. Two
+// layers are exercised:
+//
+//   1. The shared contract logic (tempo clamp + rounded dedupe, transport
+//      edge detect, prime, quantum clamp) -- one copy serves both the real
+//      and stub backends, so a regression here breaks every build.
+//   2. The app integration (startup, defer_play, the pump body): quantized
+//      arm/fire via the scriptable stub phase, armed-start cancellation on
+//      stop_count / song-generation changes, playing-edge sharing, peer
+//      transport follow, and bidirectional tempo against a recording fake
+//      player.
+//
+// Because this file #includes ableton_link.cpp, the file-statics
+// (g_play_armed, g_stub_phase, g_cached_bpm, ...) are directly readable and
+// pokable -- no test-only API needed. link_pump_body() keeps its baselines in
+// function-statics that persist across calls, so the app-level tests run in
+// a deliberate order and absorb pending edges with an extra pump where noted.
+//
+// The real Link-backed behaviour (peer discovery, beat clock, transport over
+// the network) needs a live LAN session and is covered by the headless
+// harness instead.
+
+#include "ableton_link.h"
+#include "ableton_link.cpp"
+
+#include <stdio.h>
+
+static int failures = 0;
+static int checks   = 0;
+
+#define CHECK(expr) do {                                                \
+    checks++;                                                           \
+    if (!(expr)) { failures++;                                          \
+        fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #expr); \
+    }                                                                   \
+} while(0)
+
+// --- shared contract logic ---------------------------------------------------
+
+static void test_available_is_false_in_stub() {
+    CHECK(zt_ableton_link_available() == 0);
+}
+
+static void test_init_shutdown_idempotent() {
+    link_init();
+    link_init();
+    be_shutdown();
+    be_shutdown();   // shutdown without a live session
+    link_init();
+    CHECK(zt_ableton_link_available() == 0);
+}
+
+static void test_tempo_cache_roundtrip_and_clamp() {
+    link_init();
+    link_set_tempo(140.0);
+    CHECK(zt_ableton_link_get_tempo() == 140.0);
+    link_set_tempo(90.0);
+    CHECK(zt_ableton_link_get_tempo() == 90.0);
+    // Clamp: below floor (20) and above ceiling (999).
+    link_set_tempo(5.0);
+    CHECK(zt_ableton_link_get_tempo() == 20.0);
+    link_set_tempo(5000.0);
+    CHECK(zt_ableton_link_get_tempo() == 999.0);
+}
+
+static void test_pump_tempo_change_dedupe() {
+    link_init();              // resets the "last pumped" sentinel
+    be_enable(true);          // pump_tempo reports only while enabled
+    link_set_tempo(120.0);
+    int bpm = -1;
+    // First pump after init reports the current value (sentinel was -1).
+    CHECK(link_pump_tempo(&bpm) == true);
+    CHECK(bpm == 120);
+    // No change -> no report.
+    bpm = -1;
+    CHECK(link_pump_tempo(&bpm) == false);
+    CHECK(bpm == -1);               // left untouched
+    // Change -> report once.
+    link_set_tempo(123.4);          // rounds to 123
+    CHECK(link_pump_tempo(&bpm) == true);
+    CHECK(bpm == 123);
+    CHECK(link_pump_tempo(&bpm) == false);
+    // Disabled -> never reports.
+    be_enable(false);
+    link_set_tempo(99.0);
+    CHECK(link_pump_tempo(&bpm) == false);
+}
+
+static void test_transport_cache_and_edge_detect() {
+    link_init();              // resets the transport edge sentinel
+    be_set_playing(false);
+    CHECK(be_playing() == false);
+
+    be_set_playing(true);
+    CHECK(be_playing() == true);
+
+    int want = -1;
+    // First poll after the start: edge from -1 sentinel to 1.
+    CHECK(link_poll_transport(&want) == true);
+    CHECK(want == 1);
+    // No change -> no edge.
+    want = -1;
+    CHECK(link_poll_transport(&want) == false);
+    CHECK(want == -1);
+    // Stop -> edge to 0, reported once.
+    be_set_playing(false);
+    CHECK(link_poll_transport(&want) == true);
+    CHECK(want == 0);
+    CHECK(link_poll_transport(&want) == false);
+}
+
+static void test_set_quantum_clamps() {
+    link_set_quantum(0.0);
+    CHECK(g_quantum == 1.0);
+    link_set_quantum(100.0);
+    CHECK(g_quantum == 16.0);
+    link_set_quantum(4.0);
+    CHECK(g_quantum == 4.0);
+}
+
+static void test_prime_transport_suppresses_spurious_edge() {
+    // Enabling start/stop sync must not fire a transport edge just because
+    // the sentinel was stale. Priming to the current state suppresses that
+    // first spurious edge; genuine later changes still fire.
+    link_init();              // g_last_transport sentinel = -1
+    be_set_playing(true);
+    link_prime_transport();   // baseline to current (playing)
+    int want = -1;
+    CHECK(link_poll_transport(&want) == false);  // no spurious edge
+    CHECK(want == -1);                            // left untouched
+    // A real change after priming still edges.
+    be_set_playing(false);
+    CHECK(link_poll_transport(&want) == true);
+    CHECK(want == 0);
+}
+
+// --- app integration ---------------------------------------------------------
+// These drive link_pump_body() (the pump minus its availability gate, which
+// is compile-time 0 in this TU and asserted separately below). Pump baselines
+// live in function-statics, so order matters and edges are absorbed with an
+// extra pump where noted.
+
+static void test_startup_snaps_conf_flag_in_stub() {
+    // The production "stub can't join" guarantee: available()==0 makes
+    // startup() clear the conf flag, so the pump never enables.
+    zt_config_globals.ableton_link_enable = 1;
+    song->bpm = 138;
+    zt_ableton_link_startup();
+    CHECK(zt_config_globals.ableton_link_enable == 0);
+    CHECK(zt_ableton_link_get_tempo() == 138.0);   // seeded from the song
+    CHECK(be_enabled() == false);
+}
+
+static void test_public_pump_is_inert_in_stub_build() {
+    // Even a hand-edited conf flag must not reach be_enable through the
+    // PUBLIC pump in a stub build -- the availability gate covers it.
+    zt_config_globals.ableton_link_enable = 1;
+    zt_ableton_link_pump();
+    CHECK(be_enabled() == false);
+    zt_config_globals.ableton_link_enable = 0;
+}
+
+static void test_defer_play_disabled_passes_through() {
+    be_enable(false);
+    CHECK(zt_ableton_link_defer_play(3, 9, 2) == 0);
+    CHECK(g_play_armed == false);
+    CHECK(ztPlayer->play_immediately_calls == 0);   // play() itself would start
+}
+
+static void test_pump_enable_transition_seeds_song_tempo() {
+    song->bpm    = 138;
+    g_cached_bpm = 87.0;   // stale wrapper cache from an earlier session
+    zt_config_globals.ableton_link_enable          = 1;
+    zt_config_globals.ableton_link_start_stop_sync = 1;
+    zt_config_globals.ableton_link_quantum         = 8;
+    link_pump_body();
+    CHECK(be_enabled() == true);
+    CHECK(zt_ableton_link_get_tempo() == 138.0);   // seeded, not the stale 87
+    CHECK(g_last_synced_bpm == 138);
+    CHECK(g_quantum == 8.0);                       // conf quantum reconciled
+    // Stable: a second pump must not move anything.
+    link_pump_body();
+    CHECK(song->bpm == 138);
+    CHECK(ztPlayer->set_speed_calls == 0);
+}
+
+static void test_defer_arm_and_quantized_fire() {
+    g_stub_phase = 1.0;
+    status_change = 0;
+    CHECK(zt_ableton_link_defer_play(5, 7, 2) == 1);
+    CHECK(g_play_armed == true);
+    CHECK(statusmsg != nullptr);          // "waiting for downbeat"
+    CHECK(status_change == 1);            // status repaint is gated on this
+    CHECK(be_playing() == true);          // peers told at arm time
+    // Phase advancing within the bar: no fire.
+    g_stub_phase = 2.5;
+    link_pump_body();
+    CHECK(g_play_armed == true);
+    CHECK(ztPlayer->play_immediately_calls == 0);
+    // Phase wraps past the downbeat: fire with the armed row/pat/pm.
+    g_stub_phase = 0.3;
+    link_pump_body();
+    CHECK(g_play_armed == false);
+    CHECK(ztPlayer->play_immediately_calls == 1);
+    CHECK(ztPlayer->last_row == 5);
+    CHECK(ztPlayer->last_pat == 7);
+    CHECK(ztPlayer->last_pm  == 2);
+    CHECK(ztPlayer->playing  == 1);
+    CHECK(g_chase_valid == true);             // fire anchored the phase chase
+    CHECK(g_chase_anchor == g_stub_beats);
+    link_pump_body();   // absorb the started edge (already session-playing)
+}
+
+static void test_offset_fires_early() {
+    // Link Offset: with 171 ms configured at 120 BPM, the fire must happen
+    // when the remaining time to the downbeat drops inside the offset --
+    // not at the phase wrap.
+    ztPlayer->playing = 0;
+    zt_config_globals.ableton_link_quantum   = 4;     // earlier test set 8
+    zt_config_globals.ableton_link_offset_ms = 171;
+    link_pump_body();                       // absorb stop edge, apply quantum
+    g_cached_bpm = 120.0;                   // known tempo for the ms math
+    g_stub_phase = 1.0;
+    int plays = ztPlayer->play_immediately_calls;
+    CHECK(zt_ableton_link_defer_play(0, 0, 1) == 1);
+    g_stub_phase = 3.0;                     // 500 ms remain: outside offset
+    link_pump_body();
+    CHECK(g_play_armed == true);
+    CHECK(ztPlayer->play_immediately_calls == plays);
+    g_stub_phase = 3.7;                     // 150 ms remain: inside offset
+    link_pump_body();
+    CHECK(g_play_armed == false);
+    CHECK(ztPlayer->play_immediately_calls == plays + 1);
+    zt_config_globals.ableton_link_offset_ms = 0;
+    link_pump_body();                       // absorb the start edge
+}
+
+static void test_stop_count_cancels_arm_and_pushes_stop() {
+    // F8 while armed: the player just counts the stop; the pump must both
+    // cancel the pending start and tell peers to stop.
+    ztPlayer->playing = 0;
+    link_pump_body();                       // absorb the stopped edge
+    g_stub_phase = 1.0;
+    int plays = ztPlayer->play_immediately_calls;
+    CHECK(zt_ableton_link_defer_play(0, 0, 1) == 1);
+    CHECK(g_play_armed == true);
+    CHECK(be_playing() == true);
+    ztPlayer->stop();                       // F8 -- plain player call
+    link_pump_body();
+    CHECK(g_play_armed == false);           // start cancelled
+    CHECK(be_playing() == false);           // peers stopped
+    CHECK(ztPlayer->play_immediately_calls == plays);   // never fired
+    link_pump_body();                       // absorb our own stop edge
+}
+
+static void test_song_generation_cancels_arm() {
+    g_stub_phase = 1.0;
+    int plays = ztPlayer->play_immediately_calls;
+    CHECK(zt_ableton_link_defer_play(0, 0, 1) == 1);
+    CHECK(g_play_armed == true);
+    zt_song_generation++;                   // File > New / song load
+    link_pump_body();
+    CHECK(g_play_armed == false);
+    CHECK(ztPlayer->play_immediately_calls == plays);   // stale start never fired
+    be_set_playing(false);                  // tidy session transport
+    link_prime_transport();
+    link_pump_body();
+}
+
+static void test_playing_edges_push_to_session() {
+    // A play that did not go through defer (and a stop) must still be shared.
+    CHECK(be_playing() == false);
+    ztPlayer->playing = 1;                  // direct start
+    link_pump_body();
+    CHECK(be_playing() == true);            // started edge pushed
+    ztPlayer->playing = 0;                  // direct stop (e.g. song end)
+    link_pump_body();
+    CHECK(be_playing() == false);           // stopped edge pushed
+    link_pump_body();                       // absorb the poll edges
+}
+
+static void test_tempo_pull_from_session() {
+    int speed_calls = ztPlayer->set_speed_calls;
+    g_cached_bpm = 87.4;                    // a peer committed 87.4
+    link_pump_body();
+    CHECK(song->bpm == 87);                 // rounded follow
+    CHECK(ztPlayer->set_speed_calls == speed_calls + 1);
+    g_cached_bpm = 600.0;                   // beyond zt's ceiling
+    link_pump_body();
+    CHECK(song->bpm == 500);                // clamped to chase range
+    CHECK(ztPlayer->set_speed_calls == speed_calls + 2);
+    link_pump_body();                       // stable: no re-apply
+    CHECK(ztPlayer->set_speed_calls == speed_calls + 2);
+}
+
+static void test_tempo_push_to_session() {
+    int speed_calls = ztPlayer->set_speed_calls;
+    song->bpm = 150;                        // user edit on F11
+    link_pump_body();
+    CHECK(zt_ableton_link_get_tempo() == 150.0);   // proposed to peers
+    CHECK(g_last_synced_bpm == 150);
+    link_pump_body();                       // no ping-pong
+    CHECK(song->bpm == 150);
+    CHECK(ztPlayer->set_speed_calls == speed_calls);
+}
+
+static void test_peer_transport_follow() {
+    ztPlayer->playing = 0;
+    be_set_playing(false);
+    link_prime_transport();
+    link_pump_body();                       // settle
+    song->orderlist[0] = 0;                 // valid first order
+    cur_edit_pattern   = 3;
+    g_stub_playing = true;                  // peer pressed play
+    link_pump_body();
+    CHECK(g_play_armed == true);            // follows as a quantized launch
+    CHECK(g_play_pat == 3);
+    CHECK(g_play_pm  == 1);
+    g_stub_phase = 1.0; link_pump_body();   // wait inside the bar
+    g_stub_phase = 0.2; link_pump_body();   // downbeat
+    CHECK(ztPlayer->playing == 1);
+    int stops = ztPlayer->stop_calls;
+    g_stub_playing = false;                 // peer pressed stop
+    link_pump_body();
+    CHECK(g_play_armed == false);
+    CHECK(ztPlayer->stop_calls == stops + 1);
+    CHECK(ztPlayer->playing == 0);
+    link_pump_body();                       // absorb our stop's edges
+}
+
+// --- phase chase ---------------------------------------------------------
+// Driven through link_chase_phase() directly with hand-set engine state.
+// Stub nominal: 120 BPM -> exact subtick 5208.33 us, engine avg 5208 us,
+// so the rate term alone rounds to 0 and the feedback bound is ~15.6 us.
+
+static void chase_reset_engine(double session_bpm) {
+    be_enable(true);
+    g_cached_bpm = session_bpm;
+    zt_config_globals.ableton_link_offset_ms = 0;
+    ztPlayer->playing         = 1;
+    ztPlayer->bpm             = 120;
+    ztPlayer->subtick_len_ms  = 5000;
+    ztPlayer->subtick_len_mms = 208;
+    ztPlayer->played_subticks = 0;
+    ztPlayer->chase_skew_us   = 0;
+    g_stub_beats  = 100.0;
+    g_chase_valid = false;
+}
+
+static void test_chase_anchors_then_locks_at_zero_error() {
+    chase_reset_engine(120.0);
+    link_chase_phase();                       // first call only anchors
+    CHECK(g_chase_valid == true);
+    CHECK(ztPlayer->chase_skew_us == 0);
+    g_stub_beats = 101.0;                     // one beat of session time...
+    ztPlayer->played_subticks = 96;           // ...and the engine kept up
+    link_chase_phase();
+    CHECK(ztPlayer->chase_skew_us == 0);      // rate term 0.33us rounds away
+}
+
+static void test_chase_feedback_sign_and_clamp() {
+    chase_reset_engine(120.0);
+    link_chase_phase();                       // anchor at beats=100
+    g_stub_beats = 101.0;
+    // Small error (inside 10 ms): steady-state tier, 0.3% bound (~15.6 us).
+    ztPlayer->played_subticks = 95;           // 1 subtick (~5 ms) BEHIND
+    link_chase_phase();
+    CHECK(ztPlayer->chase_skew_us < 0);       // shorter subticks to catch up
+    CHECK(ztPlayer->chase_skew_us >= -16);
+    // Large error (a deliberate move): 12% tier (~625 us).
+    ztPlayer->played_subticks = 48;           // half a beat behind
+    link_chase_phase();
+    CHECK(ztPlayer->chase_skew_us < -16);     // beyond the steady-state tier
+    CHECK(ztPlayer->chase_skew_us >= -626);   // clamped at 12%
+    ztPlayer->played_subticks = 144;          // half a beat AHEAD
+    link_chase_phase();
+    CHECK(ztPlayer->chase_skew_us > 16);      // longer subticks to fall back
+    CHECK(ztPlayer->chase_skew_us <= 626);
+}
+
+static void test_chase_live_offset_shifts_setpoint() {
+    chase_reset_engine(120.0);
+    link_chase_phase();                       // anchor at beats=100, offset 0
+    g_stub_beats = 101.0;
+    ztPlayer->played_subticks = 96;           // locked, zero error
+    link_chase_phase();
+    CHECK(ztPlayer->chase_skew_us == 0);
+    // User drags the F11 slider to 100 ms while playing: the setpoint moves
+    // 100 ms earlier, the engine is suddenly "behind" and must speed up at
+    // the deliberate-move tier.
+    zt_config_globals.ableton_link_offset_ms = 100;
+    link_chase_phase();
+    CHECK(ztPlayer->chase_skew_us < -16);
+    CHECK(ztPlayer->chase_skew_us >= -626);
+    // Catching up restores lock: advance the engine by the 100 ms the new
+    // setpoint demands (100 ms at 120 BPM = 0.2 beats = 19.2 subticks).
+    ztPlayer->played_subticks = 96 + 19;
+    link_chase_phase();
+    CHECK(ztPlayer->chase_skew_us >= -16);    // back inside steady-state
+    zt_config_globals.ableton_link_offset_ms = 0;
+}
+
+static void test_chase_fractional_tempo_rate_term() {
+    chase_reset_engine(119.6);                // session fractional, zt shows 120
+    link_chase_phase();                       // anchor
+    g_stub_beats += 1.0;                      // engine tracked the session
+    ztPlayer->played_subticks += 96;          // exactly: zero position error
+    link_chase_phase();
+    // exact subtick at 119.6 = 5225.75us vs engine avg 5208us -> +17.75
+    CHECK(ztPlayer->chase_skew_us >= 17 && ztPlayer->chase_skew_us <= 19);
+}
+
+static void test_chase_pauses_on_rate_divergence() {
+    chase_reset_engine(120.0);
+    link_chase_phase();
+    CHECK(g_chase_valid == true);
+    ztPlayer->bpm = 90;                       // Fxx took the song elsewhere
+    link_chase_phase();
+    CHECK(ztPlayer->chase_skew_us == 0);
+    CHECK(g_chase_valid == false);
+    ztPlayer->bpm = 120;                      // rates agree again
+    link_chase_phase();                       // re-anchors from current pos
+    CHECK(g_chase_valid == true);
+    link_chase_phase();
+    CHECK(ztPlayer->chase_skew_us == 0);      // no position jump
+}
+
+static void test_chase_zero_skew_when_stopped() {
+    chase_reset_engine(120.0);
+    ztPlayer->chase_skew_us = 77;
+    ztPlayer->playing = 0;
+    link_chase_phase();
+    CHECK(ztPlayer->chase_skew_us == 0);
+}
+
+static void test_peer_start_respects_empty_orderlist() {
+    song->orderlist[0] = 0x100;             // empty song: nothing to launch
+    g_stub_playing = true;
+    link_pump_body();
+    CHECK(g_play_armed == false);
+    g_stub_playing = false;
+    link_pump_body();
+}
+
+int main(void) {
+    test_available_is_false_in_stub();
+    test_init_shutdown_idempotent();
+    test_tempo_cache_roundtrip_and_clamp();
+    test_pump_tempo_change_dedupe();
+    test_transport_cache_and_edge_detect();
+    test_set_quantum_clamps();
+    test_prime_transport_suppresses_spurious_edge();
+    test_startup_snaps_conf_flag_in_stub();
+    test_public_pump_is_inert_in_stub_build();
+    test_defer_play_disabled_passes_through();
+    test_pump_enable_transition_seeds_song_tempo();
+    test_defer_arm_and_quantized_fire();
+    test_offset_fires_early();
+    test_stop_count_cancels_arm_and_pushes_stop();
+    test_song_generation_cancels_arm();
+    test_playing_edges_push_to_session();
+    test_tempo_pull_from_session();
+    test_tempo_push_to_session();
+    test_peer_transport_follow();
+    test_peer_start_respects_empty_orderlist();
+    test_chase_anchors_then_locks_at_zero_error();
+    test_chase_feedback_sign_and_clamp();
+    test_chase_live_offset_shifts_setpoint();
+    test_chase_fractional_tempo_rate_term();
+    test_chase_pauses_on_rate_divergence();
+    test_chase_zero_skew_when_stopped();
+    printf("ableton_link (stub): %d checks, %d failures\n", checks, failures);
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/zt_link_stub.h
+++ b/tests/zt_link_stub.h
@@ -1,0 +1,74 @@
+// Minimal stand-in for zt.h, used when src/ableton_link.cpp is compiled into
+// the unit test (ZT_TEST_NO_SDL). Mirrors exactly the declarations the Link
+// integration uses -- a recording fake player, a song with bpm + orderlist,
+// the three ableton_link_* conf fields, and the page-refresh globals -- so
+// the test can drive the full pump/defer logic without SDL or the real app.
+// Same pattern as tests/sdl_stub.h (see CLAUDE.md "Test harness").
+//
+// Definitions (not just declarations) live here: the test is a single
+// translation unit that includes ableton_link.cpp, which includes this.
+#ifndef ZT_LINK_STUB_H
+#define ZT_LINK_STUB_H
+
+struct zt_module {
+    int bpm = 120;
+    int orderlist[256] = {0};   // 0x100 = Break (end of song)
+};
+
+static zt_module  g_test_song;
+static zt_module *song = &g_test_song;
+
+struct player {
+    int playing    = 0;
+    int stop_count = 0;
+
+    // Phase-chase surface (mirrors src/playback.h). 120 BPM nominal:
+    // 60e6/(96*120) = 5208 us -> ms part 5000, mms remainder 208.
+    int bpm             = 120;
+    int subtick_len_ms  = 5000;
+    int subtick_len_mms = 208;
+    int played_subticks = 0;
+    int chase_skew_us   = 0;
+
+    // Recording fakes: the test asserts on these.
+    int play_immediately_calls = 0;
+    int last_row = -1, last_pat = -1, last_pm = -1;
+    int stop_calls      = 0;
+    int set_speed_calls = 0;
+
+    void play_immediately(int row, int pattern, int pm, int loopmode = 1) {
+        (void)loopmode;
+        play_immediately_calls++;
+        last_row = row; last_pat = pattern; last_pm = pm;
+        playing = 1;
+        bpm = song->bpm;        // mirrors prepare_play() adopting the song tempo
+        played_subticks = 0;    // mirrors prepare_play() resetting position
+    }
+    void stop(void) {
+        stop_count++;
+        stop_calls++;
+        playing = 0;
+    }
+    // Mirrors the real set_speed(): adopt the song tempo as the engine's
+    // nominal rate (the chase's rate-agreement guard reads it).
+    void set_speed(void) { set_speed_calls++; bpm = song->bpm; }
+};
+
+struct zt_conf {
+    int ableton_link_enable          = 0;
+    int ableton_link_start_stop_sync = 0;
+    int ableton_link_quantum         = 4;
+    int ableton_link_offset_ms       = 0;
+};
+
+static player    g_test_player;
+static player    *ztPlayer = &g_test_player;
+static zt_conf    zt_config_globals;
+
+static const char *statusmsg          = nullptr;
+static int         status_change      = 0;
+static int         need_refresh       = 0;
+static int         cur_edit_pattern   = 0;
+static int         zt_song_generation = 0;
+
+#endif /* ZT_LINK_STUB_H */


### PR DESCRIPTION
## Summary

zt can join an [Ableton Link](https://github.com/Ableton/link) session on the local network and stay tempo- and transport-locked with Ableton Live and any other Link peer — no MIDI clock cable. Off by default; toggled from F11.

- **Tempo, both directions.** zt follows the session tempo (even while stopped, so play starts in sync); editing BPM in F11 proposes it to every peer. Saving preserves the followed tempo.
- **Quantized starts.** With Link on, any play (F5–F7, ESC menu, Lua, a peer pressing play) arms and fires on the next Link downbeat, Live-style; bar length = `ableton_link_quantum` (default 4).
- **Transport sharing (opt-in, default on).** F5/F8 start/stop the session; a peer's play/stop drives zt. Stops are *observed*, not wired: the player exposes `stop_count`/`playing` and `module::init()` bumps a song generation, so plain `ztPlayer->stop()` anywhere — including the counter-thread song-end stop — notifies peers and cancels a pending armed start. No call site carries Link code; the one hook is `player::play()` asking `zt_ableton_link_defer_play()` whether to arm.
- **Phase chase.** While playing, zt phase-locks to Link's absolute beat timeline instead of free-running: a closed feedback loop (exact-rate term for the fractional session tempo + bounded P feedback) slews the subtick length, paid out in whole-ms delta-sigma quanta the 1 ms scheduler can resolve. Fractional tempos, engine rounding, and cross-machine clock drift cannot accumulate. Pauses itself while Fxx deliberately diverges the song rate.
- **Link Offset (ms).** Plays up to 500 ms early so notes monitored through a peer DAW's audio chain (e.g. Live's Overall Latency, which Link cannot discover) *sound* on the grid. Adjustable live during playback — the chase slews onto the new value in about a second, so it dials in by ear.
- **Architecture:** one new TU, `src/ableton_link.{h,cpp}` (the only file including `<ableton/Link.hpp>`): stub-or-real backend primitives behind `ZT_HAS_ABLETON_LINK`, shared contract logic, app integration. Public API is 7 functions. Link-less builds (MinGW/XP, MSVC CI) compile the stub; `extlibs/link/` is fetched by `.github/scripts/fetch-ableton-link.sh` (gitignored, vendored at build time).
- Mutually exclusive with MIDI In Sync (both directions, enforced in UI + conf load + `--midi-clock` CLI).

## Measured (Link peer + CoreMIDI probe harness)

- zt's MIDI leaves within **±5 ms** of the session beat grid; the chase pulls a run to ±2 ms.
- 90 s at session tempo **120.4** (worst case for the int-BPM engine): holds **±7 ms** end to end (~200 ms drift without the chase).
- 171 ms offset: notes land 165 ms early and stay **pinned ±4 ms** for a full run; mid-play offset moves lock in **~1.4 s**.

## Test plan

- [x] 14 ctest suites pass, including the new `test_ableton_link` (~110 checks: stub contract, defer/arm/fire, offset early-fire, stop/generation cancellation, tempo pull/push, peer follow, chase controller) — hermetic, no SDL or Link needed
- [x] Headless harness scenarios: quantized fire on-grid, F8 cancels armed start, join adopts an established session's tempo, F11 mutual-exclusion repaints, arm status message after page switch
- [x] Long-run drift, fractional tempo, and offset measurements above
- [x] Manual validation against Ableton Live (tempo both ways, transport both ways, offset dialing by ear)
- [ ] Manuel: review + cross-platform build sanity (MinGW/MSVC build the stub path; CI covers both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)