### PR TITLE
fix(playback): guard sentinel order entry before play (bus error)

### DIFF
--- a/src/pattern_guard.h
+++ b/src/pattern_guard.h
@@ -1,0 +1,43 @@
+#ifndef ZT_PATTERN_GUARD_H
+#define ZT_PATTERN_GUARD_H
+
+// Pattern-index validity + order-list sentinel handling.
+//
+// patterns[] is sized ZTM_MAX_PATTERNS (256); valid indices are 0..255.
+// Order-list entries reuse out-of-range values as sentinels: 0x100 = empty /
+// end-of-song, 0x101 = skip. Those sentinels must NEVER be used to index
+// patterns[] -- doing so reads past the array and dereferences a garbage
+// track pointer.
+//
+// Bus-error history (crash report 2026-06-03): clicking an empty order slot
+// in the F11 Order editor ran `cur_edit_pattern = orderlist[slot]` (= 0x100)
+// with no guard; pressing F6 then called player::play(cur_edit_pattern) ->
+// playback() -> patterns[256]->tracks[t]->get_event() -> SIGBUS
+// (KERN_PROTECTION_FAILURE). Both the editor assignment and the player play
+// path now funnel through the helpers below.
+//
+// Header-only and dependency-free on purpose: the unit test includes it
+// directly without SDL or module.h. ZT_PATTERN_GUARD_COUNT mirrors
+// ZTM_MAX_PATTERNS; a static_assert in OrderEditor.cpp keeps them in lock-step
+// so this constant can't silently drift from the real patterns[] size.
+
+#ifndef ZT_PATTERN_GUARD_COUNT
+#define ZT_PATTERN_GUARD_COUNT 256
+#endif
+
+// True iff idx is a real, in-range pattern slot -- not a sentinel (>= count),
+// not negative.
+static inline int zt_pattern_index_playable(int idx) {
+    return idx >= 0 && idx < ZT_PATTERN_GUARD_COUNT;
+}
+
+// Resolve an order-list entry to an editable pattern index. Real patterns pass
+// through; sentinels (or any out-of-range value) return `fallback`, so a
+// sentinel never leaks into cur_edit_pattern. Matches the behaviour of the
+// already-guarded order paths (which leave cur_edit_pattern unchanged on a
+// marker).
+static inline int zt_orderlist_select_pattern(int orderlist_value, int fallback) {
+    return zt_pattern_index_playable(orderlist_value) ? orderlist_value : fallback;
+}
+
+#endif // ZT_PATTERN_GUARD_H

--- a/src/pattern_guard.h
+++ b/src/pattern_guard.h
@@ -13,12 +13,16 @@
 // in the F11 Order editor ran `cur_edit_pattern = orderlist[slot]` (= 0x100)
 // with no guard; pressing F6 then called player::play(cur_edit_pattern) ->
 // playback() -> patterns[256]->tracks[t]->get_event() -> SIGBUS
-// (KERN_PROTECTION_FAILURE). Both the editor assignment and the player play
-// path now funnel through the helpers below.
+// (KERN_PROTECTION_FAILURE). The player play path now funnels through
+// zt_pattern_index_playable() (see play_immediately() in playback.cpp); the
+// F11 editor paths already guard cur_edit_pattern inline with `< 0x100`.
+// zt_orderlist_select_pattern() is the canonical order-entry resolver,
+// exercised by the unit test and available should those inline guards ever be
+// unified onto it.
 //
 // Header-only and dependency-free on purpose: the unit test includes it
 // directly without SDL or module.h. ZT_PATTERN_GUARD_COUNT mirrors
-// ZTM_MAX_PATTERNS; a static_assert in OrderEditor.cpp keeps them in lock-step
+// ZTM_MAX_PATTERNS; a static_assert in playback.cpp keeps them in lock-step
 // so this constant can't silently drift from the real patterns[] size.
 
 #ifndef ZT_PATTERN_GUARD_COUNT

--- a/src/playback.cpp
+++ b/src/playback.cpp
@@ -41,8 +41,13 @@
 #include "ccenv_advance.h"
 #include "sysex_macro.h"
 #include "ableton_link.h"
+#include "pattern_guard.h"
 #include <algorithm>
 #include <stdint.h>
+
+// Keep the dependency-free guard constant locked to the real patterns[] size.
+static_assert(ZT_PATTERN_GUARD_COUNT == ZTM_MAX_PATTERNS,
+              "pattern_guard count must match patterns[] size (ZTM_MAX_PATTERNS)");
 
 int mctr = 0;
 
@@ -647,6 +652,15 @@ void player::play_immediately(int row, int pattern,int pm, int loopmode)
   }
 
   prepare_play(row,pattern,pm,loopmode);
+
+  // prepare_play() bails on a sentinel order entry (its `if (cur_pattern > 0xFF)
+  // return;`) but leaves cur_pattern holding the 0x100 empty / 0x101 skip marker
+  // and signals nothing. Without this guard we fall through to playback() below,
+  // which indexes song->patterns[cur_pattern] past the 256-entry array -> wild
+  // pointer -> bus error (crash report 2026-06-03: F6 on an empty order slot;
+  // also reachable via the Ableton-Link transport-follow auto-play). There's
+  // nothing to play, so don't start.
+  if (!zt_pattern_index_playable(cur_pattern)) return;
 
   //  play_buffer[cur_buf]->reset();
   //  play_buffer[cur_buf]->insert(0,ET_MSTART,0); // First event is MIDI Start

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -147,6 +147,16 @@ target_include_directories(test_keyjazz_map PRIVATE
 target_compile_features(test_keyjazz_map PRIVATE cxx_std_17)
 add_test(NAME keyjazz_map COMMAND test_keyjazz_map)
 
+# Pattern-index guard (pattern_guard.h). Regression test for the bus error
+# where an empty-order sentinel (0x100) reached patterns[] as an index. Pure
+# header, no SDL / module.h.
+add_executable(test_pattern_guard
+    test_pattern_guard.cpp
+)
+target_include_directories(test_pattern_guard PRIVATE "${CMAKE_SOURCE_DIR}/src")
+target_compile_features(test_pattern_guard PRIVATE cxx_std_17)
+add_test(NAME pattern_guard COMMAND test_pattern_guard)
+
 add_executable(test_ableton_link
     test_ableton_link.cpp
 )

--- a/tests/test_pattern_guard.cpp
+++ b/tests/test_pattern_guard.cpp
@@ -1,0 +1,71 @@
+// Regression tests for src/pattern_guard.h.
+//
+// Locks in the fix for the 2026-06-03 bus error: clicking an empty order slot
+// on F11 set cur_edit_pattern to the 0x100 "empty" order sentinel, and F6 then
+// drove player::play(0x100) -> playback() -> patterns[256] out of bounds ->
+// SIGBUS. Both the OrderEditor click handler and player::play() now route the
+// pattern index through these helpers; this test pins their contract so a
+// future edit can't quietly let a sentinel back through.
+//
+// Pure header, no SDL / no module.h -- ZT_PATTERN_GUARD_COUNT defaults to 256
+// here, matching the static_assert against ZTM_MAX_PATTERNS in OrderEditor.cpp.
+
+#include "pattern_guard.h"
+
+#include <stdio.h>
+
+static int failures = 0;
+static int checks   = 0;
+
+#define CHECK(expr) do {                                                \
+    checks++;                                                           \
+    if (!(expr)) { failures++;                                          \
+        fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #expr); \
+    }                                                                   \
+} while(0)
+
+static void test_valid_range_is_playable() {
+    CHECK(zt_pattern_index_playable(0));
+    CHECK(zt_pattern_index_playable(1));
+    CHECK(zt_pattern_index_playable(128));
+    CHECK(zt_pattern_index_playable(255));   // last real slot
+}
+
+static void test_sentinels_and_oob_not_playable() {
+    CHECK(!zt_pattern_index_playable(256));   // 0x100 = empty / end-of-song
+    CHECK(!zt_pattern_index_playable(257));   // 0x101 = skip
+    CHECK(!zt_pattern_index_playable(0x100)); // the exact crash value
+    CHECK(!zt_pattern_index_playable(1000));
+    CHECK(!zt_pattern_index_playable(-1));    // negative (defensive)
+    CHECK(!zt_pattern_index_playable(-12345));
+}
+
+static void test_orderlist_select_passes_real_patterns() {
+    // A real pattern in a slot is selected as-is.
+    CHECK(zt_orderlist_select_pattern(0,   7) == 0);
+    CHECK(zt_orderlist_select_pattern(42,  7) == 42);
+    CHECK(zt_orderlist_select_pattern(255, 7) == 255);
+}
+
+static void test_orderlist_select_keeps_fallback_on_sentinel() {
+    // The bug: an empty (0x100) or skip (0x101) slot must keep the caller's
+    // current pattern, never leak the sentinel.
+    CHECK(zt_orderlist_select_pattern(0x100, 5) == 5);
+    CHECK(zt_orderlist_select_pattern(0x101, 5) == 5);
+    CHECK(zt_orderlist_select_pattern(256,   0) == 0);
+    CHECK(zt_orderlist_select_pattern(99999, 12) == 12);
+    CHECK(zt_orderlist_select_pattern(-1,    12) == 12);
+    // Fallback is returned verbatim even though it, too, is just trusted as-is
+    // (callers always pass the live cur_edit_pattern, which is itself kept in
+    // range elsewhere).
+    CHECK(zt_orderlist_select_pattern(0x100, 0) == 0);
+}
+
+int main(void) {
+    test_valid_range_is_playable();
+    test_sentinels_and_oob_not_playable();
+    test_orderlist_select_passes_real_patterns();
+    test_orderlist_select_keeps_fallback_on_sentinel();
+    printf("pattern_guard: %d checks, %d failures\n", checks, failures);
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_pattern_guard.cpp
+++ b/tests/test_pattern_guard.cpp
@@ -3,12 +3,12 @@
 // Locks in the fix for the 2026-06-03 bus error: clicking an empty order slot
 // on F11 set cur_edit_pattern to the 0x100 "empty" order sentinel, and F6 then
 // drove player::play(0x100) -> playback() -> patterns[256] out of bounds ->
-// SIGBUS. Both the OrderEditor click handler and player::play() now route the
-// pattern index through these helpers; this test pins their contract so a
-// future edit can't quietly let a sentinel back through.
+// SIGBUS. player::play_immediately() now routes the pattern index through
+// zt_pattern_index_playable() before the patterns[] deref; this test pins the
+// helpers' contract so a future edit can't quietly let a sentinel back through.
 //
 // Pure header, no SDL / no module.h -- ZT_PATTERN_GUARD_COUNT defaults to 256
-// here, matching the static_assert against ZTM_MAX_PATTERNS in OrderEditor.cpp.
+// here, matching the static_assert against ZTM_MAX_PATTERNS in playback.cpp.
 
 #include "pattern_guard.h"
 


### PR DESCRIPTION
## Summary

Playing an order position whose order-list entry is a **sentinel** (`0x100` empty / `0x101` skip) crashes with **SIGBUS**. This re-homes Christopher Micali's fix (from the never-merged `fix/order-empty-slot-bus-error`) onto current `master`.

## Root cause (still live in master)

1. `prepare_play()` resolves `cur_pattern` from the order list, then bails on `if (cur_pattern > 0xFF) return;` — but **leaves `cur_pattern` holding the sentinel** (`0x100`) and returns `void`, signalling nothing.
2. `play_immediately()` ignores that and proceeds to `this->playback(...)`, which indexes `song->patterns[cur_pattern]` = `patterns[256]` — **past the 256-entry array** → wild pointer → bus error (`KERN_PROTECTION_FAILURE`).

There is **no bounds check** between `prepare_play()` and the `patterns[cur_pattern]` deref, and `playing = 1` is set unconditionally.

Repro (crash report 2026-06-03): F6 on an empty order slot; also reachable via Ableton-Link transport-follow auto-play.

## Why the original branch didn't just merge

- It was authored **2026-06-04, before PR #159** refactored `player::play` into `play()` / `play_immediately()`, so its patch no longer applied (conflicts).
- Its **OrderEditor.cpp half is now redundant**: `master` already guards every `cur_edit_pattern` assignment inline with `< 0x100` (click, keyboard, and the `G` go-to path). That closed the *editor-display* half — but **not** the play path, which re-resolves the order list inside `prepare_play`. So the SIGBUS survived.

## The fix

- **`src/pattern_guard.h`** (Chris's, verbatim) — dependency-free `zt_pattern_index_playable()` / `zt_orderlist_select_pattern()`. `ZT_PATTERN_GUARD_COUNT` is `static_assert`'d against `ZTM_MAX_PATTERNS` (assert lives in `playback.cpp`, which sees both).
- **`play_immediately()`** — `if (!zt_pattern_index_playable(cur_pattern)) return;` immediately after `prepare_play`, before the prebuffer `playback()` call. Nothing to play → don't start.
- **`tests/test_pattern_guard.cpp`** (+ CMake) — pins the helper contract (real slots pass, `0x100`/`0x101`/OOB/negative rejected).

## Test plan

- [x] Clean build (Ninja) + `ctest` — **15/15 pass** (new `pattern_guard` suite included).
- [x] Guard placed against current `master`'s post-#159 `play_immediately`, not the old `play()`.
- [ ] CI green across all 5 platforms.

## Credit

Diagnosis, `pattern_guard.h`, and the test are **Christopher Micali's** (co-authored). This PR adapts the guard to the post-Ableton-Link code and drops the now-redundant OrderEditor change. @cmicali — flagging for your review since it's your work.
