### PR TITLE
MIDI clock sync on the shared phase-chase controller (resubmit of #160, hardened)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,6 +143,22 @@ jobs:
       - name: Run unit tests
         run: ctest --test-dir build --output-on-failure
 
+      - name: ThreadSanitizer unit tests
+        run: |
+          cmake -S . -B build-tsan -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_FLAGS="-fsanitize=thread -g -O1" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=thread -g -O1" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread" \
+            -DSDL3_INCLUDE_DIR="${{ steps.sdl3.outputs.include }}" \
+            -DSDL3_LIBRARY="${{ steps.sdl3.outputs.lib }}"
+          # Only the test targets need TSan (SDL-free). The point is the
+          # threaded suite: test_sysex_stress drives 4 producer threads + a
+          # consumer against the SysEx queue mutex. Locks in the project's
+          # thread-safety posture (incl. the std::atomic MIDI-clock counters).
+          cmake --build build-tsan -j --target test_sysex_stress test_sysex_inq test_midi_clock_sync
+          ctest --test-dir build-tsan --output-on-failure -R "sysex_stress|sysex_inq|midi_clock_sync"
+
       - name: Stage release
         run: |
           mkdir -p dist/ztrackerprime-linux-x86_64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,7 @@ set(ZT_SOURCES
   src/ccenv_io.cpp
   src/CUI_CCEnvelopeEditor.cpp
   src/ableton_link.cpp
+  src/midi_clock_sync.cpp
   src/zt_headless.cpp
 )
 

--- a/assets/lua/selftest.lua
+++ b/assets/lua/selftest.lua
@@ -125,6 +125,13 @@ check("transport playing after play", zt.transport.playing == true)
 zt.transport:stop()
 check("transport stopped", zt.transport.playing == false)
 
+-- MIDI-clock sync status (read-only). No external clock under test, so the
+-- state is "off"; just assert the fields exist with the right types/contract.
+check("sync_state is string", type(zt.transport.sync_state) == "string")
+check("sync_state off when not slaved", zt.transport.sync_state == "off")
+check("sync_bpm is number", type(zt.transport.sync_bpm) == "number")
+check("sync_offset_ms is number", type(zt.transport.sync_offset_ms) == "number")
+
 -- ── zt.midimacro(i) ──────────────────────────────────────────────────
 local m = zt.midimacro(0)
 m.name = "Bank" ;                  eq("midimacro.name", m.name, "Bank")
@@ -174,6 +181,13 @@ eq("notifier multiple callbacks", fired, 106)   -- +1 (first) +100 (second)
 zt.off("selftest_evt")
 zt.fire("selftest_evt", 5)
 eq("notifier off stops firing", fired, 106)     -- unchanged
+
+-- the built-in "sync" event registers and dispatches like any other
+local sync_seen = -1
+zt.on("sync", function(state) sync_seen = state end)
+zt.fire("sync", 4)
+eq("sync notifier dispatches state", sync_seen, 4)
+zt.off("sync")
 
 -- ── file save / load roundtrip ───────────────────────────────────────
 local tmp = (os.getenv("TMPDIR") or os.getenv("TEMP") or "/tmp") .. "/zt_selftest.zt"

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,28 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_06_15 (MIDI clock sync rebuilt on the phase-chase controller)
+----------------------------------------------------------------------------
+
+        * MIDI In Sync now phase-locks to the received clock grid using the
+          same closed-loop controller as Ableton Link (src/phase_chase.h):
+          24 clocks/beat is a position reference, so fractional master
+          tempos no longer drift (the old rolling-average follower walked
+          ~0.3%/min against a 120.4 BPM master).
+        * The MIDI-in callback thread no longer makes decisions: it only
+          counts what arrived (clocks, Start/Continue/Stop, SPP), and the
+          main-thread pump consumes them - fixing cross-thread player
+          play()/stop() calls and timing-field writes that dated back to
+          the original implementation.
+        * "Sync Offset ms" (was "Link Offset ms") now applies to BOTH sync
+          modes: zt plays that many ms early so notes monitored through
+          the master DAW's audio chain sound on the grid. Live-dialable
+          during playback in both modes. zt.conf key: sync_offset_ms
+          (legacy ableton_link_offset_ms still read).
+        * Master clock dropout (>1 s without clocks) pauses the chase and
+          lets the engine free-run at its nominal tempo; lock re-acquires
+          automatically when clocks resume.
+
 zt 2026_06_09 (Ableton Link support)
 ----------------------------------------------------------------------------
 

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,30 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_06_15 (MIDI clock sync: hardware timestamps on macOS + lock sim test)
+----------------------------------------------------------------------------
+
+        * macOS clock arrival times now come from the CoreMIDI packet's
+          hardware host timestamp instead of sampling a software clock inside
+          the input callback (which adds OS-scheduling jitter on top of the
+          real arrival). The mach-absolute stamp is converted into the
+          SDL_GetTicks() epoch and sanity-gated against the software clock:
+          if it's absent or implausible the software clock is used, so a bad
+          stamp can never break the lock. Windows/Linux unchanged. The lock
+          benefit on real hardware is pending confirmation with a hardware
+          MIDI-clock master; the conversion math is unit-tested and the path
+          cannot regress (verified fallback).
+
+        + Closed-loop lock-quality regression test (test_midi_clock_sync):
+          models the full feedback path (engine advances at its steered rate
+          while a fractional-tempo master streams clocks) and asserts the
+          steady-state lock holds -- 120.37 BPM within <12 ms, +/-3 ms
+          timestamp jitter within <25 ms. Turns the hand-measured lock figure
+          into a CI gate.
+
+        ! New test suite test_midi_timestamp: the mach->SDL-ms conversion and
+          the plausibility gate (stale / future / garbage stamps rejected).
+
 zt 2026_06_15 (MIDI clock sync robustness: warm re-lock + snap + TSan)
 ----------------------------------------------------------------------------
 

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,29 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_06_15 (MIDI clock sync robustness: warm re-lock + snap + TSan)
+----------------------------------------------------------------------------
+
+        * Warm re-lock. A brief clock dropout now drops only the sample
+          window and KEEPS the last tempo estimate, so sync re-locks instantly
+          when clocks resume instead of cold-starting (~1 s of wander). The
+          chase still pauses during the dropout (engine free-runs at nominal).
+
+        * Snap on discontinuity. If the engine falls more than ~1 s off the
+          master grid (a main-loop stall that skipped frames, not a deliberate
+          move), the chase snaps its anchor to the current position instead of
+          slewing for seconds and audibly rushing. The half-beat catch-up and
+          the 0-500 ms Sync Offset stay deliberate moves the controller slews.
+
+        + ThreadSanitizer CI step on the Linux job: builds the test suite with
+          -fsanitize=thread and runs the threaded suites (test_sysex_stress's
+          4 producers + consumer against the SysEx queue mutex, plus the SysEx
+          queue and MIDI-clock tests). Locks in the project's thread-safety
+          posture, including the std::atomic MIDI-clock observer counters.
+
+        ! New regression tests: warm-re-lock (tempo survives a dropout) and
+          snap-on-large-jump (a ~3-beat stall snaps rather than slews).
+
 zt 2026_06_15 (Sync observability: F11 lock meter + Lua sync state)
 ----------------------------------------------------------------------------
 

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,27 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_06_15 (Sync observability: F11 lock meter + Lua sync state)
+----------------------------------------------------------------------------
+
+        + F11 MIDI-clock lock meter. To the right of the "MIDI In Sync" row,
+          a live readout shows the lock state (waiting for clock / clock
+          dropout / transport / chasing / LOCKED), the estimated master
+          tempo, and the current position offset in ms (engine behind the
+          grid = positive). Closes the loop for dialing Sync Offset by eye
+          and for confirming a solid lock. Refreshes only when a displayed
+          value changes (same contract as the Ableton Link status line).
+
+        + Lua sync status. zt.transport.sync_state ("off"/"waiting"/
+          "dropout"/"transport"/"chasing"/"locked"), zt.transport.sync_bpm
+          and zt.transport.sync_offset_ms expose the same numbers to scripts,
+          and a new "sync" notifier fires on every lock-state transition
+          (zt.on('sync', fn); arg = numeric state).
+
+        ! Both read a single zt_midi_clock_get_status() snapshot refreshed
+          once per pump on the main thread -- no extra locking, no MIDI-thread
+          work added.
+
 zt 2026_06_15 (MIDI clock sync rebuilt on the phase-chase controller)
 ----------------------------------------------------------------------------
 

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -296,6 +296,14 @@
  drift. MIDI In Sync and Ableton Link are mutually exclusive (one tempo
  master at a time).
 
+ A lock meter to the right of the "MIDI In Sync" row shows the live
+ state - waiting for clock / clock dropout / transport / chasing /
+ LOCKED - with the estimated master tempo and the current offset in ms
+ (engine behind the grid = positive). Use it to confirm the lock and to
+ dial Sync Offset by eye. The same values are scriptable from the Lua
+ console: zt.transport.sync_state / .sync_bpm / .sync_offset_ms, and a
+ "sync" notifier fires on each state change (zt.on('sync', fn)).
+
 |L|%==|H|Troubleshooting|L|==%|U|
 
  Timing issues:

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -279,13 +279,22 @@
                      press play already in sync), and changing BPM in F11
                      proposes that tempo to every peer.
    Link Start/Stop : (on by default) Also share transport.
-   Link Offset ms  : Play this many ms EARLY (0-500, default 0). A DAW
+   Sync Offset ms  : Play this many ms EARLY (0-500, default 0). A DAW
                      monitoring zt's MIDI through its audio chain renders
                      the notes late by its audio latency (Live:
                      Preferences > Audio > Overall Latency), and Link has
                      no way to discover that value. Set it here once and
                      zt's notes SOUND on the grid - no track delay or
-                     reduced-latency mode needed in the DAW.
+                     reduced-latency mode needed in the DAW. Applies to
+                     MIDI In Sync as well, and is adjustable LIVE while
+                     playing, so it can be dialed in by ear.
+
+ MIDI In Sync (F11) slaves zt to incoming MIDI clock instead: Start /
+ Continue / Stop / Song Position Pointer drive the transport, and with
+ "Chase MIDI Tempo" on, zt phase-locks to the received clock grid the
+ same way it locks to Link - fractional master tempos hold without
+ drift. MIDI In Sync and Ableton Link are mutually exclusive (one tempo
+ master at a time).
 
 |L|%==|H|Troubleshooting|L|==%|U|
 

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -187,7 +187,7 @@ CUI_Songconfig::CUI_Songconfig(void) {
         vs->xsize = 28;
         vs->min = 0;
         vs->max = 500;
-        vs->value = zt_config_globals.ableton_link_offset_ms;
+        vs->value = zt_config_globals.sync_offset_ms;
 
         oe = new OrderEditor;
         UI->add_element(oe,9);
@@ -220,7 +220,7 @@ void CUI_Songconfig::enter(void) {
     vs = (ValueSlider *)UI->get_element(10);
     if (vs) vs->value = zt_config_globals.note_audition_step_mode;
     vs = (ValueSlider *)UI->get_element(13);
-    if (vs) vs->value = zt_config_globals.ableton_link_offset_ms;
+    if (vs) vs->value = zt_config_globals.sync_offset_ms;
 
     // F11 toggle: pressing F11 while already on Songconfig flips focus
     // between OrderEditor (id 9) and Title (id 0) on every press, so the
@@ -332,10 +332,10 @@ void CUI_Songconfig::update()
     }
     vs = (ValueSlider *)UI->get_element(13);
     if (vs && vs->from_input) vs->from_input = 0;
-    if (vs && vs->value != zt_config_globals.ableton_link_offset_ms) {
-        zt_config_globals.ableton_link_offset_ms = vs->value;
+    if (vs && vs->value != zt_config_globals.sync_offset_ms) {
+        zt_config_globals.sync_offset_ms = vs->value;
     } else if (vs) {
-        vs->value = zt_config_globals.ableton_link_offset_ms;
+        vs->value = zt_config_globals.sync_offset_ms;
     }
 
     vs = (ValueSlider *)UI->get_element(6);
@@ -457,7 +457,7 @@ void CUI_Songconfig::draw(Drawable *S) {
         // Ableton Link block. Labels right-align to col 18 like the rest.
         print(row(6),col(base_y+16),"Ableton Link",COLORS.Text,S);
         print(row(3),col(base_y+17),"Link Start/Stop",COLORS.Text,S);
-        print(row(4),col(base_y+18),"Link Offset ms",COLORS.Text,S);
+        print(row(4),col(base_y+18),"Sync Offset ms",COLORS.Text,S);
         {
             char linkstat[96];
             if (!zt_ableton_link_available()) {

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -2,6 +2,7 @@
 #include "zt.h"
 #include "OrderEditor.h"
 #include "ableton_link.h"
+#include "midi_clock_sync.h"
 
 CUI_Songconfig::CUI_Songconfig(void) {
     ValueSlider *vs;
@@ -401,6 +402,26 @@ void CUI_Songconfig::update()
                 need_refresh++;
             }
         }
+
+        // MIDI clock lock meter: state / master BPM / offset all move every
+        // frame while slaved. Same contract as the Link block above -- repaint
+        // only when a displayed value actually changed (quantized so sub-0.1
+        // jitter doesn't force a redraw every frame).
+        {
+            static int    last_sstate = -1;
+            static int    last_sbpm10  = -1;
+            static int    last_soff10  = -1000000;
+            zt_sync_status ss;
+            zt_midi_clock_get_status(&ss);
+            int sbpm10 = (int)(ss.master_bpm * 10.0 + 0.5);
+            int soff10 = (int)(ss.offset_ms  * 10.0 + (ss.offset_ms >= 0 ? 0.5 : -0.5));
+            if (ss.state != last_sstate || sbpm10 != last_sbpm10 || soff10 != last_soff10) {
+                last_sstate = ss.state;
+                last_sbpm10 = sbpm10;
+                last_soff10 = soff10;
+                need_refresh++;
+            }
+        }
     }
     vs = (ValueSlider *)UI->get_element(10);
     if (vs) {
@@ -477,6 +498,26 @@ void CUI_Songconfig::draw(Drawable *S) {
             char linkstat_field[40];
             snprintf(linkstat_field, sizeof(linkstat_field), "%-28s", linkstat);
             printBG(row(24),col(base_y+16),linkstat_field,COLORS.Highlight,COLORS.Background,S);
+        }
+        // MIDI-clock lock meter on the "MIDI In Sync" row: lock state +
+        // estimated master tempo + signed offset (engine behind = +). Same
+        // fixed-width / printBG erase trick and 28-col span as the Link status.
+        {
+            zt_sync_status ss;
+            zt_midi_clock_get_status(&ss);
+            char m[64];
+            switch (ss.state) {
+                case ZT_SYNC_WAITING:   snprintf(m,sizeof(m),"waiting for clock"); break;
+                case ZT_SYNC_DROPOUT:   snprintf(m,sizeof(m),"clock dropout"); break;
+                case ZT_SYNC_TRANSPORT: snprintf(m,sizeof(m),"transport \xb3 %.1f BPM", ss.master_bpm); break;
+                case ZT_SYNC_CHASING:   snprintf(m,sizeof(m),"chasing \xb3 %.1f BPM \xb3 %+.1f ms", ss.master_bpm, ss.offset_ms); break;
+                case ZT_SYNC_LOCKED:    snprintf(m,sizeof(m),"LOCKED \xb3 %.1f BPM \xb3 %+.1f ms", ss.master_bpm, ss.offset_ms); break;
+                case ZT_SYNC_OFF:
+                default:                m[0] = '\0'; break;
+            }
+            char field[40];
+            snprintf(field,sizeof(field),"%-28s", m);
+            printBG(row(25),col(base_y+11),field,COLORS.Highlight,COLORS.Background,S);
         }
         // Order List label aligned to the OE x-origin (col 59) — NOT shifted.
         print(row(59),col(11),"Order List",COLORS.Text,S);

--- a/src/ableton_link.cpp
+++ b/src/ableton_link.cpp
@@ -5,6 +5,7 @@
  *************************************************************************/
 
 #include "ableton_link.h"
+#include "phase_chase.h"
 
 #include <cmath>   // lround
 
@@ -241,7 +242,7 @@ static void link_arm_play(int row, int pattern, int pm) {
 // if Link was disabled while waiting). play_immediately, not play: play() would defer
 // right back to us.
 //
-// ableton_link_offset_ms fires that many ms BEFORE the downbeat: a peer
+// sync_offset_ms fires that many ms BEFORE the downbeat: a peer
 // monitoring zt through an audio chain (Live's Overall Latency) renders our
 // notes that much late, and Link cannot discover a peer's local latency, so
 // the user dials the rig's value once and zt's whole timeline runs early by
@@ -256,7 +257,7 @@ static void link_fire_quantized(void) {
     double ph = be_phase();
     if (ph < 0.0) return;
     bool fire = (ph < g_play_phase);   // wrapped past the downbeat
-    int offset_ms = zt_config_globals.ableton_link_offset_ms;
+    int offset_ms = zt_config_globals.sync_offset_ms;
     if (!fire && offset_ms > 0) {
         double tempo = be_tempo();
         if (tempo > 0.0) {
@@ -274,7 +275,7 @@ static void link_fire_quantized(void) {
         // engine to the new offset.
         double tempo = be_tempo();
         double off_beats = (tempo > 0.0)
-            ? (double)zt_config_globals.ableton_link_offset_ms * tempo / 60000.0
+            ? (double)zt_config_globals.sync_offset_ms * tempo / 60000.0
             : 0.0;
         g_chase_anchor = be_beats() + off_beats;
         g_chase_valid  = true;
@@ -315,7 +316,7 @@ static void link_chase_phase(void) {
     // The offset enters the setpoint HERE, from the live conf value, so
     // dragging the F11 slider during playback shifts the target and the
     // loop slews onto it.
-    double off_beats = (double)zt_config_globals.ableton_link_offset_ms * tempo / 60000.0;
+    double off_beats = (double)zt_config_globals.sync_offset_ms * tempo / 60000.0;
     int played = ztPlayer->played_subticks;   // one advisory read
     if (!g_chase_valid) {
         g_chase_anchor = beats - played / 96.0 + off_beats;
@@ -324,25 +325,9 @@ static void link_chase_phase(void) {
     }
     double exact_us   = 60000000.0 / (96.0 * tempo);
     double expected   = (beats - g_chase_anchor + off_beats) * 96.0;   // subticks
-    // pos_err, not err_us: <mach/error.h> (via CoreMIDI) #defines err_us.
-    double pos_err    = (expected - (double)played) * exact_us;
     double nominal_us = (double)(ztPlayer->subtick_len_ms + ztPlayer->subtick_len_mms);
-    double feedback   = pos_err / 64.0;
-    // Tiered authority: |error| beyond 10 ms is a deliberate move (offset
-    // slider, tempo step) and may slew at 12% of real time -- the output is
-    // MIDI, so a brief rush/drag while the user turns a knob is harmless,
-    // and even a full-scale 500 ms move locks in ~4 s (171 ms in ~1.4 s).
-    // Inside 10 ms (steady-state lock) corrections stay at 0.3%, far below
-    // audibility.
-    double fb_max     = exact_us * ((pos_err > 10000.0 || pos_err < -10000.0) ? 0.12 : 0.003);
-    if (feedback >  fb_max) feedback =  fb_max;
-    if (feedback < -fb_max) feedback = -fb_max;
-    // Positive error = engine behind = needs a SHORTER subtick.
-    double skew = (exact_us - nominal_us) - feedback;
-    double skew_max = exact_us * 0.15;
-    if (skew >  skew_max) skew =  skew_max;
-    if (skew < -skew_max) skew = -skew_max;
-    ztPlayer->chase_skew_us = (int)lround(skew);
+    ztPlayer->chase_skew_us =
+        phase_chase_step(expected, played, exact_us, nominal_us);
 }
 
 // Does NOT join the session here -- the first zt_ableton_link_pump() does,

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -222,7 +222,7 @@ ZTConf::ZTConf() {
     ableton_link_enable = 0;            // Ableton Link off by default (no surprise LAN traffic)
     ableton_link_start_stop_sync = 1;   // transport (play/stop) sharing on by default; only takes effect once ableton_link_enable is on
     ableton_link_quantum = 4;           // one bar of 4/4
-    ableton_link_offset_ms = 0;         // fire quantized starts early by this much
+    sync_offset_ms = 0;                 // play this many ms early under external sync
     auto_send_panic = 1; // flag_autosendpanic
     highlight_increment = 8;
     lowlight_increment = 8;
@@ -360,7 +360,8 @@ int ZTConf::load()
   if (Config->get("ableton_link_enable"))             ableton_link_enable = getFlag("ableton_link_enable");
   if (Config->get("ableton_link_start_stop_sync"))    ableton_link_start_stop_sync = getFlag("ableton_link_start_stop_sync");
   if (Config->get("ableton_link_quantum"))            ableton_link_quantum = atoi(Config->get("ableton_link_quantum"));
-  if (Config->get("ableton_link_offset_ms"))          ableton_link_offset_ms = atoi(Config->get("ableton_link_offset_ms"));
+  if (Config->get("ableton_link_offset_ms"))          sync_offset_ms = atoi(Config->get("ableton_link_offset_ms")); // legacy key
+  if (Config->get("sync_offset_ms"))                  sync_offset_ms = atoi(Config->get("sync_offset_ms"));
 
   // Ableton Link wins if both Link and MIDI Sync are enabled
   if (ableton_link_enable) {
@@ -370,8 +371,8 @@ int ZTConf::load()
 
   if (ableton_link_quantum < 1)  ableton_link_quantum = 4;
   if (ableton_link_quantum > 16) ableton_link_quantum = 16;
-  if (ableton_link_offset_ms < 0)   ableton_link_offset_ms = 0;
-  if (ableton_link_offset_ms > 500) ableton_link_offset_ms = 500;
+  if (sync_offset_ms < 0)   sync_offset_ms = 0;
+  if (sync_offset_ms > 500) sync_offset_ms = 500;
   
   full_screen = getFlag("fullscreen");                
   step_editing = getFlag("step_editing");
@@ -536,8 +537,8 @@ int ZTConf::save() {
     Config->set("ableton_link_start_stop_sync", ableton_link_start_stop_sync ? "yes" : "no");
     sprintf(s, "%d", ableton_link_quantum);
     Config->set("ableton_link_quantum", s);
-    sprintf(s, "%d", ableton_link_offset_ms);
-    Config->set("ableton_link_offset_ms", s);
+    sprintf(s, "%d", sync_offset_ms);
+    Config->set("sync_offset_ms", s);
 
     if (full_screen)
         Config->set("fullscreen","yes");

--- a/src/conf.h
+++ b/src/conf.h
@@ -77,14 +77,14 @@ class ZTConf {
         // Bar length in beats (4 = one bar of 4/4) used for beat-phase alignment
         // and quantized (bar-aligned) launch.
         int ableton_link_quantum;
-        // ableton_link_offset_ms fires the quantized start that many ms
+        // sync_offset_ms fires the quantized start that many ms
         // BEFORE the Link downbeat, so notes rendered through a peer's
         // monitored audio chain (e.g. Live's Overall Latency) SOUND on the
         // grid. Link has no way to discover a peer's local audio latency, so
         // this is a one-time per-rig setting.
         // 0 = fire exactly on the beat.
         // Recommended to set this to the audio latency value shown in Live settings
-        int ableton_link_offset_ms;
+        int sync_offset_ms;
         int auto_send_panic; // flag_autosendpanic
         int highlight_increment;
         int lowlight_increment;

--- a/src/lua_engine.cpp
+++ b/src/lua_engine.cpp
@@ -9,6 +9,7 @@
 #include "playback.h"
 #include "module.h"
 #include "midi-io.h"
+#include "midi_clock_sync.h"   // zt.transport.sync_* status fields
 #include "CDataBuf.h"   // song message text buffer (zt.song.message)
 
 #include <string.h>
@@ -673,6 +674,15 @@ static int trans_index(lua_State *L)
     if (!strcmp(k, "stop"))         { lua_pushcfunction(L, trans_stop); return 1; }
     if (!strcmp(k, "play_pattern")) { lua_pushcfunction(L, trans_play_pattern); return 1; }
     if (!strcmp(k, "panic"))        { lua_pushcfunction(L, trans_panic); return 1; }
+    // MIDI-clock sync status (read-only): mirrors the F11 lock meter.
+    if (!strcmp(k, "sync_state") || !strcmp(k, "sync_bpm") || !strcmp(k, "sync_offset_ms")) {
+        zt_sync_status ss;
+        zt_midi_clock_get_status(&ss);
+        if      (!strcmp(k, "sync_state"))     lua_pushstring(L, zt_sync_state_name(ss.state));
+        else if (!strcmp(k, "sync_bpm"))       lua_pushnumber(L, ss.master_bpm);
+        else                                   lua_pushnumber(L, ss.offset_ms);
+        return 1;
+    }
     return luaL_error(L, "zt.transport has no field '%s' (try help('transport'))", k);
 }
 static int trans_tostring(lua_State *L)
@@ -1423,7 +1433,7 @@ bool ZtLuaEngine::init()
         "    instrument = 'zt.instrument(i)  props (rw): name, channel, device, transpose, bank, volume, global_volume, default_length, flags, ccizer_bank; ro: index  (i defaults to current)',\n"
         "    pattern = 'zt.pattern(p)  props: length(rw), index, empty;  methods: :note(track,row), :set_note(track,row,note[,inst[,vol]]), :track(t)  (p defaults to current)',\n"
         "    track = 'zt.track(t[,p])  props: index, pattern, muted(rw);  methods: :note(row), :set_note(row,note[,inst[,vol]])  (defaults to current track/pattern)',\n"
-        "    transport = 'zt.transport  prop: playing;  methods: :play(), :stop(), :play_pattern(), :panic()',\n"
+        "    transport = 'zt.transport  props: playing, sync_state, sync_bpm, sync_offset_ms;  methods: :play(), :stop(), :play_pattern(), :panic()',\n"
         "    cell = 'zt.cell(track,row[,pat]) / pattern:cell(t,r) / track:cell(r)  props (rw): note, instrument, volume, length, effect, effect_data;  ro: name, empty, pattern, track, row;  method :clear()',\n"
         "    orders = 'zt.orders  array: zt.orders[i] = pattern (rw), .count, #zt.orders;  pattern markers zt.BREAK / zt.SKIP',\n"
         "    midimacro = 'zt.midimacro(i)  props: name (rw), empty, syx, index;  methods :get(step), :set(step,value), :send(device[,param])  (tokens zt.MACRO_END / zt.MACRO_PARAM)',\n"
@@ -1446,7 +1456,7 @@ bool ZtLuaEngine::init()
         "      print('  ' .. objdocs.arpeggio)\n"
         "      print('  ' .. objdocs.envelope)\n"
         "      print('Helpers: zt.note_name(60)->\"C-5\", zt.note_value(\"C-5\")->60 ; zt.load(path), zt.save(path)')\n"
-        "      print('Notifiers: zt.on(event,fn) / zt.off(event) / zt.fire(event[,arg]).  events: idle, play, stop, row')\n"
+        "      print('Notifiers: zt.on(event,fn) / zt.off(event) / zt.fire(event[,arg]).  events: idle, play, stop, row, sync')\n"
         "      print('Consts: zt.MAX_PATTERNS/TRACKS/INSTRUMENTS/ORDERS/MIDIMACROS/ARPEGGIOS, NOTE_*, MIDDLE_C, BREAK, SKIP, MACRO_END/PARAM')\n"
         "      print('  e.g.  zt.song.bpm=140   zt.cell(0,0).note = zt.note_value(\"C-5\")   zt.orders[0]=2   zt.transport:play()')\n"
         "      print('Introspect: rprint(zt) dumps all, oprint(t) lists one level, help(\"name\") for one.')\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,7 @@
 #include "midi_mappings.h"
 #include "ccizer.h"
 #include "ableton_link.h"
+#include "midi_clock_sync.h"
 
 #ifdef __APPLE__
 extern "C" void zt_macos_disable_cmd_q(void);
@@ -3447,6 +3448,9 @@ int action(Screen *S)
 
     // Ableton Link sync if enabled
     zt_ableton_link_pump();
+
+    // MIDI clock slave sync if enabled (mutually exclusive with Link)
+    zt_midi_clock_pump();
 
 #ifdef DEBUG
     playbuff1_bg->setvalue(ztPlayer->play_buffer[0]->size);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4304,6 +4304,18 @@ int main(int argc, char *argv[])
             g_lua.fire("row", s_prev_row, true);
           }
         }
+        {
+          // "sync" on MIDI-clock lock-state transitions (off/waiting/dropout/
+          // transport/chasing/locked). arg = numeric state; the readable name
+          // and the live BPM/offset are on zt.transport.sync_*.
+          static int s_prev_sync = -1;
+          zt_sync_status ss;
+          zt_midi_clock_get_status(&ss);
+          if (ss.state != s_prev_sync) {
+            s_prev_sync = ss.state;
+            g_lua.fire("sync", ss.state, true);
+          }
+        }
         g_lua.fire("idle");
       }
 

--- a/src/midi-io.cpp
+++ b/src/midi-io.cpp
@@ -41,6 +41,10 @@
 #include "midi_mappings.h"
 #include "sysex_inq.h"
 #include "midi_clock_sync.h"
+#include "midi_timestamp.h"
+#if defined(__APPLE__)
+#include <mach/mach_time.h>
+#endif
 
 
 /*
@@ -346,6 +350,29 @@ int mim_longerror = 0 ;
 
 
 
+// MIDI-clock arrival time in the SDL_GetTicks() ms epoch. On macOS the CoreMIDI
+// input shim passes the packet's mach-absolute host stamp in dwParam2; convert
+// it (the hardware arrival time is more precise than sampling a clock in this
+// callback) and sanity-gate against the software clock, falling back to it if
+// the stamp is absent or implausible -- so a bad stamp can never break the lock.
+// Other platforms (real WinMM ms, ALSA) aren't this epoch: use the soft clock.
+static inline unsigned zt_midi_clock_arrival_ms(DWORD_PTR hw_stamp) {
+    unsigned now_sdl = (unsigned)SDL_GetTicks();
+#if defined(__APPLE__)
+    uint64_t pkt = (uint64_t)hw_stamp;
+    if (pkt != 0) {
+        static mach_timebase_info_data_t tb = {0, 0};
+        if (tb.denom == 0) mach_timebase_info(&tb);
+        uint32_t cand = zt_mach_stamp_to_sdl_ms(pkt, mach_absolute_time(),
+                                                now_sdl, tb.numer, tb.denom);
+        return zt_pick_clock_stamp(cand, now_sdl, /*max_age_ms=*/2000, /*future_tol_ms=*/50);
+    }
+#else
+    (void)hw_stamp;
+#endif
+    return now_sdl;
+}
+
 void CALLBACK midiInCallback(HMIDIIN handle, UINT uMsg, DWORD_PTR dwInstance, DWORD_PTR dwParam1, DWORD_PTR dwParam2) {
 
     unsigned char msg;
@@ -456,7 +483,7 @@ void CALLBACK midiInCallback(HMIDIIN handle, UINT uMsg, DWORD_PTR dwInstance, DW
           switch(msg) {
             case 0xF8: // MIDI CLOCK
                 g_mclk_clocks++;
-                g_mclk_last_clock_ms = (unsigned)SDL_GetTicks();
+                g_mclk_last_clock_ms = zt_midi_clock_arrival_ms(dwParam2);
                 break;
             case 0xF2: // MIDI SONG POSITION POINTER
                 g_mclk_spp_raw = (dwParam1&0x7F0000)>>9 |

--- a/src/midi-io.cpp
+++ b/src/midi-io.cpp
@@ -40,6 +40,7 @@
 #include "zt.h"
 #include "midi_mappings.h"
 #include "sysex_inq.h"
+#include "midi_clock_sync.h"
 
 
 /*
@@ -329,7 +330,6 @@ void miq::clear(void) {
     qhead = qtail = 0;
     qelems = 0;
 }
-int g_midi_in_clocks_received = 0;
 
 
 
@@ -349,8 +349,6 @@ int mim_longerror = 0 ;
 void CALLBACK midiInCallback(HMIDIIN handle, UINT uMsg, DWORD_PTR dwInstance, DWORD_PTR dwParam1, DWORD_PTR dwParam2) {
 
     unsigned char msg;
-    int song_pos_ptr;
-    static int queued_row, queued_order;
 //	LPMIDIHDR		lpMIDIHeader;
 //	unsigned char *	ptr;
 
@@ -450,105 +448,27 @@ void CALLBACK midiInCallback(HMIDIIN handle, UINT uMsg, DWORD_PTR dwInstance, DW
               }
           }
 
-          if (zt_config_globals.midi_in_sync)
-              switch(msg) {
-                case 0xF8: // MIDI CLOCK
-                    g_midi_in_clocks_received++;
-                    // Tempo chase: derive BPM from the rolling average of
-                    // 24 clock intervals (= one quarter note) and push the
-                    // result into the live player without mutating
-                    // song->bpm. Gated on midi_in_sync_chase_tempo so users
-                    // who want only transport sync (Start/Stop/SPP) are
-                    // unaffected. Only active while playing — Logic sends
-                    // clocks even when stopped.
-                    if (zt_config_globals.midi_in_sync_chase_tempo
-                        && ztPlayer && ztPlayer->playing) {
-                        // File-local state — only written from this MIDI-in
-                        // callback thread, so no cross-thread locking needed
-                        // for the ring itself.
-                        static Uint64 s_last_clock_ms = 0;
-                        static int    s_ring[24] = {0};
-                        static int    s_ring_idx = 0;
-                        static int    s_ring_count = 0;
-                        static int    s_last_pushed_bpm = 0;
-
-                        Uint64 now = SDL_GetTicks();
-                        if (s_last_clock_ms != 0) {
-                            int interval = (int)(now - s_last_clock_ms);
-                            // Sanity window: 24..2500 BPM range expressed
-                            // as per-clock ms (60000/(24*bpm)).
-                            if (interval > 0 && interval < 1000) {
-                                s_ring[s_ring_idx] = interval;
-                                s_ring_idx = (s_ring_idx + 1) % 24;
-                                if (s_ring_count < 24) s_ring_count++;
-                                if (s_ring_count == 24) {
-                                    int sum = 0;
-                                    for (int i = 0; i < 24; ++i) sum += s_ring[i];
-                                    // 24 intervals == one beat, so BPM =
-                                    // 60_000 ms / sum_ms.
-                                    int bpm = (sum > 0) ? (60000 / sum) : 0;
-                                    if (bpm >= 20 && bpm <= 500
-                                        && bpm != s_last_pushed_bpm) {
-                                        ztPlayer->chase_external_tempo(bpm);
-                                        s_last_pushed_bpm = bpm;
-                                    }
-                                }
-                            } else {
-                                // Out-of-range interval — treat as dropout,
-                                // reset the ring so we rebuild a clean
-                                // average once clocks resume.
-                                s_ring_count = 0;
-                                s_ring_idx = 0;
-                                s_last_pushed_bpm = 0;
-                            }
-                        }
-                        s_last_clock_ms = now;
-                    }
-                    break;
-
-                case 0xF2: // MIDI SONG POSITION POINTER
-                    song_pos_ptr = (dwParam1&0x7F0000)>>9 |
-                                   (dwParam1&0x7F00)>>8;
-                    if (ztPlayer->calc_pos(song_pos_ptr,&queued_row,&queued_order)) {
-                        queued_row=0;
-                        queued_order=0;
-                    }
-#if 0
-                    sprintf(szStatmsg, "SONG POS 0x%04x --> row %d order %d",song_pos_ptr,queued_row,queued_order);
-                    statusmsg = szStatmsg;
-                    status_change = 1;
-                    need_refresh++; 
-#endif
-                    break;
-                case 0xFA: // MIDI START
-                    queued_row=0;
-                    queued_order=0;
-                    /* fall thru */
-                case 0xFB: // MIDI CONTINUE
-                    if (ztPlayer->playing)
-                        ztPlayer->stop();
-                    g_midi_in_clocks_received = 0;
-                    if (queued_row || queued_order) {
-                        // we have a queued row and order, play from that position.
-                        ztPlayer->play(queued_row,queued_order,3);
-                    } else {
-                        if (song->orderlist[0] < 0x100) {
-                            // if there are patterns in the orderlist,
-                            // play song from the start.
-                            ztPlayer->play(0,cur_edit_pattern,1); 
-                        } else {
-                            // otherwise loop the current pattern
-                            ztPlayer->play(0,cur_edit_pattern,0);
-                        }
-                    }
-                    break;
-                case 0xFC: // MIDI STOP
-                    g_midi_in_clocks_received=0;
-                    ztPlayer->stop();
-                    break;
-                default:
-                    break;
-              }
+          // External-sync messages: this callback runs on the platform MIDI
+          // thread, so it only RECORDS what arrived (plain-int counters,
+          // same advisory contract as player::stop_count). All decisions --
+          // starting/stopping the player, tempo estimation, phase lock --
+          // happen in zt_midi_clock_pump() on the main thread.
+          switch(msg) {
+            case 0xF8: // MIDI CLOCK
+                g_mclk_clocks++;
+                g_mclk_last_clock_ms = (unsigned)SDL_GetTicks();
+                break;
+            case 0xF2: // MIDI SONG POSITION POINTER
+                g_mclk_spp_raw = (dwParam1&0x7F0000)>>9 |
+                                 (dwParam1&0x7F00)>>8;
+                g_mclk_spp_seq++;
+                break;
+            case 0xFA: g_mclk_start_req++;    break; // MIDI START
+            case 0xFB: g_mclk_continue_req++; break; // MIDI CONTINUE
+            case 0xFC: g_mclk_stop_req++;     break; // MIDI STOP
+            default:
+                break;
+          }
 
           break;
         case MIM_MOREDATA:

--- a/src/midi-io.h
+++ b/src/midi-io.h
@@ -12,7 +12,6 @@
 
 #define MIDI_MSG( cmd, chan, data1, data2) ( (cmd+chan) + (data1<<8) + (data2<<16)) 
 
-extern int g_midi_in_clocks_received;
 
 // Process-wide MIDI input message queue.
 //

--- a/src/midi_clock_sync.cpp
+++ b/src/midi_clock_sync.cpp
@@ -1,0 +1,208 @@
+/*************************************************************************
+ * midi_clock_sync.cpp
+ *
+ * See midi_clock_sync.h. Layout mirrors ableton_link.cpp:
+ *   1. observer counters (written by the MIDI-in thread, read here)
+ *   2. main-thread pump: transport consume -> tempo estimate -> phase chase
+ *
+ * The unit test (tests/test_midi_clock_sync.cpp) #includes this file with
+ * ZT_TEST_NO_SDL: zt.h is replaced by the fake app environment and the
+ * time source by a pokable counter, so every path is drivable headlessly.
+ *************************************************************************/
+#include "midi_clock_sync.h"
+#include "phase_chase.h"
+
+#include <cmath>   // lround
+
+#ifdef ZT_TEST_NO_SDL
+#include "zt_link_stub.h"     // tests/: fake player, song, conf, globals
+static unsigned g_test_now_ms = 0;          // pokable by the unit test
+static unsigned mclk_now_ms(void) { return g_test_now_ms; }
+#else
+#include "zt.h"               // ztPlayer, song, zt_config_globals, cur_edit_pattern
+static unsigned mclk_now_ms(void) { return (unsigned)SDL_GetTicks(); }
+#endif
+
+// ---------------------------------------------------------------------------
+// Observer counters (MIDI-in thread writes, pump reads).
+
+int      g_mclk_clocks        = 0;
+unsigned g_mclk_last_clock_ms = 0;
+int      g_mclk_start_req     = 0;
+int      g_mclk_continue_req  = 0;
+int      g_mclk_stop_req      = 0;
+int      g_mclk_spp_raw       = 0;
+int      g_mclk_spp_seq       = 0;
+
+// ---------------------------------------------------------------------------
+// Pump state (main thread only).
+
+// Master tempo estimate: clock-count/wall-time samples ~250 ms apart over a
+// ~1 s sliding window. Replaces the old per-interval ring that lived on the
+// MIDI thread; the window average is immune to single-clock jitter.
+#define MCLK_SAMPLES        5
+#define MCLK_SAMPLE_MS      250
+#define MCLK_DROPOUT_MS     1000
+static int      s_sample_clocks[MCLK_SAMPLES];
+static unsigned s_sample_ms[MCLK_SAMPLES];
+static int      s_sample_count = 0;     // 0..MCLK_SAMPLES, ring fill
+static int      s_sample_head  = 0;
+static double   s_tempo_est    = 0.0;   // 0 = no estimate yet
+static int      s_last_nominal_bpm = 0;
+
+// Position chase: clock count at the consumed START/CONTINUE.
+static int      s_anchor_clocks = 0;
+static bool     s_chase_valid   = false;
+
+// Transport request baselines + the queued SPP position (mirrors the old
+// static queued_row/queued_order in midi-io.cpp: SPP sets it, START zeroes
+// it, CONTINUE plays from it, and it persists across CONTINUEs).
+static int s_last_start = -1, s_last_cont = -1, s_last_stop = -1;
+static int s_last_spp_seq = -1;
+static int s_queued_row = 0, s_queued_order = 0;
+
+static void mclk_reset_estimate(void) {
+    s_sample_count = 0;
+    s_sample_head  = 0;
+    s_tempo_est    = 0.0;
+    s_last_nominal_bpm = 0;
+}
+
+static void mclk_update_estimate(unsigned now) {
+    // Dropout: master stopped sending clocks -> forget everything and stop
+    // chasing until clocks resume (rebuild a clean window like the old ring).
+    unsigned last_clock = g_mclk_last_clock_ms;
+    if (last_clock == 0 || (now - last_clock) > MCLK_DROPOUT_MS) {
+        mclk_reset_estimate();
+        return;
+    }
+    int tail = (s_sample_head + MCLK_SAMPLES - s_sample_count) % MCLK_SAMPLES;
+    if (s_sample_count == 0 ||
+        now - s_sample_ms[(s_sample_head + MCLK_SAMPLES - 1) % MCLK_SAMPLES] >= MCLK_SAMPLE_MS) {
+        s_sample_clocks[s_sample_head] = g_mclk_clocks;
+        s_sample_ms[s_sample_head]     = now;
+        s_sample_head = (s_sample_head + 1) % MCLK_SAMPLES;
+        if (s_sample_count < MCLK_SAMPLES) s_sample_count++;
+        tail = (s_sample_head + MCLK_SAMPLES - s_sample_count) % MCLK_SAMPLES;
+    }
+    if (s_sample_count < 2) return;
+    int      head_i  = (s_sample_head + MCLK_SAMPLES - 1) % MCLK_SAMPLES;
+    int      dclocks = s_sample_clocks[head_i] - s_sample_clocks[tail];
+    unsigned dms     = s_sample_ms[head_i] - s_sample_ms[tail];
+    if (dclocks <= 0 || dms == 0) return;
+    // 24 clocks per beat: BPM = clocks/24 per minute.
+    double est = ((double)dclocks / 24.0) * 60000.0 / (double)dms;
+    if (est >= 20.0 && est <= 500.0)
+        s_tempo_est = est;
+}
+
+static void mclk_consume_transport(void) {
+    int s  = g_mclk_start_req;
+    int c  = g_mclk_continue_req;
+    int st = g_mclk_stop_req;
+    int sq = g_mclk_spp_seq;
+    bool start_intent = (s_last_start >= 0 && s != s_last_start);
+    bool cont_intent  = (s_last_cont  >= 0 && c != s_last_cont);
+    bool stop_intent  = (s_last_stop  >= 0 && st != s_last_stop);
+    bool spp_changed  = (s_last_spp_seq >= 0 && sq != s_last_spp_seq);
+    s_last_start = s; s_last_cont = c; s_last_stop = st; s_last_spp_seq = sq;
+
+    if (spp_changed) {
+        if (ztPlayer->calc_pos(g_mclk_spp_raw, &s_queued_row, &s_queued_order)) {
+            s_queued_row   = 0;
+            s_queued_order = 0;
+        }
+    }
+    if (stop_intent) {
+        ztPlayer->stop();
+        s_chase_valid = false;
+    }
+    if (start_intent || cont_intent) {
+        if (start_intent) {                  // START always means position 0
+            s_queued_row   = 0;
+            s_queued_order = 0;
+        }
+        if (ztPlayer->playing)
+            ztPlayer->stop();
+        // Same target rules the MIDI-thread handler used (midi-io.cpp,
+        // pre-refactor): an SPP-queued position plays from there; otherwise
+        // play the song from the start when the orderlist has entries, else
+        // loop the current pattern.
+        if (s_queued_row || s_queued_order) {
+            ztPlayer->play(s_queued_row, s_queued_order, 3);
+        } else if (song->orderlist[0] < 0x100) {
+            ztPlayer->play(0, cur_edit_pattern, 1);
+        } else {
+            ztPlayer->play(0, cur_edit_pattern, 0);
+        }
+        s_anchor_clocks = g_mclk_clocks;     // expected position 0 is NOW
+        s_chase_valid   = true;
+    }
+}
+
+static void mclk_chase(unsigned now) {
+    if (!zt_config_globals.midi_in_sync_chase_tempo) {
+        // Transport-only mode: never touch the engine rate (matches the old
+        // behavior where the tempo ring was gated on this flag).
+        ztPlayer->chase_skew_us = 0;
+        s_chase_valid = false;
+        return;
+    }
+    if (!ztPlayer->playing || s_tempo_est <= 0.0) {
+        ztPlayer->chase_skew_us = 0;
+        return;
+    }
+    // Keep the engine nominal on the rounded master tempo (the old
+    // chase_external_tempo contract: never writes song->bpm). The fractional
+    // remainder is the chase's rate term.
+    int bpm_int = (int)lround(s_tempo_est);
+    if (bpm_int != s_last_nominal_bpm) {
+        ztPlayer->chase_external_tempo(bpm_int);
+        s_last_nominal_bpm = bpm_int;
+    }
+    if (!s_chase_valid) {
+        // Started outside a consumed START (e.g. local F6 while slaved):
+        // anchor at the current position so the lock is drift-only.
+        s_anchor_clocks = g_mclk_clocks - ztPlayer->played_subticks / 4;
+        s_chase_valid   = true;
+        return;
+    }
+    // Expected position: 4 subticks per clock, plus intra-clock
+    // interpolation from wall time so the reference doesn't advance in
+    // 4-subtick stairs (~20 ms at 120 BPM) that would kick the controller
+    // out of its steady-state deadband.
+    double clock_period_ms = 60000.0 / (24.0 * s_tempo_est);
+    double frac = (double)(now - g_mclk_last_clock_ms) / clock_period_ms * 4.0;
+    if (frac < 0.0) frac = 0.0;
+    if (frac > 3.99) frac = 3.99;
+    // sync_offset_ms: play early so notes monitored through the master
+    // DAW's audio chain sound on the grid -- live-dialable, same as Link.
+    double off_subticks = (double)zt_config_globals.sync_offset_ms
+                          * s_tempo_est / 60000.0 * 96.0;
+    double expected = (double)(g_mclk_clocks - s_anchor_clocks) * 4.0
+                      + frac + off_subticks;
+    double exact_us   = 60000000.0 / (96.0 * s_tempo_est);
+    double nominal_us = (double)(ztPlayer->subtick_len_ms + ztPlayer->subtick_len_mms);
+    ztPlayer->chase_skew_us = phase_chase_step(expected, ztPlayer->played_subticks,
+                                               exact_us, nominal_us);
+}
+
+void zt_midi_clock_pump(void) {
+    if (!ztPlayer) return;
+    if (!zt_config_globals.midi_in_sync) {
+        // Track baselines while disabled so a pile of requests received
+        // before enabling doesn't replay as intents; leave chase_skew_us
+        // alone -- the Link pump may own it.
+        s_last_start   = g_mclk_start_req;
+        s_last_cont    = g_mclk_continue_req;
+        s_last_stop    = g_mclk_stop_req;
+        s_last_spp_seq = g_mclk_spp_seq;
+        s_chase_valid  = false;
+        mclk_reset_estimate();
+        return;
+    }
+    unsigned now = mclk_now_ms();
+    mclk_consume_transport();
+    mclk_update_estimate(now);
+    mclk_chase(now);
+}

--- a/src/midi_clock_sync.cpp
+++ b/src/midi_clock_sync.cpp
@@ -26,13 +26,13 @@ static unsigned mclk_now_ms(void) { return (unsigned)SDL_GetTicks(); }
 // ---------------------------------------------------------------------------
 // Observer counters (MIDI-in thread writes, pump reads).
 
-int      g_mclk_clocks        = 0;
-unsigned g_mclk_last_clock_ms = 0;
-int      g_mclk_start_req     = 0;
-int      g_mclk_continue_req  = 0;
-int      g_mclk_stop_req      = 0;
-int      g_mclk_spp_raw       = 0;
-int      g_mclk_spp_seq       = 0;
+std::atomic<int>      g_mclk_clocks        {0};
+std::atomic<unsigned> g_mclk_last_clock_ms {0};
+std::atomic<int>      g_mclk_start_req     {0};
+std::atomic<int>      g_mclk_continue_req  {0};
+std::atomic<int>      g_mclk_stop_req      {0};
+std::atomic<int>      g_mclk_spp_raw       {0};
+std::atomic<int>      g_mclk_spp_seq       {0};
 
 // ---------------------------------------------------------------------------
 // Pump state (main thread only).
@@ -68,10 +68,9 @@ static void mclk_reset_estimate(void) {
     s_last_nominal_bpm = 0;
 }
 
-static void mclk_update_estimate(unsigned now) {
+static void mclk_update_estimate(unsigned now, int clocks, unsigned last_clock) {
     // Dropout: master stopped sending clocks -> forget everything and stop
     // chasing until clocks resume (rebuild a clean window like the old ring).
-    unsigned last_clock = g_mclk_last_clock_ms;
     if (last_clock == 0 || (now - last_clock) > MCLK_DROPOUT_MS) {
         mclk_reset_estimate();
         return;
@@ -79,7 +78,7 @@ static void mclk_update_estimate(unsigned now) {
     int tail = (s_sample_head + MCLK_SAMPLES - s_sample_count) % MCLK_SAMPLES;
     if (s_sample_count == 0 ||
         now - s_sample_ms[(s_sample_head + MCLK_SAMPLES - 1) % MCLK_SAMPLES] >= MCLK_SAMPLE_MS) {
-        s_sample_clocks[s_sample_head] = g_mclk_clocks;
+        s_sample_clocks[s_sample_head] = clocks;
         s_sample_ms[s_sample_head]     = now;
         s_sample_head = (s_sample_head + 1) % MCLK_SAMPLES;
         if (s_sample_count < MCLK_SAMPLES) s_sample_count++;
@@ -96,7 +95,7 @@ static void mclk_update_estimate(unsigned now) {
         s_tempo_est = est;
 }
 
-static void mclk_consume_transport(void) {
+static void mclk_consume_transport(int clocks_now) {
     int s  = g_mclk_start_req;
     int c  = g_mclk_continue_req;
     int st = g_mclk_stop_req;
@@ -135,12 +134,12 @@ static void mclk_consume_transport(void) {
         } else {
             ztPlayer->play(0, cur_edit_pattern, 0);
         }
-        s_anchor_clocks = g_mclk_clocks;     // expected position 0 is NOW
+        s_anchor_clocks = clocks_now;        // expected position 0 is NOW
         s_chase_valid   = true;
     }
 }
 
-static void mclk_chase(unsigned now) {
+static void mclk_chase(unsigned now, int clocks, unsigned last_clock) {
     if (!zt_config_globals.midi_in_sync_chase_tempo) {
         // Transport-only mode: never touch the engine rate (matches the old
         // behavior where the tempo ring was gated on this flag).
@@ -163,7 +162,7 @@ static void mclk_chase(unsigned now) {
     if (!s_chase_valid) {
         // Started outside a consumed START (e.g. local F6 while slaved):
         // anchor at the current position so the lock is drift-only.
-        s_anchor_clocks = g_mclk_clocks - ztPlayer->played_subticks / 4;
+        s_anchor_clocks = clocks - ztPlayer->played_subticks / 4;
         s_chase_valid   = true;
         return;
     }
@@ -172,14 +171,14 @@ static void mclk_chase(unsigned now) {
     // 4-subtick stairs (~20 ms at 120 BPM) that would kick the controller
     // out of its steady-state deadband.
     double clock_period_ms = 60000.0 / (24.0 * s_tempo_est);
-    double frac = (double)(now - g_mclk_last_clock_ms) / clock_period_ms * 4.0;
+    double frac = (double)(now - last_clock) / clock_period_ms * 4.0;
     if (frac < 0.0) frac = 0.0;
     if (frac > 3.99) frac = 3.99;
     // sync_offset_ms: play early so notes monitored through the master
     // DAW's audio chain sound on the grid -- live-dialable, same as Link.
     double off_subticks = (double)zt_config_globals.sync_offset_ms
                           * s_tempo_est / 60000.0 * 96.0;
-    double expected = (double)(g_mclk_clocks - s_anchor_clocks) * 4.0
+    double expected = (double)(clocks - s_anchor_clocks) * 4.0
                       + frac + off_subticks;
     double exact_us   = 60000000.0 / (96.0 * s_tempo_est);
     double nominal_us = (double)(ztPlayer->subtick_len_ms + ztPlayer->subtick_len_mms);
@@ -202,7 +201,17 @@ void zt_midi_clock_pump(void) {
         return;
     }
     unsigned now = mclk_now_ms();
-    mclk_consume_transport();
-    mclk_update_estimate(now);
-    mclk_chase(now);
+    // One consistent snapshot of the clock counters for this whole frame, so
+    // the anchor (consume), the tempo sample (estimate) and the position
+    // reference (chase) can't disagree by a clock that lands mid-pump. Read
+    // the COUNT before the TIMESTAMP: if a 0xF8 arrives between the two loads
+    // we then see (old count, fresh timestamp) -> the interpolation fraction
+    // collapses toward 0, which is consistent. The opposite order would briefly
+    // add a whole clock (new count) on top of a near-full fraction (~20 ms at
+    // 120 BPM) and kick the controller out of its deadband.
+    int      clocks     = g_mclk_clocks;
+    unsigned last_clock = g_mclk_last_clock_ms;
+    mclk_consume_transport(clocks);
+    mclk_update_estimate(now, clocks, last_clock);
+    mclk_chase(now, clocks, last_clock);
 }

--- a/src/midi_clock_sync.cpp
+++ b/src/midi_clock_sync.cpp
@@ -43,6 +43,12 @@ std::atomic<int>      g_mclk_spp_seq       {0};
 #define MCLK_SAMPLES        5
 #define MCLK_SAMPLE_MS      250
 #define MCLK_DROPOUT_MS     1000
+// Position error past this is a discontinuity (a multi-frame stall, not a
+// deliberate move) -> snap instead of slew. Set well above the controller's
+// normal operating range: a half-beat catch-up and the 0-500 ms Sync Offset
+// are deliberate moves the move-tier is meant to slew, so the snap floor sits
+// at ~1 s to catch only genuine discontinuities.
+#define MCLK_SNAP_MS        1000.0
 static int      s_sample_clocks[MCLK_SAMPLES];
 static unsigned s_sample_ms[MCLK_SAMPLES];
 static int      s_sample_count = 0;     // 0..MCLK_SAMPLES, ring fill
@@ -65,18 +71,23 @@ static int s_last_start = -1, s_last_cont = -1, s_last_stop = -1;
 static int s_last_spp_seq = -1;
 static int s_queued_row = 0, s_queued_order = 0;
 
-static void mclk_reset_estimate(void) {
+// keep_tempo: drop the sample window but PRESERVE s_tempo_est, so a brief
+// dropout warm-re-locks from the last known tempo instead of cold-starting
+// (~1 s of wander). Cold reset (keep_tempo=false) only when sync is disabled.
+static void mclk_reset_estimate(bool keep_tempo) {
     s_sample_count = 0;
     s_sample_head  = 0;
-    s_tempo_est    = 0.0;
-    s_last_nominal_bpm = 0;
+    if (!keep_tempo) {
+        s_tempo_est        = 0.0;
+        s_last_nominal_bpm = 0;
+    }
 }
 
-static void mclk_update_estimate(unsigned now, int clocks, unsigned last_clock) {
-    // Dropout: master stopped sending clocks -> forget everything and stop
-    // chasing until clocks resume (rebuild a clean window like the old ring).
-    if (last_clock == 0 || (now - last_clock) > MCLK_DROPOUT_MS) {
-        mclk_reset_estimate();
+static void mclk_update_estimate(unsigned now, int clocks, bool clocks_recent) {
+    // Dropout: master stopped sending clocks. Drop the stale window but keep
+    // the last tempo (warm re-lock); the chase stops separately.
+    if (!clocks_recent) {
+        mclk_reset_estimate(/*keep_tempo=*/true);
         return;
     }
     int tail = (s_sample_head + MCLK_SAMPLES - s_sample_count) % MCLK_SAMPLES;
@@ -143,10 +154,20 @@ static void mclk_consume_transport(int clocks_now) {
     }
 }
 
-static void mclk_chase(unsigned now, int clocks, unsigned last_clock) {
+static void mclk_chase(unsigned now, int clocks, unsigned last_clock,
+                       bool clocks_recent) {
     if (!zt_config_globals.midi_in_sync_chase_tempo) {
         // Transport-only mode: never touch the engine rate (matches the old
         // behavior where the tempo ring was gated on this flag).
+        ztPlayer->chase_skew_us = 0;
+        s_chase_valid = false;
+        s_offset_ms   = 0.0;
+        return;
+    }
+    if (!clocks_recent) {
+        // Dropout: the position reference is stale. Stop steering and free-run
+        // the engine at the last nominal tempo; invalidate the anchor so the
+        // first chase after clocks resume re-anchors (warm re-lock).
         ztPlayer->chase_skew_us = 0;
         s_chase_valid = false;
         s_offset_ms   = 0.0;
@@ -189,11 +210,23 @@ static void mclk_chase(unsigned now, int clocks, unsigned last_clock) {
                       + frac + off_subticks;
     double exact_us   = 60000000.0 / (96.0 * s_tempo_est);
     double nominal_us = (double)(ztPlayer->subtick_len_ms + ztPlayer->subtick_len_mms);
+    // Position error (the quantity phase_chase_step feeds back on): engine
+    // behind the master grid = positive.
+    double err_ms = (expected - (double)ztPlayer->played_subticks) * exact_us / 1000.0;
+    if (err_ms > MCLK_SNAP_MS || err_ms < -MCLK_SNAP_MS) {
+        // A jump this large isn't drift -- it's a discontinuity (a main-loop
+        // stall that skipped frames, or the engine resuming behind). Slewing it
+        // back at the controller's bounded authority would take ~1.4 s and
+        // audibly rush; instead snap the anchor to the engine's current
+        // position and let the fine lock re-establish over the next frames.
+        s_anchor_clocks = clocks - ztPlayer->played_subticks / 4;
+        ztPlayer->chase_skew_us = 0;
+        s_offset_ms = 0.0;
+        return;
+    }
     ztPlayer->chase_skew_us = phase_chase_step(expected, ztPlayer->played_subticks,
                                                exact_us, nominal_us);
-    // Position error for the status readout (same quantity phase_chase_step
-    // feeds back on): engine behind the master grid = positive.
-    s_offset_ms = (expected - (double)ztPlayer->played_subticks) * exact_us / 1000.0;
+    s_offset_ms = err_ms;
 }
 
 void zt_midi_clock_pump(void) {
@@ -207,7 +240,7 @@ void zt_midi_clock_pump(void) {
         s_last_stop    = g_mclk_stop_req;
         s_last_spp_seq = g_mclk_spp_seq;
         s_chase_valid  = false;
-        mclk_reset_estimate();
+        mclk_reset_estimate(/*keep_tempo=*/false);
         s_state     = ZT_SYNC_OFF;
         s_offset_ms = 0.0;
         return;
@@ -221,14 +254,14 @@ void zt_midi_clock_pump(void) {
     // collapses toward 0, which is consistent. The opposite order would briefly
     // add a whole clock (new count) on top of a near-full fraction (~20 ms at
     // 120 BPM) and kick the controller out of its deadband.
-    int      clocks     = g_mclk_clocks;
-    unsigned last_clock = g_mclk_last_clock_ms;
+    int      clocks      = g_mclk_clocks;
+    unsigned last_clock  = g_mclk_last_clock_ms;
+    bool clocks_recent   = (last_clock != 0) && ((now - last_clock) <= MCLK_DROPOUT_MS);
     mclk_consume_transport(clocks);
-    mclk_update_estimate(now, clocks, last_clock);
-    mclk_chase(now, clocks, last_clock);
+    mclk_update_estimate(now, clocks, clocks_recent);
+    mclk_chase(now, clocks, last_clock, clocks_recent);
 
     // Derive the user-facing lock state (F11 meter + Lua) from the snapshot.
-    bool clocks_recent = (last_clock != 0) && ((now - last_clock) <= MCLK_DROPOUT_MS);
     if (!clocks_recent) {
         s_state = (last_clock == 0) ? ZT_SYNC_WAITING : ZT_SYNC_DROPOUT;
     } else if (!zt_config_globals.midi_in_sync_chase_tempo) {

--- a/src/midi_clock_sync.cpp
+++ b/src/midi_clock_sync.cpp
@@ -54,6 +54,10 @@ static int      s_last_nominal_bpm = 0;
 static int      s_anchor_clocks = 0;
 static bool     s_chase_valid   = false;
 
+// User-facing status (F11 lock meter + Lua), refreshed at the end of the pump.
+static int      s_state     = ZT_SYNC_OFF;
+static double   s_offset_ms = 0.0;          // signed position error, 0 unless chasing
+
 // Transport request baselines + the queued SPP position (mirrors the old
 // static queued_row/queued_order in midi-io.cpp: SPP sets it, START zeroes
 // it, CONTINUE plays from it, and it persists across CONTINUEs).
@@ -145,10 +149,12 @@ static void mclk_chase(unsigned now, int clocks, unsigned last_clock) {
         // behavior where the tempo ring was gated on this flag).
         ztPlayer->chase_skew_us = 0;
         s_chase_valid = false;
+        s_offset_ms   = 0.0;
         return;
     }
     if (!ztPlayer->playing || s_tempo_est <= 0.0) {
         ztPlayer->chase_skew_us = 0;
+        s_offset_ms = 0.0;
         return;
     }
     // Keep the engine nominal on the rounded master tempo (the old
@@ -164,6 +170,7 @@ static void mclk_chase(unsigned now, int clocks, unsigned last_clock) {
         // anchor at the current position so the lock is drift-only.
         s_anchor_clocks = clocks - ztPlayer->played_subticks / 4;
         s_chase_valid   = true;
+        s_offset_ms     = 0.0;
         return;
     }
     // Expected position: 4 subticks per clock, plus intra-clock
@@ -184,6 +191,9 @@ static void mclk_chase(unsigned now, int clocks, unsigned last_clock) {
     double nominal_us = (double)(ztPlayer->subtick_len_ms + ztPlayer->subtick_len_mms);
     ztPlayer->chase_skew_us = phase_chase_step(expected, ztPlayer->played_subticks,
                                                exact_us, nominal_us);
+    // Position error for the status readout (same quantity phase_chase_step
+    // feeds back on): engine behind the master grid = positive.
+    s_offset_ms = (expected - (double)ztPlayer->played_subticks) * exact_us / 1000.0;
 }
 
 void zt_midi_clock_pump(void) {
@@ -198,6 +208,8 @@ void zt_midi_clock_pump(void) {
         s_last_spp_seq = g_mclk_spp_seq;
         s_chase_valid  = false;
         mclk_reset_estimate();
+        s_state     = ZT_SYNC_OFF;
+        s_offset_ms = 0.0;
         return;
     }
     unsigned now = mclk_now_ms();
@@ -214,4 +226,37 @@ void zt_midi_clock_pump(void) {
     mclk_consume_transport(clocks);
     mclk_update_estimate(now, clocks, last_clock);
     mclk_chase(now, clocks, last_clock);
+
+    // Derive the user-facing lock state (F11 meter + Lua) from the snapshot.
+    bool clocks_recent = (last_clock != 0) && ((now - last_clock) <= MCLK_DROPOUT_MS);
+    if (!clocks_recent) {
+        s_state = (last_clock == 0) ? ZT_SYNC_WAITING : ZT_SYNC_DROPOUT;
+    } else if (!zt_config_globals.midi_in_sync_chase_tempo) {
+        s_state = ZT_SYNC_TRANSPORT;
+    } else if (s_tempo_est <= 0.0 || !ztPlayer->playing) {
+        s_state = ZT_SYNC_WAITING;
+    } else {
+        double err_us = s_offset_ms * 1000.0;
+        s_state = (err_us <= PHASE_CHASE_DEADBAND_US && err_us >= -PHASE_CHASE_DEADBAND_US)
+                  ? ZT_SYNC_LOCKED : ZT_SYNC_CHASING;
+    }
+}
+
+void zt_midi_clock_get_status(zt_sync_status *out) {
+    if (!out) return;
+    out->state      = s_state;
+    out->master_bpm = s_tempo_est;
+    out->offset_ms  = s_offset_ms;
+}
+
+const char *zt_sync_state_name(int state) {
+    switch (state) {
+        case ZT_SYNC_WAITING:   return "waiting";
+        case ZT_SYNC_DROPOUT:   return "dropout";
+        case ZT_SYNC_TRANSPORT: return "transport";
+        case ZT_SYNC_CHASING:   return "chasing";
+        case ZT_SYNC_LOCKED:    return "locked";
+        case ZT_SYNC_OFF:
+        default:                return "off";
+    }
 }

--- a/src/midi_clock_sync.h
+++ b/src/midi_clock_sync.h
@@ -1,0 +1,37 @@
+/*************************************************************************
+ * midi_clock_sync.h
+ *
+ * MIDI clock slave sync (midi_in_sync / midi_in_sync_chase_tempo), built
+ * on the same observer architecture as the Ableton Link integration: the
+ * MIDI-in callback thread only RECORDS what arrived (plain-int counters,
+ * same advisory contract as player::stop_count); all decisions -- starting
+ * and stopping the player, deriving the master tempo, phase-locking the
+ * engine -- happen in zt_midi_clock_pump() on the main thread, once per
+ * frame. Drives the engine through the shared phase_chase.h controller, so
+ * a fractional-tempo master cannot drift, and honors sync_offset_ms (play
+ * early to beat a DAW's monitoring latency) identically to Link.
+ *
+ * A MIDI clock stream is a position reference, not just a rate: 24 clocks
+ * per beat = 4 subticks per clock. Counting clocks since the consumed
+ * START gives "expected position" exactly as Link's beatAtTime does.
+ *************************************************************************/
+#ifndef ZT_MIDI_CLOCK_SYNC_H
+#define ZT_MIDI_CLOCK_SYNC_H
+
+/* Observer counters, bumped ONLY by the MIDI-in callback thread
+ * (midi-io.cpp), read by the pump. Plain ints on purpose. */
+extern int      g_mclk_clocks;          /* 0xF8 count, monotonic            */
+extern unsigned g_mclk_last_clock_ms;   /* SDL_GetTicks() at the last 0xF8  */
+extern int      g_mclk_start_req;       /* 0xFA count                       */
+extern int      g_mclk_continue_req;    /* 0xFB count                       */
+extern int      g_mclk_stop_req;        /* 0xFC count                       */
+extern int      g_mclk_spp_raw;         /* last 0xF2 value (14-bit)         */
+extern int      g_mclk_spp_seq;         /* bumped per 0xF2                  */
+
+/* Per-frame pump: consume transport requests (start/continue/stop on the
+ * main thread), estimate the master tempo as a double from clock arrival
+ * counts, and phase-lock the playing engine to the clock grid. Call once
+ * per main loop, next to zt_ableton_link_pump(). */
+void zt_midi_clock_pump(void);
+
+#endif /* ZT_MIDI_CLOCK_SYNC_H */

--- a/src/midi_clock_sync.h
+++ b/src/midi_clock_sync.h
@@ -18,15 +18,23 @@
 #ifndef ZT_MIDI_CLOCK_SYNC_H
 #define ZT_MIDI_CLOCK_SYNC_H
 
+#include <atomic>
+
 /* Observer counters, bumped ONLY by the MIDI-in callback thread
- * (midi-io.cpp), read by the pump. Plain ints on purpose. */
-extern int      g_mclk_clocks;          /* 0xF8 count, monotonic            */
-extern unsigned g_mclk_last_clock_ms;   /* SDL_GetTicks() at the last 0xF8  */
-extern int      g_mclk_start_req;       /* 0xFA count                       */
-extern int      g_mclk_continue_req;    /* 0xFB count                       */
-extern int      g_mclk_stop_req;        /* 0xFC count                       */
-extern int      g_mclk_spp_raw;         /* last 0xF2 value (14-bit)         */
-extern int      g_mclk_spp_seq;         /* bumped per 0xF2                  */
+ * (midi-io.cpp), read by the pump on the main thread. std::atomic, not plain
+ * int: a value written on one thread and read on another is a data race in
+ * the C++ memory model -- atomic makes it well-defined (ThreadSanitizer-clean).
+ * We rely only on per-counter atomicity, not on any ordering BETWEEN counters:
+ * each is an independent monotonic tally and the pump re-reads every frame,
+ * tolerating a bump seen a frame late. Cost is nil on the targets we ship --
+ * an aligned-word load/store, same as the plain int it replaces. */
+extern std::atomic<int>      g_mclk_clocks;        /* 0xF8 count, monotonic           */
+extern std::atomic<unsigned> g_mclk_last_clock_ms; /* SDL_GetTicks() at the last 0xF8 */
+extern std::atomic<int>      g_mclk_start_req;     /* 0xFA count                      */
+extern std::atomic<int>      g_mclk_continue_req;  /* 0xFB count                      */
+extern std::atomic<int>      g_mclk_stop_req;      /* 0xFC count                      */
+extern std::atomic<int>      g_mclk_spp_raw;       /* last 0xF2 value (14-bit)        */
+extern std::atomic<int>      g_mclk_spp_seq;       /* bumped per 0xF2                 */
 
 /* Per-frame pump: consume transport requests (start/continue/stop on the
  * main thread), estimate the master tempo as a double from clock arrival

--- a/src/midi_clock_sync.h
+++ b/src/midi_clock_sync.h
@@ -42,4 +42,26 @@ extern std::atomic<int>      g_mclk_spp_seq;       /* bumped per 0xF2           
  * per main loop, next to zt_ableton_link_pump(). */
 void zt_midi_clock_pump(void);
 
+/* --- Sync status -----------------------------------------------------------
+ * Snapshot of the chase, refreshed once per zt_midi_clock_pump(). Read on the
+ * MAIN thread only (F11 lock meter, Lua zt.transport.sync_*), so it needs no
+ * locking -- pump and readers are the same thread. */
+enum zt_sync_state {
+    ZT_SYNC_OFF = 0,    /* MIDI In Sync disabled                              */
+    ZT_SYNC_WAITING,    /* enabled, no usable clock yet (acquiring/not playing)*/
+    ZT_SYNC_DROPOUT,    /* clock was flowing, then stopped (> dropout window)  */
+    ZT_SYNC_TRANSPORT,  /* following start/stop only (Chase MIDI Tempo off)    */
+    ZT_SYNC_CHASING,    /* phase-locking, error outside the deadband           */
+    ZT_SYNC_LOCKED      /* phase-locked, error within the deadband             */
+};
+
+struct zt_sync_status {
+    int    state;       /* zt_sync_state                                       */
+    double master_bpm;  /* estimated master tempo, 0.0 if none                 */
+    double offset_ms;   /* signed position error (engine behind = +); 0 unless chasing */
+};
+
+void        zt_midi_clock_get_status(zt_sync_status *out);
+const char *zt_sync_state_name(int state);   /* "off" / "waiting" / ... / "locked" */
+
 #endif /* ZT_MIDI_CLOCK_SYNC_H */

--- a/src/midi_timestamp.h
+++ b/src/midi_timestamp.h
@@ -1,0 +1,59 @@
+#ifndef ZT_MIDI_TIMESTAMP_H
+#define ZT_MIDI_TIMESTAMP_H
+
+// Pure helpers for using a platform MIDI hardware timestamp as the clock
+// arrival time, instead of sampling a software clock inside the input
+// callback (which adds OS-scheduling jitter on top of the real arrival).
+//
+// The MIDI-clock pump compares the stored arrival time against SDL_GetTicks(),
+// so any hardware stamp MUST be expressed in that same millisecond epoch.
+// macOS CoreMIDI packet timestamps are mach_absolute_time ticks (a different
+// epoch), so we convert them using a (now_mach, now_sdl_ms) pair sampled at the
+// same instant in the callback, plus the mach timebase (ns = ticks*numer/denom).
+//
+// SDL-free / CoreMIDI-free on purpose: exhaustively unit-tested
+// (tests/test_midi_timestamp.cpp) and used from midi-io.cpp under __APPLE__.
+//
+// These two are designed to be used TOGETHER: convert, then gate. The gate is
+// what makes a garbage hardware stamp harmless -- it falls back to the software
+// clock rather than feeding a wild arrival time into the phase lock.
+
+#include <stdint.h>
+
+// Convert a mach_absolute_time packet stamp into the SDL_GetTicks() ms epoch.
+// `now_mach`/`now_sdl_ms` are sampled at the same instant; the packet is in the
+// past, so its arrival = now_sdl_ms - age. A future-dated packet (can happen
+// with scheduled delivery) clamps age to 0. denom==0 (no timebase) -> fallback
+// to now_sdl_ms.
+static inline uint32_t zt_mach_stamp_to_sdl_ms(uint64_t packet_mach,
+                                               uint64_t now_mach,
+                                               uint32_t now_sdl_ms,
+                                               uint32_t numer, uint32_t denom)
+{
+    if (denom == 0) return now_sdl_ms;
+    if (packet_mach >= now_mach) return now_sdl_ms;          // future / same instant
+    uint64_t age_ticks = now_mach - packet_mach;
+    // Cap before the multiply so garbage (e.g. packet_mach==0) can't overflow;
+    // anything this old is rejected by zt_pick_clock_stamp anyway.
+    if (age_ticks > (uint64_t)1 << 40) return now_sdl_ms - 0xFFFFFFu; // -> rejected
+    uint64_t age_ms = (age_ticks * (uint64_t)numer / (uint64_t)denom) / 1000000ull;
+    if (age_ms > 0xFFFFFFu) age_ms = 0xFFFFFFu;
+    return now_sdl_ms - (uint32_t)age_ms;
+}
+
+// Accept a hardware-derived stamp only if it's plausible relative to the
+// software-clock fallback: not stale (older than max_age_ms) and not in the
+// future beyond future_tol_ms. Otherwise use `fallback_ms`. Wrap-safe via
+// signed difference.
+static inline uint32_t zt_pick_clock_stamp(uint32_t candidate_ms,
+                                           uint32_t fallback_ms,
+                                           uint32_t max_age_ms,
+                                           uint32_t future_tol_ms)
+{
+    int64_t age = (int64_t)fallback_ms - (int64_t)candidate_ms;
+    if (age < -(int64_t)future_tol_ms) return fallback_ms;   // too far future
+    if (age >  (int64_t)max_age_ms)    return fallback_ms;   // too old / garbage
+    return candidate_ms;
+}
+
+#endif // ZT_MIDI_TIMESTAMP_H

--- a/src/phase_chase.h
+++ b/src/phase_chase.h
@@ -1,0 +1,54 @@
+/*************************************************************************
+ * phase_chase.h
+ *
+ * The closed-loop position controller shared by the external-sync chases
+ * (Ableton Link in ableton_link.cpp, MIDI clock in midi_clock_sync.cpp).
+ * Pure logic, no app or SDL dependencies, exhaustively unit-tested
+ * (tests/test_phase_chase.cpp) -- same pattern as preset_selector.h.
+ *
+ * The caller compares two clocks each frame: where the master timeline
+ * says the engine should be (expected subticks since some anchor) versus
+ * the engine's own odometer (player::played_subticks), and applies the
+ * returned skew to player::chase_skew_us. Any residual rate error -- int
+ * BPM rounding, set_speed()'s whole-us truncation, a peer machine's
+ * crystal -- integrates into position error, which the loop cancels:
+ *
+ *   skew = (exact master subtick - engine nominal subtick)   rate term
+ *        - bounded P feedback on the position error
+ *
+ * Feedback authority is tiered: inside PHASE_CHASE_DEADBAND_US the
+ * correction stays far below audibility; beyond it the error is a
+ * deliberate move (offset slider, tempo step) and may slew hard -- the
+ * output is MIDI, so a brief rush while the user turns a knob is
+ * harmless. Positive position error = engine behind = shorter subticks.
+ *************************************************************************/
+#ifndef ZT_PHASE_CHASE_H
+#define ZT_PHASE_CHASE_H
+
+#include <cmath>   // lround
+
+#define PHASE_CHASE_DEADBAND_US   10000.0   /* steady-state vs deliberate-move */
+#define PHASE_CHASE_FB_STEADY     0.003     /* inaudible lock corrections */
+#define PHASE_CHASE_FB_MOVE       0.12      /* ~171 ms move locks in ~1.4 s */
+#define PHASE_CHASE_SKEW_CLAMP    0.15      /* absolute authority ceiling */
+
+static inline int phase_chase_step(double expected_subticks,
+                                   int    played_subticks,
+                                   double exact_subtick_us,
+                                   double nominal_subtick_us)
+{
+    double pos_err  = (expected_subticks - (double)played_subticks) * exact_subtick_us;
+    double feedback = pos_err / 64.0;
+    double fb_max   = exact_subtick_us *
+        ((pos_err > PHASE_CHASE_DEADBAND_US || pos_err < -PHASE_CHASE_DEADBAND_US)
+             ? PHASE_CHASE_FB_MOVE : PHASE_CHASE_FB_STEADY);
+    if (feedback >  fb_max) feedback =  fb_max;
+    if (feedback < -fb_max) feedback = -fb_max;
+    double skew = (exact_subtick_us - nominal_subtick_us) - feedback;
+    double skew_max = exact_subtick_us * PHASE_CHASE_SKEW_CLAMP;
+    if (skew >  skew_max) skew =  skew_max;
+    if (skew < -skew_max) skew = -skew_max;
+    return (int)lround(skew);
+}
+
+#endif /* ZT_PHASE_CHASE_H */

--- a/src/playback.cpp
+++ b/src/playback.cpp
@@ -44,7 +44,6 @@
 #include <algorithm>
 #include <stdint.h>
 
-int mctr = 0;
 
 #define TARGET_RESOLUTION 1         // 1-millisecond target resolution
 
@@ -74,23 +73,6 @@ void CALLBACK player_callback(UINT wTimerID, UINT msg, DWORD_PTR dwUser, DWORD_P
   ztPlayer->counter += ztPlayer->wTimerRes*1000;
 
   if (ztPlayer->counter >= (ztPlayer->subtick_len_ms+ztPlayer->subtick_add+ztPlayer->chase_adj)) {
-
-    if (zt_config_globals.midi_in_sync) {
-
-      if (mctr >= 4) {
-
-        if (g_midi_in_clocks_received) {
-        
-          g_midi_in_clocks_received--;
-          mctr = 0;
-        }
-        else {
-        
-          //goto skip ;
-        }
-      }
-      else mctr++;
-    }
 
     ztPlayer->counter = 0;
     ztPlayer->played_subticks++;
@@ -566,8 +548,6 @@ void player::prepare_play(int row, int pattern, int pm, int loopmode)
     chase_skew_us = 0;
     chase_err_us = 0;
     chase_adj = 0;
-
-    mctr = 0;
 
     skip = 0xFFF;
     this->tpb = song->tpb;

--- a/src/winmm_compat.h
+++ b/src/winmm_compat.h
@@ -1047,11 +1047,15 @@ static inline MMRESULT zt_midi_out_sysex(HMIDIOUT h, const unsigned char *bytes,
     return MMSYSERR_ERROR;
 }
 
-static inline void zt_coremidi_emit_data(zt_coremidi_in_handle *ctx, unsigned int packed_msg) {
+static inline void zt_coremidi_emit_data(zt_coremidi_in_handle *ctx, unsigned int packed_msg,
+                                         UInt64 host_stamp) {
     if (!ctx || !ctx->callback) {
         return;
     }
-    ctx->callback((HMIDIIN)ctx, MIM_DATA, ctx->instance, (DWORD_PTR)packed_msg, 0);
+    // dwParam2 carries the CoreMIDI packet's mach-absolute host timestamp;
+    // midi-io.cpp converts it to the SDL ms epoch for the MIDI-clock arrival
+    // time (more precise than sampling a clock in this callback). 0 = none.
+    ctx->callback((HMIDIIN)ctx, MIM_DATA, ctx->instance, (DWORD_PTR)packed_msg, (DWORD_PTR)host_stamp);
 }
 
 // Forward declaration of the SysEx queue producer; defined in
@@ -1131,7 +1135,7 @@ static inline void zt_coremidi_read_proc(const MIDIPacketList *packet_list, void
                 if (len > 2) {
                     msg |= ((unsigned int)(data[i + 2] & 0x7F)) << 16;
                 }
-                zt_coremidi_emit_data(ctx, msg);
+                zt_coremidi_emit_data(ctx, msg, packet->timeStamp);
                 i = (UInt16)(i + len);
                 continue;
             }
@@ -1141,7 +1145,7 @@ static inline void zt_coremidi_read_proc(const MIDIPacketList *packet_list, void
                 if (len == 2 && i < packet->length) {
                     unsigned int msg = (unsigned int)ctx->running_status |
                                        ((unsigned int)(data[i] & 0x7F) << 8);
-                    zt_coremidi_emit_data(ctx, msg);
+                    zt_coremidi_emit_data(ctx, msg, packet->timeStamp);
                     i++;
                     continue;
                 }
@@ -1149,7 +1153,7 @@ static inline void zt_coremidi_read_proc(const MIDIPacketList *packet_list, void
                     unsigned int msg = (unsigned int)ctx->running_status |
                                        ((unsigned int)(data[i] & 0x7F) << 8) |
                                        ((unsigned int)(data[i + 1] & 0x7F) << 16);
-                    zt_coremidi_emit_data(ctx, msg);
+                    zt_coremidi_emit_data(ctx, msg, packet->timeStamp);
                     i += 2;
                     continue;
                 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -147,6 +147,24 @@ target_include_directories(test_keyjazz_map PRIVATE
 target_compile_features(test_keyjazz_map PRIVATE cxx_std_17)
 add_test(NAME keyjazz_map COMMAND test_keyjazz_map)
 
+add_executable(test_phase_chase
+    test_phase_chase.cpp
+)
+target_include_directories(test_phase_chase PRIVATE "${CMAKE_SOURCE_DIR}/src")
+target_compile_features(test_phase_chase PRIVATE cxx_std_17)
+add_test(NAME phase_chase COMMAND test_phase_chase)
+
+add_executable(test_midi_clock_sync
+    test_midi_clock_sync.cpp
+)
+target_include_directories(test_midi_clock_sync PRIVATE
+    "${CMAKE_SOURCE_DIR}/src"
+    "${CMAKE_SOURCE_DIR}/tests"
+)
+target_compile_definitions(test_midi_clock_sync PRIVATE ZT_TEST_NO_SDL)
+target_compile_features(test_midi_clock_sync PRIVATE cxx_std_17)
+add_test(NAME midi_clock_sync COMMAND test_midi_clock_sync)
+
 add_executable(test_ableton_link
     test_ableton_link.cpp
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -154,6 +154,13 @@ target_include_directories(test_phase_chase PRIVATE "${CMAKE_SOURCE_DIR}/src")
 target_compile_features(test_phase_chase PRIVATE cxx_std_17)
 add_test(NAME phase_chase COMMAND test_phase_chase)
 
+add_executable(test_midi_timestamp
+    test_midi_timestamp.cpp
+)
+target_include_directories(test_midi_timestamp PRIVATE "${CMAKE_SOURCE_DIR}/src")
+target_compile_features(test_midi_timestamp PRIVATE cxx_std_17)
+add_test(NAME midi_timestamp COMMAND test_midi_timestamp)
+
 add_executable(test_midi_clock_sync
     test_midi_clock_sync.cpp
 )

--- a/tests/test_ableton_link.cpp
+++ b/tests/test_ableton_link.cpp
@@ -220,7 +220,7 @@ static void test_offset_fires_early() {
     // not at the phase wrap.
     ztPlayer->playing = 0;
     zt_config_globals.ableton_link_quantum   = 4;     // earlier test set 8
-    zt_config_globals.ableton_link_offset_ms = 171;
+    zt_config_globals.sync_offset_ms = 171;
     link_pump_body();                       // absorb stop edge, apply quantum
     g_cached_bpm = 120.0;                   // known tempo for the ms math
     g_stub_phase = 1.0;
@@ -234,7 +234,7 @@ static void test_offset_fires_early() {
     link_pump_body();
     CHECK(g_play_armed == false);
     CHECK(ztPlayer->play_immediately_calls == plays + 1);
-    zt_config_globals.ableton_link_offset_ms = 0;
+    zt_config_globals.sync_offset_ms = 0;
     link_pump_body();                       // absorb the start edge
 }
 
@@ -339,7 +339,7 @@ static void test_peer_transport_follow() {
 static void chase_reset_engine(double session_bpm) {
     be_enable(true);
     g_cached_bpm = session_bpm;
-    zt_config_globals.ableton_link_offset_ms = 0;
+    zt_config_globals.sync_offset_ms = 0;
     ztPlayer->playing         = 1;
     ztPlayer->bpm             = 120;
     ztPlayer->subtick_len_ms  = 5000;
@@ -391,7 +391,7 @@ static void test_chase_live_offset_shifts_setpoint() {
     // User drags the F11 slider to 100 ms while playing: the setpoint moves
     // 100 ms earlier, the engine is suddenly "behind" and must speed up at
     // the deliberate-move tier.
-    zt_config_globals.ableton_link_offset_ms = 100;
+    zt_config_globals.sync_offset_ms = 100;
     link_chase_phase();
     CHECK(ztPlayer->chase_skew_us < -16);
     CHECK(ztPlayer->chase_skew_us >= -626);
@@ -400,7 +400,7 @@ static void test_chase_live_offset_shifts_setpoint() {
     ztPlayer->played_subticks = 96 + 19;
     link_chase_phase();
     CHECK(ztPlayer->chase_skew_us >= -16);    // back inside steady-state
-    zt_config_globals.ableton_link_offset_ms = 0;
+    zt_config_globals.sync_offset_ms = 0;
 }
 
 static void test_chase_fractional_tempo_rate_term() {

--- a/tests/test_midi_clock_sync.cpp
+++ b/tests/test_midi_clock_sync.cpp
@@ -1,0 +1,207 @@
+// Unit tests for src/midi_clock_sync.cpp.
+//
+// Compiled with ZT_TEST_NO_SDL: the fake app environment comes from
+// zt_link_stub.h and the time source is the pokable g_test_now_ms, so the
+// whole pump -- transport request consumption, the sliding-window tempo
+// estimate, dropout handling, and the phase chase -- runs headlessly.
+// Because this file #includes midi_clock_sync.cpp, the pump's file-statics
+// (s_tempo_est, s_anchor_clocks, ...) are directly readable and pokable.
+//
+// The simulated master sends clocks by bumping g_mclk_clocks /
+// g_mclk_last_clock_ms exactly as the MIDI-in thread does.
+
+#include "midi_clock_sync.h"
+#include "midi_clock_sync.cpp"
+
+#include <stdio.h>
+#include <math.h>
+
+static int failures = 0;
+static int checks   = 0;
+
+#define CHECK(expr) do {                                                \
+    checks++;                                                           \
+    if (!(expr)) { failures++;                                          \
+        fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #expr); \
+    }                                                                   \
+} while(0)
+
+// Simulate the master running for `ms` at `bpm`: advance wall time and the
+// clock counter in small steps, pumping each step like the main loop would.
+static void run_master(unsigned ms, double bpm) {
+    double clock_period = 60000.0 / (24.0 * bpm);
+    static double clock_acc = 0.0;
+    unsigned step = 10;
+    for (unsigned t = 0; t < ms; t += step) {
+        g_test_now_ms += step;
+        clock_acc += step / clock_period;
+        while (clock_acc >= 1.0) {
+            g_mclk_clocks++;
+            g_mclk_last_clock_ms = g_test_now_ms;
+            clock_acc -= 1.0;
+        }
+        zt_midi_clock_pump();
+    }
+}
+
+static void reset_env(void) {
+    *ztPlayer = player();
+    *song = zt_module();
+    zt_config_globals = zt_conf();
+    zt_config_globals.midi_in_sync             = 1;
+    zt_config_globals.midi_in_sync_chase_tempo = 1;
+    cur_edit_pattern = 0;
+    zt_midi_clock_pump();   // record request baselines, reset estimate
+}
+
+static void test_disabled_requests_do_not_replay() {
+    *ztPlayer = player();
+    zt_config_globals = zt_conf();        // midi_in_sync = 0
+    g_mclk_start_req += 3;                // master spammed START while off
+    zt_midi_clock_pump();                 // disabled: baselines track
+    zt_config_globals.midi_in_sync = 1;
+    zt_midi_clock_pump();
+    CHECK(ztPlayer->play_immediately_calls == 0);   // nothing replayed
+}
+
+static void test_start_plays_song_from_top() {
+    reset_env();
+    song->orderlist[0] = 5;               // orderlist has entries
+    g_mclk_start_req++;
+    zt_midi_clock_pump();
+    CHECK(ztPlayer->play_immediately_calls == 1);
+    CHECK(ztPlayer->last_row == 0);
+    CHECK(ztPlayer->last_pm  == 1);       // song mode
+    CHECK(ztPlayer->playing  == 1);
+}
+
+static void test_start_loops_pattern_on_empty_orderlist() {
+    reset_env();
+    song->orderlist[0] = 0x100;           // empty song
+    cur_edit_pattern = 7;
+    g_mclk_start_req++;
+    zt_midi_clock_pump();
+    CHECK(ztPlayer->last_pat == 7);
+    CHECK(ztPlayer->last_pm  == 0);       // loop current pattern
+}
+
+static void test_stop_stops() {
+    reset_env();
+    g_mclk_start_req++;
+    zt_midi_clock_pump();
+    CHECK(ztPlayer->playing == 1);
+    g_mclk_stop_req++;
+    zt_midi_clock_pump();
+    CHECK(ztPlayer->playing == 0);
+    CHECK(ztPlayer->stop_calls >= 1);
+}
+
+static void test_spp_continue_and_start_reset() {
+    reset_env();
+    ztPlayer->calc_pos_row   = 8;         // scripted SPP mapping
+    ztPlayer->calc_pos_order = 2;
+    g_mclk_spp_raw = 64;
+    g_mclk_spp_seq++;
+    g_mclk_continue_req++;
+    zt_midi_clock_pump();
+    CHECK(ztPlayer->last_row == 8);       // CONTINUE honors the SPP position
+    CHECK(ztPlayer->last_pat == 2);
+    CHECK(ztPlayer->last_pm  == 3);
+    // A second CONTINUE reuses the same queued position.
+    g_mclk_continue_req++;
+    zt_midi_clock_pump();
+    CHECK(ztPlayer->last_row == 8);
+    // START resets to the top.
+    g_mclk_start_req++;
+    zt_midi_clock_pump();
+    CHECK(ztPlayer->last_row == 0);
+    CHECK(ztPlayer->last_pm  == 1);
+}
+
+static void test_tempo_estimate_fractional_no_song_bpm_write() {
+    reset_env();
+    song->bpm = 99;                       // sentinel: must never change
+    g_mclk_start_req++;
+    zt_midi_clock_pump();                 // playing (nominal adopted 99)
+    run_master(2000, 120.4);
+    CHECK(s_tempo_est > 119.4 && s_tempo_est < 121.4);
+    CHECK(ztPlayer->bpm == 120);          // nominal follows rounded master
+    CHECK(song->bpm == 99);               // chase never writes song->bpm
+}
+
+static void test_position_chase_locks_and_lags() {
+    reset_env();
+    g_mclk_start_req++;
+    zt_midi_clock_pump();
+    run_master(2000, 120.0);
+    // Engine kept pace exactly: 4 subticks per clock since the anchor.
+    ztPlayer->played_subticks = (g_mclk_clocks - s_anchor_clocks) * 4;
+    g_mclk_last_clock_ms = g_test_now_ms; // fresh clock: no interpolation
+    zt_midi_clock_pump();
+    int locked = ztPlayer->chase_skew_us;
+    CHECK(locked >= -17 && locked <= 17); // rate term + steady feedback only
+    // Engine half a beat behind: move-tier catch-up (negative skew).
+    ztPlayer->played_subticks -= 48;
+    zt_midi_clock_pump();
+    CHECK(ztPlayer->chase_skew_us < -16);
+    CHECK(ztPlayer->chase_skew_us >= -630);
+}
+
+static void test_offset_shifts_setpoint() {
+    reset_env();
+    g_mclk_start_req++;
+    zt_midi_clock_pump();
+    run_master(2000, 120.0);
+    ztPlayer->played_subticks = (g_mclk_clocks - s_anchor_clocks) * 4;
+    g_mclk_last_clock_ms = g_test_now_ms;
+    zt_midi_clock_pump();
+    CHECK(ztPlayer->chase_skew_us >= -17 && ztPlayer->chase_skew_us <= 17);
+    // 171 ms offset: the engine must move EARLIER -> it is suddenly behind
+    // the shifted setpoint -> aggressive negative skew.
+    zt_config_globals.sync_offset_ms = 171;
+    zt_midi_clock_pump();
+    CHECK(ztPlayer->chase_skew_us < -16);
+}
+
+static void test_dropout_pauses_chase() {
+    reset_env();
+    g_mclk_start_req++;
+    zt_midi_clock_pump();
+    run_master(2000, 120.0);
+    CHECK(s_tempo_est > 0.0);
+    ztPlayer->chase_skew_us = 77;
+    g_test_now_ms += 1500;                // no clocks for 1.5 s
+    zt_midi_clock_pump();
+    CHECK(s_tempo_est == 0.0);            // estimate forgotten
+    CHECK(ztPlayer->chase_skew_us == 0);  // engine runs free at nominal
+    run_master(2000, 120.0);              // clocks resume
+    CHECK(s_tempo_est > 119.0 && s_tempo_est < 121.0);   // re-locks
+}
+
+static void test_transport_only_mode_never_touches_rate() {
+    reset_env();
+    zt_config_globals.midi_in_sync_chase_tempo = 0;
+    g_mclk_start_req++;
+    zt_midi_clock_pump();
+    CHECK(ztPlayer->playing == 1);        // transport still follows
+    int nominal = ztPlayer->bpm;
+    run_master(2000, 140.0);
+    CHECK(ztPlayer->bpm == nominal);      // rate untouched
+    CHECK(ztPlayer->chase_skew_us == 0);
+    CHECK(ztPlayer->chase_external_tempo_calls == 0);
+}
+
+int main(void) {
+    test_disabled_requests_do_not_replay();
+    test_start_plays_song_from_top();
+    test_start_loops_pattern_on_empty_orderlist();
+    test_stop_stops();
+    test_spp_continue_and_start_reset();
+    test_tempo_estimate_fractional_no_song_bpm_write();
+    test_position_chase_locks_and_lags();
+    test_offset_shifts_setpoint();
+    test_dropout_pauses_chase();
+    test_transport_only_mode_never_touches_rate();
+    printf("midi_clock_sync: %d checks, %d failures\n", checks, failures);
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_midi_clock_sync.cpp
+++ b/tests/test_midi_clock_sync.cpp
@@ -163,7 +163,7 @@ static void test_offset_shifts_setpoint() {
     CHECK(ztPlayer->chase_skew_us < -16);
 }
 
-static void test_dropout_pauses_chase() {
+static void test_dropout_pauses_chase_then_warm_relocks() {
     reset_env();
     g_mclk_start_req++;
     zt_midi_clock_pump();
@@ -172,10 +172,34 @@ static void test_dropout_pauses_chase() {
     ztPlayer->chase_skew_us = 77;
     g_test_now_ms += 1500;                // no clocks for 1.5 s
     zt_midi_clock_pump();
-    CHECK(s_tempo_est == 0.0);            // estimate forgotten
-    CHECK(ztPlayer->chase_skew_us == 0);  // engine runs free at nominal
+    CHECK(ztPlayer->chase_skew_us == 0);  // chase paused: engine runs free at nominal
+    // Warm re-lock (Tier 2): the sample window is dropped but the last tempo is
+    // PRESERVED, so a brief dropout re-locks instantly instead of cold-starting.
+    CHECK(s_tempo_est > 119.0 && s_tempo_est < 121.0);   // tempo kept warm
     run_master(2000, 120.0);              // clocks resume
-    CHECK(s_tempo_est > 119.0 && s_tempo_est < 121.0);   // re-locks
+    CHECK(s_tempo_est > 119.0 && s_tempo_est < 121.0);   // still locked
+}
+
+static void test_snap_on_large_jump() {
+    reset_env();
+    g_mclk_start_req++;
+    zt_midi_clock_pump();
+    run_master(2000, 120.0);
+    ztPlayer->played_subticks = (g_mclk_clocks - s_anchor_clocks) * 4;
+    g_mclk_last_clock_ms = g_test_now_ms;
+    zt_midi_clock_pump();                       // locked
+    CHECK(ztPlayer->chase_skew_us >= -17 && ztPlayer->chase_skew_us <= 17);
+    // Simulate a main-loop stall: the engine fell ~1.5 s (3 beats) behind the
+    // master grid -- far past any deliberate move. Tier 2 should SNAP the
+    // anchor (skew 0, error collapses) rather than slew for many seconds.
+    ztPlayer->played_subticks -= 96 * 3;
+    ztPlayer->chase_skew_us = 1234;             // sentinel that must be cleared
+    zt_midi_clock_pump();
+    CHECK(ztPlayer->chase_skew_us == 0);        // snapped, not a huge slew
+    // Next frame after the snap the engine is re-anchored: tiny residual error.
+    g_mclk_last_clock_ms = g_test_now_ms;
+    zt_midi_clock_pump();
+    CHECK(s_offset_ms > -30.0 && s_offset_ms < 30.0);
 }
 
 static void test_transport_only_mode_never_touches_rate() {
@@ -200,7 +224,8 @@ int main(void) {
     test_tempo_estimate_fractional_no_song_bpm_write();
     test_position_chase_locks_and_lags();
     test_offset_shifts_setpoint();
-    test_dropout_pauses_chase();
+    test_dropout_pauses_chase_then_warm_relocks();
+    test_snap_on_large_jump();
     test_transport_only_mode_never_touches_rate();
     printf("midi_clock_sync: %d checks, %d failures\n", checks, failures);
     return failures == 0 ? 0 : 1;

--- a/tests/test_midi_clock_sync.cpp
+++ b/tests/test_midi_clock_sync.cpp
@@ -202,6 +202,62 @@ static void test_snap_on_large_jump() {
     CHECK(s_offset_ms > -30.0 && s_offset_ms < 30.0);
 }
 
+// Closed-loop simulation: a fractional-tempo master streams clocks while the
+// engine advances played_subticks at its OWN steered rate (nominal subtick +
+// the chase's skew, exactly as the real timer does). The pump steers each ms.
+// optional `jitter_ms`: deterministically perturb the clock timestamp to model
+// input timing noise. Returns the worst |offset| (ms) seen after settling.
+static double run_closed_loop(double master_bpm, int total_ms, int jitter_ms) {
+    const double nominal_us = 5208.333;              // stub subtick (120 nominal)
+    double clock_period_ms  = 60000.0 / (24.0 * master_bpm);
+    double clock_acc = 0.0, subtick_acc_us = 0.0, worst = 0.0;
+    unsigned jseed = 12345;                          // deterministic, no rng
+    for (int ms = 0; ms < total_ms; ms++) {
+        g_test_now_ms += 1;
+        clock_acc += 1.0 / clock_period_ms;
+        while (clock_acc >= 1.0) {
+            g_mclk_clocks++;
+            unsigned stamp = g_test_now_ms;
+            if (jitter_ms) {                          // +/- jitter_ms, deterministic
+                jseed = jseed * 1103515245u + 12345u;
+                int j = (int)((jseed >> 16) % (2u * jitter_ms + 1u)) - jitter_ms;
+                stamp = (unsigned)((int)g_test_now_ms + j);
+            }
+            g_mclk_last_clock_ms = stamp;
+            clock_acc -= 1.0;
+        }
+        double actual_us = nominal_us + (double)ztPlayer->chase_skew_us;
+        if (actual_us < 1000.0) actual_us = 1000.0;
+        subtick_acc_us += 1000.0;                     // 1 ms
+        while (subtick_acc_us >= actual_us) { ztPlayer->played_subticks++; subtick_acc_us -= actual_us; }
+        zt_midi_clock_pump();
+        if (ms > total_ms / 2) {                      // measure after settling
+            double a = s_offset_ms < 0 ? -s_offset_ms : s_offset_ms;
+            if (a > worst) worst = a;
+        }
+    }
+    return worst;
+}
+
+static void test_sim_fractional_tempo_locks() {
+    reset_env();
+    g_mclk_start_req++;
+    zt_midi_clock_pump();                              // START, anchor now
+    // A fractional master the old int-BPM chase would drift on (~0.3%/min):
+    // the phase-lock holds it within a few ms of the grid.
+    double worst = run_closed_loop(120.37, 6000, /*jitter_ms=*/0);
+    CHECK(worst < 12.0);
+}
+
+static void test_sim_jittery_clock_stays_bounded() {
+    reset_env();
+    g_mclk_start_req++;
+    zt_midi_clock_pump();
+    // +/-3 ms timestamp jitter (USB / scheduler) must not unlock the chase.
+    double worst = run_closed_loop(132.5, 6000, /*jitter_ms=*/3);
+    CHECK(worst < 25.0);
+}
+
 static void test_transport_only_mode_never_touches_rate() {
     reset_env();
     zt_config_globals.midi_in_sync_chase_tempo = 0;
@@ -226,6 +282,8 @@ int main(void) {
     test_offset_shifts_setpoint();
     test_dropout_pauses_chase_then_warm_relocks();
     test_snap_on_large_jump();
+    test_sim_fractional_tempo_locks();
+    test_sim_jittery_clock_stays_bounded();
     test_transport_only_mode_never_touches_rate();
     printf("midi_clock_sync: %d checks, %d failures\n", checks, failures);
     return failures == 0 ? 0 : 1;

--- a/tests/test_midi_timestamp.cpp
+++ b/tests/test_midi_timestamp.cpp
@@ -1,0 +1,58 @@
+// Tests for src/midi_timestamp.h -- the pure mach->SDL-ms conversion and the
+// plausibility gate that makes a bad hardware MIDI timestamp harmless.
+
+#include "midi_timestamp.h"
+#include <stdio.h>
+
+static int failures = 0, checks = 0;
+#define CHECK(e) do { checks++; if (!(e)) { failures++; \
+    fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #e); } } while (0)
+
+static void test_convert_basic() {
+    // numer/denom = 1/1 -> 1 tick == 1 ns. A packet 2,000,000 ns (2 ms) before
+    // now maps to now_sdl - 2.
+    CHECK(zt_mach_stamp_to_sdl_ms(/*pkt*/8000000, /*now_mach*/10000000,
+                                  /*now_sdl*/5000, 1, 1) == 4998);
+    // A fresh packet (same instant) maps to now_sdl exactly.
+    CHECK(zt_mach_stamp_to_sdl_ms(10000000, 10000000, 5000, 1, 1) == 5000);
+}
+
+static void test_convert_timebase() {
+    // Apple-Silicon-ish timebase 125/3: 1 tick = 41.667 ns. 720,000 ticks =
+    // 30,000,000 ns = 30 ms before now.
+    CHECK(zt_mach_stamp_to_sdl_ms(/*pkt*/280000, /*now_mach*/1000000,
+                                  /*now_sdl*/1000, 125, 3) == 970);
+}
+
+static void test_convert_guards() {
+    CHECK(zt_mach_stamp_to_sdl_ms(100, 200, 7777, 1, /*denom=*/0) == 7777); // no timebase
+    CHECK(zt_mach_stamp_to_sdl_ms(/*pkt future*/300, 200, 7777, 1, 1) == 7777); // future -> now
+}
+
+static void test_pick_gate() {
+    // Candidate close to fallback -> use it.
+    CHECK(zt_pick_clock_stamp(/*cand*/995, /*fallback*/1000, 2000, 50) == 995);
+    // Candidate too old (garbage conversion) -> fallback.
+    CHECK(zt_pick_clock_stamp(/*cand*/1000, /*fallback*/5000, 2000, 50) == 5000);
+    // Candidate too far in the future -> fallback.
+    CHECK(zt_pick_clock_stamp(/*cand*/2000, /*fallback*/1000, 2000, 50) == 1000);
+    // Slightly future within tolerance -> keep.
+    CHECK(zt_pick_clock_stamp(/*cand*/1020, /*fallback*/1000, 2000, 50) == 1020);
+}
+
+static void test_garbage_stamp_is_rejected() {
+    // packet_mach = 0 (uninitialized) with a large now_mach -> conversion yields
+    // a wildly old value; the gate must reject it and keep the fallback.
+    uint32_t cand = zt_mach_stamp_to_sdl_ms(0, 24000000000ull, 100000, 125, 3);
+    CHECK(zt_pick_clock_stamp(cand, 100000, 2000, 50) == 100000);
+}
+
+int main(void) {
+    test_convert_basic();
+    test_convert_timebase();
+    test_convert_guards();
+    test_pick_gate();
+    test_garbage_stamp_is_rejected();
+    printf("midi_timestamp: %d checks, %d failures\n", checks, failures);
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_phase_chase.cpp
+++ b/tests/test_phase_chase.cpp
@@ -1,0 +1,87 @@
+// Unit tests for src/phase_chase.h -- the closed-loop position controller
+// shared by the Ableton Link and MIDI clock chases. Pure math, no stubs.
+//
+// Reference numbers (120 BPM): exact subtick 60e6/(96*120) = 5208.333 us,
+// engine nominal (set_speed truncation) 5208 us, so the rate term alone
+// rounds to 0; steady-tier feedback bound = 5208.33*0.003 = 15.6 us;
+// move-tier bound = 5208.33*0.12 = 625 us; total clamp 15% = 781 us.
+
+#include "phase_chase.h"
+
+#include <stdio.h>
+
+static int failures = 0;
+static int checks   = 0;
+
+#define CHECK(expr) do {                                                \
+    checks++;                                                           \
+    if (!(expr)) { failures++;                                          \
+        fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #expr); \
+    }                                                                   \
+} while(0)
+
+static const double EXACT_120   = 60000000.0 / (96.0 * 120.0);
+static const double NOMINAL_120 = 5208.0;
+
+static void test_zero_error_locks_at_rate_term() {
+    // In lock, the only output is the rate term (0.33 us -> rounds to 0).
+    CHECK(phase_chase_step(96.0, 96, EXACT_120, NOMINAL_120) == 0);
+    CHECK(phase_chase_step(0.0, 0, EXACT_120, NOMINAL_120) == 0);
+}
+
+static void test_steady_tier_sign_and_clamp() {
+    // 1 subtick (~5.2 ms) of error: inside the deadband, 0.3% authority.
+    int behind = phase_chase_step(96.0, 95, EXACT_120, NOMINAL_120);
+    CHECK(behind < 0);            // engine behind -> shorter subticks
+    CHECK(behind >= -16);         // clamped at the steady bound
+    int ahead = phase_chase_step(96.0, 97, EXACT_120, NOMINAL_120);
+    CHECK(ahead > 0);             // engine ahead -> longer subticks
+    CHECK(ahead <= 16);
+}
+
+static void test_move_tier_sign_and_clamp() {
+    // Half a beat (250 ms): a deliberate move, 12% authority.
+    int behind = phase_chase_step(96.0, 48, EXACT_120, NOMINAL_120);
+    CHECK(behind < -16);
+    CHECK(behind >= -626);
+    int ahead = phase_chase_step(96.0, 144, EXACT_120, NOMINAL_120);
+    CHECK(ahead > 16);
+    CHECK(ahead <= 626);
+}
+
+static void test_deadband_boundary() {
+    // Just under 10 ms (1.9 subticks behind): steady tier caps the
+    // catch-up at -16. Just over (2.1): move tier engages (err/64 ~ -171).
+    int inside  = phase_chase_step(96.0 + 1.9, 96, EXACT_120, NOMINAL_120);
+    CHECK(inside < 0 && inside >= -16);
+    int outside = phase_chase_step(96.0 + 2.1, 96, EXACT_120, NOMINAL_120);
+    CHECK(outside < -16);
+}
+
+static void test_rate_term_fractional_master() {
+    // Master at 119.6, engine nominal at int-120: zero position error must
+    // still output the exact-vs-nominal difference (+17.75 -> 18).
+    double exact_1196 = 60000000.0 / (96.0 * 119.6);
+    int skew = phase_chase_step(96.0, 96, exact_1196, NOMINAL_120);
+    CHECK(skew >= 17 && skew <= 19);
+}
+
+static void test_total_clamp() {
+    // Pathological nominal mismatch: output is capped at 15% of the exact
+    // subtick no matter what.
+    int skew = phase_chase_step(0.0, 0, EXACT_120, NOMINAL_120 * 0.5);
+    CHECK(skew <= (int)(EXACT_120 * 0.15) + 1);
+    skew = phase_chase_step(0.0, 0, EXACT_120, NOMINAL_120 * 2.0);
+    CHECK(skew >= -(int)(EXACT_120 * 0.15) - 1);
+}
+
+int main(void) {
+    test_zero_error_locks_at_rate_term();
+    test_steady_tier_sign_and_clamp();
+    test_move_tier_sign_and_clamp();
+    test_deadband_boundary();
+    test_rate_term_fractional_master();
+    test_total_clamp();
+    printf("phase_chase: %d checks, %d failures\n", checks, failures);
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/zt_link_stub.h
+++ b/tests/zt_link_stub.h
@@ -1,9 +1,10 @@
-// Minimal stand-in for zt.h, used when src/ableton_link.cpp is compiled into
-// the unit test (ZT_TEST_NO_SDL). Mirrors exactly the declarations the Link
-// integration uses -- a recording fake player, a song with bpm + orderlist,
-// the three ableton_link_* conf fields, and the page-refresh globals -- so
-// the test can drive the full pump/defer logic without SDL or the real app.
-// Same pattern as tests/sdl_stub.h (see CLAUDE.md "Test harness").
+// Minimal stand-in for zt.h, used when src/ableton_link.cpp or
+// src/midi_clock_sync.cpp is compiled into a unit test (ZT_TEST_NO_SDL).
+// Mirrors exactly the declarations the sync integrations use -- a recording
+// fake player, a song with bpm + orderlist, the sync conf fields, and the
+// page-refresh globals -- so the tests can drive the full pump logic
+// without SDL or the real app. Same pattern as tests/sdl_stub.h (see
+// CLAUDE.md "Test harness").
 //
 // Definitions (not just declarations) live here: the test is a single
 // translation unit that includes ableton_link.cpp, which includes this.
@@ -52,13 +53,36 @@ struct player {
     // Mirrors the real set_speed(): adopt the song tempo as the engine's
     // nominal rate (the chase's rate-agreement guard reads it).
     void set_speed(void) { set_speed_calls++; bpm = song->bpm; }
+
+    // play(): same defer-free fake as play_immediately (the MIDI pump calls
+    // play(); the Link defer hook is irrelevant in the stub env).
+    void play(int row, int pattern, int pm, int loopmode = 1) {
+        play_immediately(row, pattern, pm, loopmode);
+    }
+
+    // chase_external_tempo(): adopt an external master's rounded tempo as
+    // the engine nominal WITHOUT touching song->bpm (the real contract).
+    int chase_external_tempo_calls = 0;
+    void chase_external_tempo(int new_bpm) {
+        chase_external_tempo_calls++;
+        if (new_bpm >= 20 && new_bpm <= 500) bpm = new_bpm;
+    }
+
+    // calc_pos(): scripted SPP -> row/order mapping for the test.
+    int calc_pos_row = 0, calc_pos_order = 0, calc_pos_ret = 0;
+    int calc_pos(int /*spp*/, int *row, int *order) {
+        *row = calc_pos_row; *order = calc_pos_order;
+        return calc_pos_ret;
+    }
 };
 
 struct zt_conf {
     int ableton_link_enable          = 0;
     int ableton_link_start_stop_sync = 0;
     int ableton_link_quantum         = 4;
-    int ableton_link_offset_ms       = 0;
+    int sync_offset_ms               = 0;
+    int midi_in_sync                 = 0;
+    int midi_in_sync_chase_tempo     = 0;
 };
 
 static player    g_test_player;


### PR DESCRIPTION
## Summary

MIDI In clock sync now **phase-locks to the received clock grid using the same closed-loop controller Ableton Link uses**, and the MIDI-in callback thread no longer makes any decisions. This is @cmicali's work from the withdrawn PR #160, rebased onto current `master` (post-#159), with a thread-safety hardening pass on top. Opened at Esa's request — @cmicali, flagging for your review since the design and the bulk of the code are yours.

## What it does (Chris's work — commit 1)

- **`src/phase_chase.h`** — the position controller extracted out of `ableton_link.cpp` into a pure, SDL-free, unit-tested header (the repo's tested-decision-logic pattern). Tiered proportional feedback: 0.3% authority inside a 10 ms deadband (inaudible steady-state lock), 12% beyond (deliberate moves settle in ~1.4 s), 15% ceiling, plus the exact-vs-nominal rate term. **Both Link and MIDI clock now drive the identical loop.**
- **`src/midi_clock_sync.{h,cpp}`** — MIDI-in sync rebuilt on the observer architecture:
  - The MIDI-in callback thread only **counts** what arrived (clocks, Start/Continue/Stop, SPP); a main-thread pump consumes them. This removes a real bug — the old handler called `ztPlayer->play()/stop()` and wrote subtick timing fields **from the platform MIDI thread**, the same unsynchronized cross-thread class PR #116 fixed for `midiInQueue`.
  - Tempo estimated as a **double** over a ~1 s sliding window (the old code rounded to int BPM, so fractional masters drifted ~0.3%/min). A clock stream is treated as a *position* reference (24 clocks/beat → 4 subticks/clock, interpolated, anchored at START) so drift can't accumulate; >1 s dropout pauses the chase and re-acquires when clocks resume.
  - `chase_external_tempo` still never writes `song->bpm`.
- **"Link Offset" → "Sync Offset"** (`sync_offset_ms`, legacy `ableton_link_offset_ms` still read) now applies to **both** sync modes — play up to 500 ms early so notes monitored through a DAW's audio chain land on the grid.
- Tests: `test_phase_chase` + `test_midi_clock_sync` (16 ctest suites total).

Chris's measured result on his `clockprobe` harness (fractional 120.4 BPM master): offset went from walking the full ±250 ms/min (unlocked) to held within **±8 ms** end-to-end.

## Hardening pass (commit 2 — on top)

Chris flagged #160 "not ready." Two robustness fixes so this is solid, not just working-in-practice:

1. **Atomic observer counters.** The `g_mclk_*` counters are written on the MIDI thread and read on the main thread — as plain `int` that's a data race (UB per the C++ memory model; ThreadSanitizer flags it), well-defined before only by luck of aligned-word atomicity on our targets. Now `std::atomic`. We rely only on per-counter atomicity (no ordering between counters), so cost is nil and every `++`/`=`/read call site — including `midi-io.cpp` and the unit test — is unchanged.
2. **One consistent per-frame snapshot.** The pump re-read `g_mclk_clocks` / `g_mclk_last_clock_ms` in three places; a `0xF8` landing mid-pump could make them disagree and briefly add a whole clock (~20 ms at 120 BPM) on top of a near-full interpolation fraction, kicking the controller out of its deadband. Now snapshotted once at the top of the pump (count **before** timestamp, so a mid-read clock collapses the fraction toward 0 instead of double-counting) and threaded through consume / estimate / chase.

## Test plan

- [x] Rebased clean onto `master` (post-#159); Chris's commit preserved with his authorship, hardening in a separate commit.
- [x] Clean build (Ninja) + `ctest` **16/16** — `phase_chase` and `midi_clock_sync` green.
- [x] Headless smoke: F11 renders the renamed **Sync Offset** field; `--headless` run with the per-frame pump active (F5 play / F8 stop) exits clean.
- [ ] **Cannot verify locally:** real-hardware MIDI-clock lock measurement (needs an external clock master) and cross-platform (Ableton Link isn't compiled into the default local build — CI-fetched). Flagging for @cmicali / @m6502 to confirm the ±8 ms lock on hardware and the cross-platform build.

## Provenance

Chris's branch `feature/midi-clock-phase-lock` and his withdrawn PR #160 are untouched — this is a separate branch (`esa/midi-clock-phase-lock`). If you'd rather take it back over and land your own version, say so and I'll close this.

---

## Update: now introduces the whole lot (no stack)

Folded the Tier 3 observability layer into this PR (was #165, now closed) so #164 introduces everything in one go:

- **F11 lock meter** on the "MIDI In Sync" row: state (waiting/dropout/transport/chasing/LOCKED) + estimated master BPM + signed offset ms.
- **Lua sync state**: `zt.transport.sync_state` / `.sync_bpm` / `.sync_offset_ms` + a `"sync"` notifier on lock-state transitions; covered by `selftest.lua`.
- Shared `zt_midi_clock_get_status()` snapshot (main-thread, no extra locking).

Tier 2 (robustness) and Tier 1 (estimator/timestamps) will be added as further commits to **this same branch** — no PR stack.

Verified after fold: clean build + ctest **16/16**.
