### PR TITLE
Sync observability: F11 lock meter + Lua sync state (Tier 3)

### DIFF
--- a/assets/lua/selftest.lua
+++ b/assets/lua/selftest.lua
@@ -125,6 +125,13 @@ check("transport playing after play", zt.transport.playing == true)
 zt.transport:stop()
 check("transport stopped", zt.transport.playing == false)
 
+-- MIDI-clock sync status (read-only). No external clock under test, so the
+-- state is "off"; just assert the fields exist with the right types/contract.
+check("sync_state is string", type(zt.transport.sync_state) == "string")
+check("sync_state off when not slaved", zt.transport.sync_state == "off")
+check("sync_bpm is number", type(zt.transport.sync_bpm) == "number")
+check("sync_offset_ms is number", type(zt.transport.sync_offset_ms) == "number")
+
 -- ── zt.midimacro(i) ──────────────────────────────────────────────────
 local m = zt.midimacro(0)
 m.name = "Bank" ;                  eq("midimacro.name", m.name, "Bank")
@@ -174,6 +181,13 @@ eq("notifier multiple callbacks", fired, 106)   -- +1 (first) +100 (second)
 zt.off("selftest_evt")
 zt.fire("selftest_evt", 5)
 eq("notifier off stops firing", fired, 106)     -- unchanged
+
+-- the built-in "sync" event registers and dispatches like any other
+local sync_seen = -1
+zt.on("sync", function(state) sync_seen = state end)
+zt.fire("sync", 4)
+eq("sync notifier dispatches state", sync_seen, 4)
+zt.off("sync")
 
 -- ── file save / load roundtrip ───────────────────────────────────────
 local tmp = (os.getenv("TMPDIR") or os.getenv("TEMP") or "/tmp") .. "/zt_selftest.zt"

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,27 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_06_15 (Sync observability: F11 lock meter + Lua sync state)
+----------------------------------------------------------------------------
+
+        + F11 MIDI-clock lock meter. To the right of the "MIDI In Sync" row,
+          a live readout shows the lock state (waiting for clock / clock
+          dropout / transport / chasing / LOCKED), the estimated master
+          tempo, and the current position offset in ms (engine behind the
+          grid = positive). Closes the loop for dialing Sync Offset by eye
+          and for confirming a solid lock. Refreshes only when a displayed
+          value changes (same contract as the Ableton Link status line).
+
+        + Lua sync status. zt.transport.sync_state ("off"/"waiting"/
+          "dropout"/"transport"/"chasing"/"locked"), zt.transport.sync_bpm
+          and zt.transport.sync_offset_ms expose the same numbers to scripts,
+          and a new "sync" notifier fires on every lock-state transition
+          (zt.on('sync', fn); arg = numeric state).
+
+        ! Both read a single zt_midi_clock_get_status() snapshot refreshed
+          once per pump on the main thread -- no extra locking, no MIDI-thread
+          work added.
+
 zt 2026_06_15 (MIDI clock sync rebuilt on the phase-chase controller)
 ----------------------------------------------------------------------------
 

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -296,6 +296,14 @@
  drift. MIDI In Sync and Ableton Link are mutually exclusive (one tempo
  master at a time).
 
+ A lock meter to the right of the "MIDI In Sync" row shows the live
+ state - waiting for clock / clock dropout / transport / chasing /
+ LOCKED - with the estimated master tempo and the current offset in ms
+ (engine behind the grid = positive). Use it to confirm the lock and to
+ dial Sync Offset by eye. The same values are scriptable from the Lua
+ console: zt.transport.sync_state / .sync_bpm / .sync_offset_ms, and a
+ "sync" notifier fires on each state change (zt.on('sync', fn)).
+
 |L|%==|H|Troubleshooting|L|==%|U|
 
  Timing issues:

--- a/src/CUI_Songconfig.cpp
+++ b/src/CUI_Songconfig.cpp
@@ -2,6 +2,7 @@
 #include "zt.h"
 #include "OrderEditor.h"
 #include "ableton_link.h"
+#include "midi_clock_sync.h"
 
 CUI_Songconfig::CUI_Songconfig(void) {
     ValueSlider *vs;
@@ -401,6 +402,26 @@ void CUI_Songconfig::update()
                 need_refresh++;
             }
         }
+
+        // MIDI clock lock meter: state / master BPM / offset all move every
+        // frame while slaved. Same contract as the Link block above -- repaint
+        // only when a displayed value actually changed (quantized so sub-0.1
+        // jitter doesn't force a redraw every frame).
+        {
+            static int    last_sstate = -1;
+            static int    last_sbpm10  = -1;
+            static int    last_soff10  = -1000000;
+            zt_sync_status ss;
+            zt_midi_clock_get_status(&ss);
+            int sbpm10 = (int)(ss.master_bpm * 10.0 + 0.5);
+            int soff10 = (int)(ss.offset_ms  * 10.0 + (ss.offset_ms >= 0 ? 0.5 : -0.5));
+            if (ss.state != last_sstate || sbpm10 != last_sbpm10 || soff10 != last_soff10) {
+                last_sstate = ss.state;
+                last_sbpm10 = sbpm10;
+                last_soff10 = soff10;
+                need_refresh++;
+            }
+        }
     }
     vs = (ValueSlider *)UI->get_element(10);
     if (vs) {
@@ -477,6 +498,26 @@ void CUI_Songconfig::draw(Drawable *S) {
             char linkstat_field[40];
             snprintf(linkstat_field, sizeof(linkstat_field), "%-28s", linkstat);
             printBG(row(24),col(base_y+16),linkstat_field,COLORS.Highlight,COLORS.Background,S);
+        }
+        // MIDI-clock lock meter on the "MIDI In Sync" row: lock state +
+        // estimated master tempo + signed offset (engine behind = +). Same
+        // fixed-width / printBG erase trick and 28-col span as the Link status.
+        {
+            zt_sync_status ss;
+            zt_midi_clock_get_status(&ss);
+            char m[64];
+            switch (ss.state) {
+                case ZT_SYNC_WAITING:   snprintf(m,sizeof(m),"waiting for clock"); break;
+                case ZT_SYNC_DROPOUT:   snprintf(m,sizeof(m),"clock dropout"); break;
+                case ZT_SYNC_TRANSPORT: snprintf(m,sizeof(m),"transport \xb3 %.1f BPM", ss.master_bpm); break;
+                case ZT_SYNC_CHASING:   snprintf(m,sizeof(m),"chasing \xb3 %.1f BPM \xb3 %+.1f ms", ss.master_bpm, ss.offset_ms); break;
+                case ZT_SYNC_LOCKED:    snprintf(m,sizeof(m),"LOCKED \xb3 %.1f BPM \xb3 %+.1f ms", ss.master_bpm, ss.offset_ms); break;
+                case ZT_SYNC_OFF:
+                default:                m[0] = '\0'; break;
+            }
+            char field[40];
+            snprintf(field,sizeof(field),"%-28s", m);
+            printBG(row(25),col(base_y+11),field,COLORS.Highlight,COLORS.Background,S);
         }
         // Order List label aligned to the OE x-origin (col 59) — NOT shifted.
         print(row(59),col(11),"Order List",COLORS.Text,S);

--- a/src/lua_engine.cpp
+++ b/src/lua_engine.cpp
@@ -9,6 +9,7 @@
 #include "playback.h"
 #include "module.h"
 #include "midi-io.h"
+#include "midi_clock_sync.h"   // zt.transport.sync_* status fields
 #include "CDataBuf.h"   // song message text buffer (zt.song.message)
 
 #include <string.h>
@@ -673,6 +674,15 @@ static int trans_index(lua_State *L)
     if (!strcmp(k, "stop"))         { lua_pushcfunction(L, trans_stop); return 1; }
     if (!strcmp(k, "play_pattern")) { lua_pushcfunction(L, trans_play_pattern); return 1; }
     if (!strcmp(k, "panic"))        { lua_pushcfunction(L, trans_panic); return 1; }
+    // MIDI-clock sync status (read-only): mirrors the F11 lock meter.
+    if (!strcmp(k, "sync_state") || !strcmp(k, "sync_bpm") || !strcmp(k, "sync_offset_ms")) {
+        zt_sync_status ss;
+        zt_midi_clock_get_status(&ss);
+        if      (!strcmp(k, "sync_state"))     lua_pushstring(L, zt_sync_state_name(ss.state));
+        else if (!strcmp(k, "sync_bpm"))       lua_pushnumber(L, ss.master_bpm);
+        else                                   lua_pushnumber(L, ss.offset_ms);
+        return 1;
+    }
     return luaL_error(L, "zt.transport has no field '%s' (try help('transport'))", k);
 }
 static int trans_tostring(lua_State *L)
@@ -1423,7 +1433,7 @@ bool ZtLuaEngine::init()
         "    instrument = 'zt.instrument(i)  props (rw): name, channel, device, transpose, bank, volume, global_volume, default_length, flags, ccizer_bank; ro: index  (i defaults to current)',\n"
         "    pattern = 'zt.pattern(p)  props: length(rw), index, empty;  methods: :note(track,row), :set_note(track,row,note[,inst[,vol]]), :track(t)  (p defaults to current)',\n"
         "    track = 'zt.track(t[,p])  props: index, pattern, muted(rw);  methods: :note(row), :set_note(row,note[,inst[,vol]])  (defaults to current track/pattern)',\n"
-        "    transport = 'zt.transport  prop: playing;  methods: :play(), :stop(), :play_pattern(), :panic()',\n"
+        "    transport = 'zt.transport  props: playing, sync_state, sync_bpm, sync_offset_ms;  methods: :play(), :stop(), :play_pattern(), :panic()',\n"
         "    cell = 'zt.cell(track,row[,pat]) / pattern:cell(t,r) / track:cell(r)  props (rw): note, instrument, volume, length, effect, effect_data;  ro: name, empty, pattern, track, row;  method :clear()',\n"
         "    orders = 'zt.orders  array: zt.orders[i] = pattern (rw), .count, #zt.orders;  pattern markers zt.BREAK / zt.SKIP',\n"
         "    midimacro = 'zt.midimacro(i)  props: name (rw), empty, syx, index;  methods :get(step), :set(step,value), :send(device[,param])  (tokens zt.MACRO_END / zt.MACRO_PARAM)',\n"
@@ -1446,7 +1456,7 @@ bool ZtLuaEngine::init()
         "      print('  ' .. objdocs.arpeggio)\n"
         "      print('  ' .. objdocs.envelope)\n"
         "      print('Helpers: zt.note_name(60)->\"C-5\", zt.note_value(\"C-5\")->60 ; zt.load(path), zt.save(path)')\n"
-        "      print('Notifiers: zt.on(event,fn) / zt.off(event) / zt.fire(event[,arg]).  events: idle, play, stop, row')\n"
+        "      print('Notifiers: zt.on(event,fn) / zt.off(event) / zt.fire(event[,arg]).  events: idle, play, stop, row, sync')\n"
         "      print('Consts: zt.MAX_PATTERNS/TRACKS/INSTRUMENTS/ORDERS/MIDIMACROS/ARPEGGIOS, NOTE_*, MIDDLE_C, BREAK, SKIP, MACRO_END/PARAM')\n"
         "      print('  e.g.  zt.song.bpm=140   zt.cell(0,0).note = zt.note_value(\"C-5\")   zt.orders[0]=2   zt.transport:play()')\n"
         "      print('Introspect: rprint(zt) dumps all, oprint(t) lists one level, help(\"name\") for one.')\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4304,6 +4304,18 @@ int main(int argc, char *argv[])
             g_lua.fire("row", s_prev_row, true);
           }
         }
+        {
+          // "sync" on MIDI-clock lock-state transitions (off/waiting/dropout/
+          // transport/chasing/locked). arg = numeric state; the readable name
+          // and the live BPM/offset are on zt.transport.sync_*.
+          static int s_prev_sync = -1;
+          zt_sync_status ss;
+          zt_midi_clock_get_status(&ss);
+          if (ss.state != s_prev_sync) {
+            s_prev_sync = ss.state;
+            g_lua.fire("sync", ss.state, true);
+          }
+        }
         g_lua.fire("idle");
       }
 

--- a/src/midi_clock_sync.cpp
+++ b/src/midi_clock_sync.cpp
@@ -54,6 +54,10 @@ static int      s_last_nominal_bpm = 0;
 static int      s_anchor_clocks = 0;
 static bool     s_chase_valid   = false;
 
+// User-facing status (F11 lock meter + Lua), refreshed at the end of the pump.
+static int      s_state     = ZT_SYNC_OFF;
+static double   s_offset_ms = 0.0;          // signed position error, 0 unless chasing
+
 // Transport request baselines + the queued SPP position (mirrors the old
 // static queued_row/queued_order in midi-io.cpp: SPP sets it, START zeroes
 // it, CONTINUE plays from it, and it persists across CONTINUEs).
@@ -145,10 +149,12 @@ static void mclk_chase(unsigned now, int clocks, unsigned last_clock) {
         // behavior where the tempo ring was gated on this flag).
         ztPlayer->chase_skew_us = 0;
         s_chase_valid = false;
+        s_offset_ms   = 0.0;
         return;
     }
     if (!ztPlayer->playing || s_tempo_est <= 0.0) {
         ztPlayer->chase_skew_us = 0;
+        s_offset_ms = 0.0;
         return;
     }
     // Keep the engine nominal on the rounded master tempo (the old
@@ -164,6 +170,7 @@ static void mclk_chase(unsigned now, int clocks, unsigned last_clock) {
         // anchor at the current position so the lock is drift-only.
         s_anchor_clocks = clocks - ztPlayer->played_subticks / 4;
         s_chase_valid   = true;
+        s_offset_ms     = 0.0;
         return;
     }
     // Expected position: 4 subticks per clock, plus intra-clock
@@ -184,6 +191,9 @@ static void mclk_chase(unsigned now, int clocks, unsigned last_clock) {
     double nominal_us = (double)(ztPlayer->subtick_len_ms + ztPlayer->subtick_len_mms);
     ztPlayer->chase_skew_us = phase_chase_step(expected, ztPlayer->played_subticks,
                                                exact_us, nominal_us);
+    // Position error for the status readout (same quantity phase_chase_step
+    // feeds back on): engine behind the master grid = positive.
+    s_offset_ms = (expected - (double)ztPlayer->played_subticks) * exact_us / 1000.0;
 }
 
 void zt_midi_clock_pump(void) {
@@ -198,6 +208,8 @@ void zt_midi_clock_pump(void) {
         s_last_spp_seq = g_mclk_spp_seq;
         s_chase_valid  = false;
         mclk_reset_estimate();
+        s_state     = ZT_SYNC_OFF;
+        s_offset_ms = 0.0;
         return;
     }
     unsigned now = mclk_now_ms();
@@ -214,4 +226,37 @@ void zt_midi_clock_pump(void) {
     mclk_consume_transport(clocks);
     mclk_update_estimate(now, clocks, last_clock);
     mclk_chase(now, clocks, last_clock);
+
+    // Derive the user-facing lock state (F11 meter + Lua) from the snapshot.
+    bool clocks_recent = (last_clock != 0) && ((now - last_clock) <= MCLK_DROPOUT_MS);
+    if (!clocks_recent) {
+        s_state = (last_clock == 0) ? ZT_SYNC_WAITING : ZT_SYNC_DROPOUT;
+    } else if (!zt_config_globals.midi_in_sync_chase_tempo) {
+        s_state = ZT_SYNC_TRANSPORT;
+    } else if (s_tempo_est <= 0.0 || !ztPlayer->playing) {
+        s_state = ZT_SYNC_WAITING;
+    } else {
+        double err_us = s_offset_ms * 1000.0;
+        s_state = (err_us <= PHASE_CHASE_DEADBAND_US && err_us >= -PHASE_CHASE_DEADBAND_US)
+                  ? ZT_SYNC_LOCKED : ZT_SYNC_CHASING;
+    }
+}
+
+void zt_midi_clock_get_status(zt_sync_status *out) {
+    if (!out) return;
+    out->state      = s_state;
+    out->master_bpm = s_tempo_est;
+    out->offset_ms  = s_offset_ms;
+}
+
+const char *zt_sync_state_name(int state) {
+    switch (state) {
+        case ZT_SYNC_WAITING:   return "waiting";
+        case ZT_SYNC_DROPOUT:   return "dropout";
+        case ZT_SYNC_TRANSPORT: return "transport";
+        case ZT_SYNC_CHASING:   return "chasing";
+        case ZT_SYNC_LOCKED:    return "locked";
+        case ZT_SYNC_OFF:
+        default:                return "off";
+    }
 }

--- a/src/midi_clock_sync.h
+++ b/src/midi_clock_sync.h
@@ -42,4 +42,26 @@ extern std::atomic<int>      g_mclk_spp_seq;       /* bumped per 0xF2           
  * per main loop, next to zt_ableton_link_pump(). */
 void zt_midi_clock_pump(void);
 
+/* --- Sync status -----------------------------------------------------------
+ * Snapshot of the chase, refreshed once per zt_midi_clock_pump(). Read on the
+ * MAIN thread only (F11 lock meter, Lua zt.transport.sync_*), so it needs no
+ * locking -- pump and readers are the same thread. */
+enum zt_sync_state {
+    ZT_SYNC_OFF = 0,    /* MIDI In Sync disabled                              */
+    ZT_SYNC_WAITING,    /* enabled, no usable clock yet (acquiring/not playing)*/
+    ZT_SYNC_DROPOUT,    /* clock was flowing, then stopped (> dropout window)  */
+    ZT_SYNC_TRANSPORT,  /* following start/stop only (Chase MIDI Tempo off)    */
+    ZT_SYNC_CHASING,    /* phase-locking, error outside the deadband           */
+    ZT_SYNC_LOCKED      /* phase-locked, error within the deadband             */
+};
+
+struct zt_sync_status {
+    int    state;       /* zt_sync_state                                       */
+    double master_bpm;  /* estimated master tempo, 0.0 if none                 */
+    double offset_ms;   /* signed position error (engine behind = +); 0 unless chasing */
+};
+
+void        zt_midi_clock_get_status(zt_sync_status *out);
+const char *zt_sync_state_name(int state);   /* "off" / "waiting" / ... / "locked" */
+
 #endif /* ZT_MIDI_CLOCK_SYNC_H */


### PR DESCRIPTION
## Summary

**Tier 3 (observability)** on top of the MIDI-clock phase-lock work: make the lock *visible* so the user can confirm it and dial Sync Offset by eye instead of blind, and make the same numbers scriptable from Lua.

> ⚠️ **Stacked on #164** (`esa/midi-clock-phase-lock`) — this PR is based on that branch, so the diff is just the observability layer. Review/merge #164 first; I'll retarget to `master` once it lands.

## What

**Shared status API** (`midi_clock_sync.{h,cpp}`) — `zt_midi_clock_get_status()` fills a `{state, master_bpm, offset_ms}` snapshot, refreshed once per pump on the main thread (no locking, no MIDI-thread work added). `state` ∈ off / waiting / dropout / transport / chasing / locked, derived from clock recency, the chase-tempo flag, the tempo estimate, and the live position error vs the deadband.

**F11 lock meter** (`CUI_Songconfig.cpp`) — a live readout on the "MIDI In Sync" row:
```
MIDI In Sync   [on]   LOCKED │ 120.4 BPM │ +2.1 ms
```
States render as `waiting for clock` / `clock dropout` / `transport │ <bpm>` / `chasing │ <bpm> │ <offset>` / `LOCKED │ <bpm> │ <offset>` (engine behind the grid = positive offset). Same fixed-width `printBG` erase trick and repaint-only-on-change contract as the existing Ableton Link status line.

**Lua** (`lua_engine.cpp`, `main.cpp`) — read-only `zt.transport.sync_state` (string) / `.sync_bpm` / `.sync_offset_ms`, plus a `"sync"` notifier fired on each lock-state transition from the main loop alongside `play`/`stop`/`row`/`idle` (`zt.on('sync', fn)`; arg = numeric state).

```lua
zt.on('sync', function(s) print('sync:', zt.transport.sync_state, zt.transport.sync_bpm) end)
```

## Why
The phase-lock engine had no UI surface — you couldn't tell locked from drifting, and `sync_offset_ms` was a blind dial. This closes that loop (#8 in the theorization) and exposes the engine to scripting (#9).

## Test plan
- [x] Clean build (Ninja) + `ctest` **16/16**, including the Lua self-test (`selftest.lua` now asserts the new fields' types and that `sync` registers + dispatches).
- [x] Headless F11 screenshot with `midi_in_sync` enabled shows the meter rendering `waiting for clock` (no master present); F11 with sync off unchanged — no regression.
- [x] Status read on the main thread only (pump + F11 draw + Lua are all main-thread), so no new synchronization needed.

## Provenance
Builds on @cmicali's phase-lock work (#164). Independent observability layer — no changes to the controller or the chase math.
