### PR TITLE
docs: resync CLAUDE.md with codebase + anti-drift freshness guard

### DIFF
--- a/.claude/skills/ztrackerprime/SKILL.md
+++ b/.claude/skills/ztrackerprime/SKILL.md
@@ -13,7 +13,7 @@ triggers:
 
 # zTracker Prime Development Skill
 
-> **Last verified: 2026-06-14.** If this date is more than ~7 days old when you load this skill, your first move is to check what merged since: `gh pr list --repo m6502/ztrackerprime --state merged --json number,title,mergedAt --jq '[.[] | select(.mergedAt > "<this date>")]'`. Reconcile any architecture / shortcut / invariant claims below against current `master` before acting on them. Then bump this date in the same PR that fixes the drift.
+> **Last verified: 2026-06-15.** If this date is more than ~7 days old when you load this skill, your first move is to check what merged since: `gh pr list --repo m6502/ztrackerprime --state merged --json number,title,mergedAt --jq '[.[] | select(.mergedAt > "<this date>")]'`. Reconcile any architecture / shortcut / invariant claims below against current `master` before acting on them. Then bump this date in the same PR that fixes the drift.
 >
 > **What lives elsewhere on purpose:** the open-PR list and merged landmarks are NOT in this skill — they go stale fast. For current state run `gh pr list --repo m6502/ztrackerprime` (open) or `gh pr list --repo m6502/ztrackerprime --state merged --limit 30` (recent landings). The skill stays timeless: architecture, invariants, foot-guns, conventions.
 
@@ -176,7 +176,7 @@ palettes against an actual screenshot; don't trust the 16→18 slot mapping.
 | `src/editor_layout.h` | Shared character-grid constants for F4/Shift+F4 |
 | `assets/ccizer/` | Bundled CCizer banks (sc88st, microfreak, minilogue, monologue, Prophet6, deepmind6, waldorf_blofeld, tb03, se02, pro800, polyend_*, midi_control_example) — copied from Paketti. README.md documents the format. |
 | `assets/syx/` | Bundled SysEx files. `request_universal_inquiry.syx` = `F0 7E 7F 06 01 F7` for first-test handshakes. README.md documents the librarian workflow. |
-| `tests/` | CTest unit-test executables — 13 suites: `presets`, `selector`, `page_sync`, `save_key`, `keybuffer`, `ccizer`, `sysex_inq`, `sysex_stress`, `sysex_macro`, `ccbn_roundtrip`, `ccenv`, `keyjazz_map`, `ableton_link`. (Count drifts as suites are added — `ctest` is the source of truth.) Note the macOS CI also runs the Lua API self-test via `--lua-test` (PRs #154, #156). |
+| `tests/` | CTest unit-test executables — 14 suites: `presets`, `selector`, `page_sync`, `save_key`, `keybuffer`, `ccizer`, `sysex_inq`, `sysex_stress`, `sysex_macro`, `ccbn_roundtrip`, `ccenv`, `keyjazz_map`, `ableton_link`, `lua_api`. The `lua_api` suite drives the real `zt` binary headless (`--headless --lua-test`) against a scratch song and runs on macOS CI (PRs #154, #156); the rest are SDL-free and run on Linux CI. (Count drifts as suites are added — `ctest -N` is the source of truth.) |
 | `doc/help.txt` | In-app F1 help — update when adding keybinds or CLI flags |
 | `doc/CHANGELOG.txt` | Release notes, chronological |
 | `.github/workflows/build.yml` | 5-platform CI matrix; Linux job runs `ctest` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,9 @@
 
 This file is loaded automatically by Claude Code (and other AI agents that support `CLAUDE.md`) when working in this repo. It distills the conventions and gotchas that have been learned the hard way during zTracker Prime development. **Read this before making changes.**
 
-For deeper material — recipes, foot-gun details, effect reference, glossary, coding conventions — see [`.claude/skills/ztrackerprime/SKILL.md`](.claude/skills/ztrackerprime/SKILL.md) and the `references/` + `recipes/` directories alongside it.
+**This file is self-contained** — you do not need the skill to contribute. For *deeper* material — headless-screenshot recipes, the full list-pane construction idiom (with code), effect reference, glossary — see [`.claude/skills/ztrackerprime/SKILL.md`](.claude/skills/ztrackerprime/SKILL.md) and the `references/` + `recipes/` directories alongside it. The skill is the continuously-maintained companion; CLAUDE.md is the standalone briefing that mirrors its essentials for agents and humans who don't load skills.
+
+> **Last synced with the codebase: 2026-06-15.** If that date is more than ~2 weeks old when you read this, your first move is to check what merged since — `gh pr list --repo m6502/ztrackerprime --state merged --json number,title,mergedAt` — and reconcile the key-files table, shortcut map, feature sections, and test list below against current `master` before relying on them. Bump this date in the same commit that fixes any drift. (This guard exists because CLAUDE.md silently fell ~7 weeks out of date once: it duplicated the skill's content but, unlike the skill, had no reconcile step.)
 
 ---
 
@@ -50,13 +52,19 @@ CMake option `ZT_BUILD_TESTS` (default ON) controls whether the `tests/` subdire
 | `src/CUI_KeyBindings.cpp` | Unified Shortcuts & MIDI Mappings (**Shift+F2** — moved from Shift+F3 to free that slot for the CC Console). |
 | `src/CUI_CcConsole.cpp` | CC Console (**Shift+F3**) — Paketti CCizer file load + sliders/knobs send-out + per-slot MIDI Learn (`L` to learn, `U` to unbind, `B` to assign as current instrument's bank). |
 | `src/CUI_SysExLibrarian.cpp` | SysEx Librarian (**Shift+F5**) — `.syx` file send + auto-capture of incoming SysEx as `recv_<timestamp>.syx`. |
+| `src/CUI_CCEnvelopeEditor.cpp` | CC Envelope Editor (**Shift+F6**) — per-instrument, CCizer-aware CC envelopes (Schism-style). Persisted in the optional `INSE` chunk; loads/saves `.env` presets. See `ccenv_{advance,interp,io}.{h,cpp}`. |
+| `src/CUI_LuaConsole.cpp` | Lua Console (**Ctrl+Alt+L**) — Renoise-style interactive console over the embedded Lua engine. Tab cycling, `rprint`/`oprint`/`help`, wrapping scrollback. |
+| `src/CUI_Page.{h,cpp}` | Base class for all `CUI_*` pages. |
 | `src/CUI_*.cpp` | Other pages: Sysconfig, Songconfig, Help, About, InstEditor, MainMenu, etc. |
 | `src/UserInterface.{h,cpp}` | Widget classes — `CheckBox`, `ValueSlider`, `TextInput`, `Frame`, `Button`, `TextBox`, `ListBox`, `MidiOutDeviceOpener`, `SkinSelector`, `VUPlay`. **Fix rendering bugs in the widget class, not at every caller.** |
 | `src/keybuffer.{h,cpp}` | Key buffer + KS_ALT/KS_CTRL/KS_META/KS_SHIFT state. `KS_HAS_ALT(s)` macro accepts ALT or macOS Cmd. Header has a `ZT_TEST_NO_SDL` guard so it can be compiled into SDL-free unit tests via `tests/sdl_stub.h`. |
 | `src/font.cpp` | `print()` / `printtitle()` / `printBG()` drawing primitives. |
 | `src/zt.h` | Kitchen-sink: `STATE_*` enum (incl. `STATE_CCCONSOLE`, `STATE_SYSEX_LIB`), `CMD_*` enum, page globals (`UIP_CcConsole`, `UIP_SysExLibrarian`), `g_cc_drawmode`, layout macros. |
 | `src/module.{h,cpp}` | Song data: patterns, tracks, events, instruments, arpeggios, midimacros. `instrument` carries `ccizer_bank[256]` (per-instrument Paketti file). |
-| `src/playback.{h,cpp}` | MIDI output timing, playback state, R-effect arpeggio + Z-effect macro dispatch. **Z on a `*.syx`-named midimacro** dispatches the file as SysEx via `MidiOut->sendSysEx`. |
+| `src/playback.{h,cpp}` | MIDI output timing, playback state, R-effect arpeggio + Z-effect macro dispatch. **Z on a `*.syx`-named midimacro** dispatches the file as SysEx via `MidiOut->sendSysEx`. Drives the Ableton Link pump. |
+| `src/lua_engine.{cpp,h}` | Embedded Lua API: object model (`zt`, `song`, `transport`, `pattern`, `track`, cells, order list) + notifiers (`zt.on/off/fire` for play/stop/row/idle). `lua/selftest.lua` exercises the surface via `--lua-test`. |
+| `src/ableton_link.{cpp,h}` | Ableton Link tempo + transport sync (PR #159). C API: `zt_ableton_link_startup/teardown/pump/defer_play/available/get_tempo`. Driven from `playback.cpp`, configured from F11, conf keys in `conf.cpp`. |
+| `src/ccenv_{advance,interp,io}.{h,cpp}` | CC Envelope engine: advance/step logic, interpolation, and `.env` preset + `INSE` chunk I/O. Backs `CUI_CCEnvelopeEditor`. |
 | `src/winmm_compat.h` | Cross-platform MIDI shim. `zt_midi_out_sysex` for SysEx send (CoreMIDI `MIDIPacketListAdd` / WinMM `midiOutLongMsg` / ALSA `snd_seq_ev_set_sysex`). macOS `zt_coremidi_read_proc` parses incoming `F0..F7` into `zt_sysex_inq_push`. |
 | `src/sysex_inq.{h,cpp}` | Process-wide receive queue for incoming SysEx (16 slots × 8 KB; `std::mutex` protected; overflow drops oldest). |
 | `src/sysex_macro.{h,cpp}` | Helpers for the `*.syx`-named-midimacro convention: predicate + `syx_folder` path resolution + framing-checked file reader. |
@@ -130,8 +138,16 @@ The ESC menu has a "Copy Relaunch Command" entry that captures current state (op
 | **Shift+F3** | **CC Console** — Paketti CCizer file load + sliders/knobs send-out + MIDI Learn |
 | F5 / F6 / F7 / F8 / F9 | Play / Play Pattern / From Cursor / Stop / Panic |
 | **Shift+F5** | **SysEx Librarian** — `.syx` send + auto-capture as `recv_<TS>.syx` |
+| **Shift+F6** | **CC Envelope Editor** — per-instrument CCizer-aware CC envelopes (PR #132) |
 | F10 / F11 / F12 | Song Message / Song Config / System Config (incl. CCizer Folder input) |
-| **Ctrl+Shift+§** | **CC drawmode toggle** — incoming CC writes `Sxxyy`, PB writes `Wxxxx` |
+| **Ctrl+Alt+L** | **Lua Console** — interactive Lua over the embedded engine (siblings: Ctrl+Alt+K Keybindings, Ctrl+Alt+N New Song) |
+| **Ctrl+Shift+§** | **CC drawmode toggle** — incoming CC writes `Sxxyy`, PB writes `Wxxxx` (Windows: `Ctrl+Shift+`` ` ``) |
+
+Sub-modes worth knowing:
+- **F2 again** from the Pattern Editor → PEParms. **F2 F2 toggles "PianoKey"**, the Ableton/Logic piano keyjazz layout (PR #135).
+- **F3 again** from the Instrument Editor → "Create 16 Channels" popup: fills the next empty instrument slots with the current device on ch 1..16 (PR #136). F3 row 11 shows `CCizer Bank: <basename>`.
+- **F11** Song Config hosts the **Ableton Link** controls (enable / start-stop-sync checkboxes, quantize-offset slider).
+- **CC drawmode** is extended by PRs #123–#129: mouse drag-to-draw drawbars, CCizer-slot cycling, one-key arm-and-draw, double-click reset, `Ctrl+F2` slot cycle, keyjazz audition while drawing. `[CC DRAW]` badge top-right while active.
 
 ---
 
@@ -145,26 +161,59 @@ Three feature areas wired in seven stacked PRs:
 
 3. **SysEx**. Foundation in `winmm_compat.h` (`zt_midi_out_sysex`) + `OutputDevice::sendSysEx` + receive queue `sysex_inq.{h,cpp}`. macOS callback parses incoming `F0..F7` into the queue. **SysEx Librarian** (Shift+F5) lists `.syx` files in `syx_folder`, sends on Enter, auto-saves received messages as `recv_<timestamp>.syx`. **Pattern dispatch convention**: a midimacro whose `name` ends in `.syx` (case-insensitive, len > 4) is dispatched as a SysEx file send by the Z-effect handler — no `.zt` format change because the existing MMAC chunk already round-trips the name.
 
-Cross-platform status (2026-04-30): SysEx send works on all three platforms; receive parsing is macOS-only today (Linux/Windows on the followup TODO).
+Cross-platform status (verified 2026-05-02): SysEx **send** works on macOS (CoreMIDI `MIDIPacketListAdd`), Windows (WinMM `midiOutLongMsg` + MHDR_DONE poll, PR #87), Linux (ALSA `snd_seq_ev_set_sysex`). SysEx **receive** works on macOS and Windows (`MIM_LONGDATA` accumulator, PR #90). Linux ALSA MIDI input landed in PR #113 (marked "needs hardware verification") — confirm SysEx-receive-on-Linux against real hardware before relying on it.
 
 Tests for all three: `test_ccizer` (51 checks), `test_sysex_inq` (~25), `test_sysex_macro` (~20). Bundled assets under `assets/ccizer/` (Paketti subset) and `assets/syx/` (universal device inquiry).
 
 ---
 
+## CC Envelope Editor (Shift+F6, PR #132)
+
+Per-instrument, CCizer-aware CC envelopes (Schism-style). Page is `CUI_CCEnvelopeEditor.cpp`; the engine is split across `ccenv_advance.h` (per-row advance), `ccenv_interp.h` (interpolation), and `ccenv_io.{cpp,h}` (`.env` preset files + persistence). Envelopes are stored in a new optional `INSE` chunk in the `.zt` save format (forward/backward compatible the same way `CCBN` is — old zTracker skips the unrecognised chunk). The editor loads/saves `.env` presets from a configurable folder.
+
+---
+
+## Lua scripting (PRs #148–#157)
+
+An embedded Lua engine + interactive console. Treat it as a first-class subsystem.
+
+- **Engine** (`src/lua_engine.{cpp,h}`) — a Renoise-flavoured object model: `zt` (top-level), `song`, `transport`, `pattern`, `track`, plus cell access, the order list, note names, constants. Notifier API: `zt.on(event, fn)` / `zt.off(...)` / `zt.fire(...)` for `play` / `stop` / `row` / `idle`, pumped from the main loop. MIDI macros expose `:send()`.
+- **Console** (`src/CUI_LuaConsole.cpp`, **Ctrl+Alt+L**) — Tab cycling, `rprint` / `oprint` / `help`, wrapping scrollback.
+- **Self-test** — `lua/selftest.lua` exercises the whole API surface; runs via `--lua-test` (the `lua_api` ctest target) and is wired into macOS CI. **When you add or rename a Lua binding, update `lua/selftest.lua` in the same PR** — CI catches regressions there.
+
+---
+
+## Ableton Link (PR #159, merged 2026-06-10)
+
+Tempo + transport sync with Ableton Live and other Link-aware apps over the local network.
+
+- **Core** (`src/ableton_link.{cpp,h}`) — C API: `zt_ableton_link_startup` / `_teardown` / `_pump` / `_defer_play(row, pattern, pm)` / `_available` / `_get_tempo`. Pumped from `playback.cpp`; the pump can move `song->bpm` underneath the UI, so F11 re-reads it each frame.
+- **Config** (`conf.cpp`, persisted in `zt.conf`): `ableton_link_enable` (**OFF by default** — no surprise LAN traffic), `ableton_link_start_stop_sync` (ON by default; only effective once Link is enabled), `ableton_link_quantum` (default 4 = one bar of 4/4), `ableton_link_offset_ms`.
+- **UI** — F11 Song Configuration hosts the enable + start/stop-sync checkboxes and the offset slider.
+- **Precedence:** if both Ableton Link and MIDI Sync are enabled, **Link wins**.
+
+---
+
 ## Test harness
 
-`tests/` builds eight CTest executables:
+`tests/` builds a growing set of CTest suites. **`ctest --test-dir build -N` is the source of truth for the current list** (the count drifts as suites are added). As of the last sync there are 14:
 
-- `test_presets` — preset arrays + apply functions.
-- `test_selector` — listbox click / arrow / Space / P-cycle decision logic.
-- `test_page_sync` — apply→refresh→sync per-frame cycle.
-- `test_save_key` — global Ctrl-S dispatch.
-- `test_keybuffer` — real `KeyBuffer` from `src/keybuffer.cpp`, compiled under `ZT_TEST_NO_SDL` against `tests/sdl_stub.h`.
-- `test_ccizer` — Paketti CCizer parser (`PB`/CC# tokens, comments, blanks, out-of-range), `.cc-view` view-hint sidecar round-trip, MIDI byte builder for CC + 14-bit Pitchbend, folder resolution, `.txt` directory scan.
-- `test_sysex_inq` — process-wide SysEx receive queue: empty / push-pop round-trip / FIFO ordering / overflow drops oldest / undersized pop buffer (message stays queued) / invalid input rejection.
-- `test_sysex_macro` — `*.syx`-named-midimacro convention helpers: predicate (case-insensitive, rejects bare `.syx`), path resolution against `syx_folder`, and the framing-checked file reader (rejects missing `F0`/`F7`, oversized, missing).
+- `presets` — preset arrays + apply functions.
+- `selector` — listbox click / arrow / Space / P-cycle decision logic.
+- `page_sync` — apply→refresh→sync per-frame cycle.
+- `save_key` — global Ctrl-S dispatch.
+- `keybuffer` — real `KeyBuffer` from `src/keybuffer.cpp`, compiled under `ZT_TEST_NO_SDL` against `tests/sdl_stub.h`.
+- `ccizer` — Paketti CCizer parser (`PB`/CC# tokens, comments, blanks, out-of-range), `.cc-view` view-hint sidecar round-trip, MIDI byte builder for CC + 14-bit Pitchbend, folder resolution, `.txt` directory scan.
+- `sysex_inq` — process-wide SysEx receive queue: empty / push-pop / FIFO / overflow drops oldest / undersized pop buffer / invalid input rejection.
+- `sysex_stress` — SysEx queue under concurrent load.
+- `sysex_macro` — `*.syx`-named-midimacro convention helpers: predicate, path resolution against `syx_folder`, framing-checked file reader.
+- `ccbn_roundtrip` — per-instrument `CCBN` chunk save/load round-trip.
+- `ccenv` — CC Envelope advance / interpolation / `.env` + `INSE` I/O.
+- `keyjazz_map` — Ableton/Logic PianoKey layout + the two layouts' mutual exclusivity.
+- `ableton_link` — Ableton Link config + precedence (`ZT_TEST_NO_SDL`).
+- `lua_api` — full Lua API self-test: drives the real `zt` binary headless (`--headless --lua-test`) against a scratch song, runs `lua/selftest.lua`, asserts exit 0.
 
-Run all: `ctest --test-dir build --output-on-failure`. CI runs them on the Linux job after every push.
+Run all: `ctest --test-dir build --output-on-failure`. Linux CI runs the SDL-free suites after every push; the `lua_api` self-test runs on macOS CI.
 
 When you fix a class of bug that has bitten more than once (preset apply, save-key dispatch, button-up consumption), extract the decision logic into a header (`preset_selector.h`, `save_key_dispatch.h`, `page_sync.h`, etc.) and add tests. Bug-class regression test scaffolding has paid off multiple times in the F4/Shift+F4 work.
 
@@ -224,7 +273,7 @@ If the trace doesn't show how the reported input produces the symptom, the model
 ## PR discipline
 
 - **Keep PRs focused.** Manuel's preferred size: 1 feature, ~30–300 LOC. Large kitchen-sink PRs are tolerated when the body has a clear table of contents.
-- Tag commits with `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` (or current model).
+- Tag commits with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` (or current model).
 - Don't merge to master without Manuel's approval — open PRs and let him review/merge.
 - `doc/CHANGELOG.txt` gets a section per PR.
 - Don't duplicate content across PRs.


### PR DESCRIPTION
## Summary

`CLAUDE.md` had silently fallen ~7 weeks out of date. It duplicated the `ztrackerprime` skill's content but — unlike the skill — carried **no reconcile-against-master step**, so it froze at the end-April CCizer/SysEx wave while Lua scripting, Ableton Link, and the CC Envelope editor all landed on `master`.

This PR brings it current **and** gives it the same self-healing mechanism the skill has, so it can't silently rot again. It documents **merged `master` reality only** — the in-flight MIDI-clock phase-lock suites are intentionally left out and will be documented when that branch's own PR lands.

## Root cause of the drift

Two copies of the same truth (CLAUDE.md + SKILL.md) always diverge. The skill self-heals via a "Last verified / reconcile if stale" header; CLAUDE.md had no such guard.

## Changes

**CLAUDE.md**
- **Anti-drift freshness guard** — a dated "Last synced" block with a `gh pr list --merged` reconcile step (mirrors the skill's mechanism).
- **Division of labour stated** — CLAUDE.md is the self-contained briefing for agents/humans who don't load skills; the skill is the deeper maintained companion. (Kept CLAUDE.md standalone-complete on purpose.)
- **Key-files table** — added `CUI_CCEnvelopeEditor`, `CUI_LuaConsole`, `CUI_Page`, `lua_engine`, `ableton_link`, `ccenv_{advance,interp,io}`.
- **Shortcut map** — added Shift+F6 (CC Envelope), Ctrl+Alt+L (Lua Console); notes for F2 F2 PianoKey, F3 Create-16-Channels, F11 Ableton Link, CC-drawmode #123–#129.
- **New feature sections** — CC Envelope Editor (#132), Lua scripting (#148–157), Ableton Link (#159).
- **SysEx cross-platform status** refreshed (Windows receive #90, Linux ALSA-in #113).
- **Test harness** — 8 → the real **14** merged suites, with `ctest -N` named as the source of truth.
- Co-Authored-By model example bumped 4.7 → 4.8.

**SKILL.md**
- Bumped `Last verified` to 2026-06-15.
- Added the `lua_api` suite to its test list (it was described in prose but missing from the count → now 14).

## Test plan

- [x] Docs-only change — no source, build, or test impact.
- [x] Test-suite list cross-checked against `tests/CMakeLists.txt` on `master` (14 merged suites).
- [x] All referenced source files confirmed to exist.
