### PR TITLE
docs: document the MIDI clock sync & phase-lock subsystem

### DIFF
--- a/.claude/skills/ztrackerprime/SKILL.md
+++ b/.claude/skills/ztrackerprime/SKILL.md
@@ -179,7 +179,7 @@ palettes against an actual screenshot; don't trust the 16→18 slot mapping.
 | `src/editor_layout.h` | Shared character-grid constants for F4/Shift+F4 |
 | `assets/ccizer/` | Bundled CCizer banks (sc88st, microfreak, minilogue, monologue, Prophet6, deepmind6, waldorf_blofeld, tb03, se02, pro800, polyend_*, midi_control_example) — copied from Paketti. README.md documents the format. |
 | `assets/syx/` | Bundled SysEx files. `request_universal_inquiry.syx` = `F0 7E 7F 06 01 F7` for first-test handshakes. README.md documents the librarian workflow. |
-| `tests/` | CTest unit-test executables — 14 suites: `presets`, `selector`, `page_sync`, `save_key`, `keybuffer`, `ccizer`, `sysex_inq`, `sysex_stress`, `sysex_macro`, `ccbn_roundtrip`, `ccenv`, `keyjazz_map`, `ableton_link`, `lua_api`. The `lua_api` suite drives the real `zt` binary headless (`--headless --lua-test`) against a scratch song and runs on macOS CI (PRs #154, #156); the rest are SDL-free and run on Linux CI. The MIDI clock phase-lock feature adds 3 more (`phase_chase`, `midi_timestamp`, `midi_clock_sync` → 17). (Count drifts as suites are added — `ctest -N` is the source of truth.) |
+| `tests/` | CTest unit-test executables — 14 suites: `presets`, `selector`, `page_sync`, `save_key`, `keybuffer`, `ccizer`, `sysex_inq`, `sysex_stress`, `sysex_macro`, `ccbn_roundtrip`, `ccenv`, `keyjazz_map`, `ableton_link`, `lua_api`. The `lua_api` suite drives the real `zt` binary headless (`--headless --lua-test`) against a scratch song and runs on macOS CI (PRs #154, #156); the rest are SDL-free and run on Linux CI. The MIDI clock phase-lock feature (integration PR #169) adds 4 more (`phase_chase`, `midi_timestamp`, `midi_clock_sync`, `midi_clock_estimator` → 18). (Count drifts as suites are added — `ctest -N` is the source of truth.) |
 | `doc/help.txt` | In-app F1 help — update when adding keybinds or CLI flags |
 | `doc/CHANGELOG.txt` | Release notes, chronological |
 | `.github/workflows/build.yml` | 5-platform CI matrix; Linux job runs `ctest` |
@@ -267,16 +267,17 @@ Tempo + transport sync with Ableton Live and other Link-aware apps over the loca
 - **UI** — F11 Song Configuration (`CUI_Songconfig.cpp`) hosts the enable + start/stop-sync checkboxes and the offset slider.
 - **Precedence:** if both Ableton Link and MIDI Sync are enabled, **Link wins** (`conf.cpp`).
 
-## MIDI clock sync & phase-lock (`esa/midi-clock-phase-lock`, documented ahead of merge)
+## MIDI clock sync & phase-lock (integration PR #169, documented ahead of merge)
 
-External MIDI-clock slave sync built on the **same** `phase_chase.h` controller as Ableton Link, so a fractional-tempo master cannot drift the engine. `midi_in_sync` follows start/stop; `midi_in_sync_chase_tempo` derives tempo and phase-locks; the `--midi-clock` CLI flag turns both on.
+External MIDI-clock slave sync built on the **same** `phase_chase.h` controller as Ableton Link, so a fractional-tempo master cannot drift the engine. `midi_in_sync` follows start/stop; `midi_in_sync_chase_tempo` derives tempo and phase-locks; the `--midi-clock` CLI flag turns both on. The engine is the merge of two independent rewrites that converged on an identical `phase_chase.h`: Chris Micali's tempo estimator (`cmicali/midi-sync-improvements`) under the hardening branch's observability + robustness.
 
 - **Observer architecture** (`midi_clock_sync.{cpp,h}`) — the MIDI-in callback thread only records into `std::atomic` counters (`g_mclk_*`, same advisory contract as `player::stop_count`); all decisions run in `zt_midi_clock_pump()` on the main thread once/frame, next to `zt_ableton_link_pump()`. ThreadSanitizer-clean (TSan CI job). Relies only on per-counter atomicity, tolerating a bump seen a frame late.
+- **Tempo estimate** (Chris's) — least-squares regression over a ~1 s sliding window of clock-*arrival* samples (a jitter-delayed edge carries only 1/n weight), plus retune anti-flap hysteresis (>0.6 BPM held, >3.0 BPM immediate) so a master on a rounding boundary like 124.5 doesn't flap the nominal.
 - **Position, not just rate** — 24 clocks/beat = 4 subticks/clock; clocks-since-START is the exact expected position (MIDI-clock analogue of Link's `beatAtTime`), fed through `phase_chase_step()` into `player::chase_skew_us`.
-- **Hardware timestamps** (`midi_timestamp.h`, macOS) — CoreMIDI packet stamp → `SDL_GetTicks()` epoch removes callback scheduling jitter; sanity-gated so a bad stamp falls back to the software clock.
+- **Hardware timestamps** (`midi_timestamp.h`, macOS) — CoreMIDI packet stamp → `SDL_GetTicks()` epoch removes callback scheduling jitter and feeds the estimator's arrival edge; sanity-gated so a bad stamp falls back to the software clock.
 - **Hardening** — warm re-lock + snap-on-discontinuity recover cleanly from a dropout or transport jump.
 - **Observability** — six-state lock model (`zt_sync_state`: off/waiting/dropout/transport/chasing/locked) via `zt_midi_clock_get_status()` → F11 lock meter + Lua `zt.transport.sync_state`/`sync_bpm`/`sync_offset_ms` + the `sync` notifier. `sync_offset_ms` conf key (legacy alias `ableton_link_offset_ms`).
-- **Tests** — `phase_chase`, `midi_timestamp`, `midi_clock_sync` (the 3 suites that take the harness from 14 → 17 when this lands).
+- **Tests** — `phase_chase`, `midi_timestamp`, `midi_clock_sync`, and Chris's `midi_clock_estimator` (the 4 suites that take the harness from 14 → 18 when this lands).
 
 ## INVARIANTS for any new or modified page
 

--- a/.claude/skills/ztrackerprime/SKILL.md
+++ b/.claude/skills/ztrackerprime/SKILL.md
@@ -155,7 +155,10 @@ palettes against an actual screenshot; don't trust the 16→18 slot mapping.
 | `src/CUI_SysExLibrarian.cpp` | SysEx Librarian (**Shift+F5**) — `.syx` file send + auto-capture of incoming SysEx |
 | `src/CUI_LuaConsole.cpp` | Lua Console (**Ctrl+Alt+L**) — Renoise-style interactive console over the embedded Lua engine. Tab cycling, `rprint`/`oprint`/`help`, scrollback wrapping. |
 | `src/lua_engine.{cpp,h}` | Embedded Lua API: object model (`zt`, `song`, `transport`, `pattern`, `track`, cells, order list) + notifiers (`zt.on/off/fire` for play/stop/row/idle). `lua/selftest.lua` exercises the surface via `--lua-test` (a ctest target). |
-| `src/ableton_link.{cpp,h}` | Ableton Link tempo + transport sync (PR #159). C API: `zt_ableton_link_startup/teardown/pump/defer_play/available/get_tempo`. Driven from `playback.cpp`; configured from F11 Song Config; conf keys in `conf.cpp`. |
+| `src/ableton_link.{cpp,h}` | Ableton Link tempo + transport sync (PR #159). C API: `zt_ableton_link_startup/teardown/pump/defer_play/available/get_tempo`. Driven from `playback.cpp`; configured from F11 Song Config; conf keys in `conf.cpp`. Rebuilt on the shared `phase_chase.h` controller. |
+| `src/phase_chase.h` | Shared closed-loop position controller (pure logic, SDL-free, unit-tested), used by **both** Ableton Link and MIDI clock sync. `phase_chase_step()` returns a bounded skew that cancels rate error (int-BPM rounding, crystal drift); deadband-tiered feedback. |
+| `src/midi_clock_sync.{cpp,h}` | MIDI clock slave (`midi_in_sync` / `midi_in_sync_chase_tempo`). MIDI-in thread only records into atomic `g_mclk_*` counters; `zt_midi_clock_pump()` (main thread, once/frame) consumes transport, estimates tempo, phase-locks via `phase_chase.h`. Six-state `zt_sync_state`; `zt_midi_clock_get_status()`. Honors `sync_offset_ms`. |
+| `src/midi_timestamp.h` | Pure helpers (SDL-free, unit-tested) to use a MIDI hardware timestamp as clock-arrival time. macOS `mach_absolute_time` → `SDL_GetTicks()` ms via `zt_mach_stamp_to_sdl_ms`, sanity-gated (garbage stamp falls back to software clock). |
 | `src/CUI_*.cpp` | Other pages (Sysconfig, Songconfig, Help, InstEditor, MainMenu, Playsong, etc.) |
 | `src/CUI_Page.{h,cpp}` | Base class for pages |
 | `src/UserInterface.{h,cpp}` | Widget classes — `CheckBox`, `ValueSlider`, `TextInput`, `Frame`, `Button`, `TextBox`, `ListBox`, `MidiOutDeviceOpener`, `SkinSelector`, `VUPlay`. Fix rendering bugs HERE, not in callers. |
@@ -176,7 +179,7 @@ palettes against an actual screenshot; don't trust the 16→18 slot mapping.
 | `src/editor_layout.h` | Shared character-grid constants for F4/Shift+F4 |
 | `assets/ccizer/` | Bundled CCizer banks (sc88st, microfreak, minilogue, monologue, Prophet6, deepmind6, waldorf_blofeld, tb03, se02, pro800, polyend_*, midi_control_example) — copied from Paketti. README.md documents the format. |
 | `assets/syx/` | Bundled SysEx files. `request_universal_inquiry.syx` = `F0 7E 7F 06 01 F7` for first-test handshakes. README.md documents the librarian workflow. |
-| `tests/` | CTest unit-test executables — 14 suites: `presets`, `selector`, `page_sync`, `save_key`, `keybuffer`, `ccizer`, `sysex_inq`, `sysex_stress`, `sysex_macro`, `ccbn_roundtrip`, `ccenv`, `keyjazz_map`, `ableton_link`, `lua_api`. The `lua_api` suite drives the real `zt` binary headless (`--headless --lua-test`) against a scratch song and runs on macOS CI (PRs #154, #156); the rest are SDL-free and run on Linux CI. (Count drifts as suites are added — `ctest -N` is the source of truth.) |
+| `tests/` | CTest unit-test executables — 14 suites: `presets`, `selector`, `page_sync`, `save_key`, `keybuffer`, `ccizer`, `sysex_inq`, `sysex_stress`, `sysex_macro`, `ccbn_roundtrip`, `ccenv`, `keyjazz_map`, `ableton_link`, `lua_api`. The `lua_api` suite drives the real `zt` binary headless (`--headless --lua-test`) against a scratch song and runs on macOS CI (PRs #154, #156); the rest are SDL-free and run on Linux CI. The MIDI clock phase-lock feature adds 3 more (`phase_chase`, `midi_timestamp`, `midi_clock_sync` → 17). (Count drifts as suites are added — `ctest -N` is the source of truth.) |
 | `doc/help.txt` | In-app F1 help — update when adding keybinds or CLI flags |
 | `doc/CHANGELOG.txt` | Release notes, chronological |
 | `.github/workflows/build.yml` | 5-platform CI matrix; Linux job runs `ctest` |
@@ -263,6 +266,17 @@ Tempo + transport sync with Ableton Live and other Link-aware apps over the loca
 - **Config** (`conf.cpp`, keys persisted in `zt.conf`): `ableton_link_enable` (**OFF by default** — no surprise LAN traffic), `ableton_link_start_stop_sync` (ON by default; only effective once Link is enabled), `ableton_link_quantum` (default 4 = one bar of 4/4), `ableton_link_offset_ms` (fire quantized starts early by this much).
 - **UI** — F11 Song Configuration (`CUI_Songconfig.cpp`) hosts the enable + start/stop-sync checkboxes and the offset slider.
 - **Precedence:** if both Ableton Link and MIDI Sync are enabled, **Link wins** (`conf.cpp`).
+
+## MIDI clock sync & phase-lock (`esa/midi-clock-phase-lock`, documented ahead of merge)
+
+External MIDI-clock slave sync built on the **same** `phase_chase.h` controller as Ableton Link, so a fractional-tempo master cannot drift the engine. `midi_in_sync` follows start/stop; `midi_in_sync_chase_tempo` derives tempo and phase-locks; the `--midi-clock` CLI flag turns both on.
+
+- **Observer architecture** (`midi_clock_sync.{cpp,h}`) — the MIDI-in callback thread only records into `std::atomic` counters (`g_mclk_*`, same advisory contract as `player::stop_count`); all decisions run in `zt_midi_clock_pump()` on the main thread once/frame, next to `zt_ableton_link_pump()`. ThreadSanitizer-clean (TSan CI job). Relies only on per-counter atomicity, tolerating a bump seen a frame late.
+- **Position, not just rate** — 24 clocks/beat = 4 subticks/clock; clocks-since-START is the exact expected position (MIDI-clock analogue of Link's `beatAtTime`), fed through `phase_chase_step()` into `player::chase_skew_us`.
+- **Hardware timestamps** (`midi_timestamp.h`, macOS) — CoreMIDI packet stamp → `SDL_GetTicks()` epoch removes callback scheduling jitter; sanity-gated so a bad stamp falls back to the software clock.
+- **Hardening** — warm re-lock + snap-on-discontinuity recover cleanly from a dropout or transport jump.
+- **Observability** — six-state lock model (`zt_sync_state`: off/waiting/dropout/transport/chasing/locked) via `zt_midi_clock_get_status()` → F11 lock meter + Lua `zt.transport.sync_state`/`sync_bpm`/`sync_offset_ms` + the `sync` notifier. `sync_offset_ms` conf key (legacy alias `ableton_link_offset_ms`).
+- **Tests** — `phase_chase`, `midi_timestamp`, `midi_clock_sync` (the 3 suites that take the harness from 14 → 17 when this lands).
 
 ## INVARIANTS for any new or modified page
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,14 +62,17 @@ CMake option `ZT_BUILD_TESTS` (default ON) controls whether the `tests/` subdire
 | `src/zt.h` | Kitchen-sink: `STATE_*` enum (incl. `STATE_CCCONSOLE`, `STATE_SYSEX_LIB`), `CMD_*` enum, page globals (`UIP_CcConsole`, `UIP_SysExLibrarian`), `g_cc_drawmode`, layout macros. |
 | `src/module.{h,cpp}` | Song data: patterns, tracks, events, instruments, arpeggios, midimacros. `instrument` carries `ccizer_bank[256]` (per-instrument Paketti file). |
 | `src/playback.{h,cpp}` | MIDI output timing, playback state, R-effect arpeggio + Z-effect macro dispatch. **Z on a `*.syx`-named midimacro** dispatches the file as SysEx via `MidiOut->sendSysEx`. Drives the Ableton Link pump. |
-| `src/lua_engine.{cpp,h}` | Embedded Lua API: object model (`zt`, `song`, `transport`, `pattern`, `track`, cells, order list) + notifiers (`zt.on/off/fire` for play/stop/row/idle). `lua/selftest.lua` exercises the surface via `--lua-test`. |
-| `src/ableton_link.{cpp,h}` | Ableton Link tempo + transport sync (PR #159). C API: `zt_ableton_link_startup/teardown/pump/defer_play/available/get_tempo`. Driven from `playback.cpp`, configured from F11, conf keys in `conf.cpp`. |
+| `src/lua_engine.{cpp,h}` | Embedded Lua API: object model (`zt`, `song`, `transport`, `pattern`, `track`, cells, order list) + notifiers (`zt.on/off/fire` for play/stop/row/idle/**sync**). `zt.transport` exposes read-only `sync_state` / `sync_bpm` / `sync_offset_ms` mirroring the F11 lock meter. `lua/selftest.lua` exercises the surface via `--lua-test`. |
+| `src/ableton_link.{cpp,h}` | Ableton Link tempo + transport sync (PR #159). C API: `zt_ableton_link_startup/teardown/pump/defer_play/available/get_tempo`. Driven from `playback.cpp`, configured from F11, conf keys in `conf.cpp`. Rebuilt on the shared `phase_chase.h` controller. |
+| `src/phase_chase.h` | Shared closed-loop position controller (pure logic, SDL-free, unit-tested). Used by **both** Ableton Link and MIDI clock sync: compares the master timeline against `player::played_subticks` each frame and returns a bounded skew that cancels rate error (int-BPM rounding, crystal drift). Deadband-tiered feedback (inaudible inside `PHASE_CHASE_DEADBAND_US`, hard slew outside). |
+| `src/midi_clock_sync.{cpp,h}` | MIDI clock slave (`midi_in_sync` / `midi_in_sync_chase_tempo`). Observer architecture: the MIDI-in thread only **records** (atomic counters `g_mclk_*`); all decisions happen in `zt_midi_clock_pump()` on the main thread once/frame. 24 clocks/beat = 4 subticks/clock = a position reference, fed through `phase_chase.h`. Six-state lock model (`zt_sync_state`): off / waiting / dropout / transport / chasing / locked; read via `zt_midi_clock_get_status()`. Honors `sync_offset_ms`. |
+| `src/midi_timestamp.h` | Pure helpers (SDL-free, unit-tested) to use a platform MIDI **hardware** timestamp as the clock-arrival time instead of sampling a software clock in the callback (removes OS-scheduling jitter). macOS CoreMIDI `mach_absolute_time` → `SDL_GetTicks()` ms epoch via `zt_mach_stamp_to_sdl_ms`, then sanity-**gated**: a garbage stamp falls back to the software clock rather than poisoning the phase lock. |
 | `src/ccenv_{advance,interp,io}.{h,cpp}` | CC Envelope engine: advance/step logic, interpolation, and `.env` preset + `INSE` chunk I/O. Backs `CUI_CCEnvelopeEditor`. |
 | `src/winmm_compat.h` | Cross-platform MIDI shim. `zt_midi_out_sysex` for SysEx send (CoreMIDI `MIDIPacketListAdd` / WinMM `midiOutLongMsg` / ALSA `snd_seq_ev_set_sysex`). macOS `zt_coremidi_read_proc` parses incoming `F0..F7` into `zt_sysex_inq_push`. |
 | `src/sysex_inq.{h,cpp}` | Process-wide receive queue for incoming SysEx (16 slots × 8 KB; `std::mutex` protected; overflow drops oldest). |
 | `src/sysex_macro.{h,cpp}` | Helpers for the `*.syx`-named-midimacro convention: predicate + `syx_folder` path resolution + framing-checked file reader. |
 | `src/ccizer.{h,cpp}` | CCizer parser, `.cc-view` slider/knob sidecar, `.cc-midi` MIDI Learn sidecar, folder scan, MIDI byte builder, `zt_ccizer_current_file()` (Pattern Editor reads it for friendly slot names in CC drawmode status). |
-| `src/conf.{h,cpp}` | zt.conf — adds `ccizer_folder` + `syx_folder` keys. |
+| `src/conf.{h,cpp}` | zt.conf — adds `ccizer_folder` + `syx_folder` keys, and `sync_offset_ms` (0–500, play early under external sync to beat a DAW's monitoring latency; `ableton_link_offset_ms` is a legacy alias). |
 | `src/preset_data.h` | F4/Shift+F4 preset arrays + pure `*_apply_preset_to(struct*, idx)` apply functions. Header-only, SDL-free, exhaustively unit-tested. |
 | `src/preset_selector.h` | Pure decision logic for the preset listbox (click / arrow / Space / P-cycle). Unit-tested. |
 | `src/page_sync.h` | F4/Shift+F4 widget↔data sync helpers. Prevents the "preset reverts on next frame" class of bug. |
@@ -146,7 +149,7 @@ The ESC menu has a "Copy Relaunch Command" entry that captures current state (op
 Sub-modes worth knowing:
 - **F2 again** from the Pattern Editor → PEParms. **F2 F2 toggles "PianoKey"**, the Ableton/Logic piano keyjazz layout (PR #135).
 - **F3 again** from the Instrument Editor → "Create 16 Channels" popup: fills the next empty instrument slots with the current device on ch 1..16 (PR #136). F3 row 11 shows `CCizer Bank: <basename>`.
-- **F11** Song Config hosts the **Ableton Link** controls (enable / start-stop-sync checkboxes, quantize-offset slider).
+- **F11** Song Config hosts the **Ableton Link** controls (enable / start-stop-sync checkboxes, quantize-offset slider), the **Sync Offset ms** slider, and the **MIDI clock lock meter** on the "MIDI In Sync" row (lock state + estimated master BPM + signed offset).
 - **CC drawmode** is extended by PRs #123–#129: mouse drag-to-draw drawbars, CCizer-slot cycling, one-key arm-and-draw, double-click reset, `Ctrl+F2` slot cycle, keyjazz audition while drawing. `[CC DRAW]` badge top-right while active.
 
 ---
@@ -194,6 +197,20 @@ Tempo + transport sync with Ableton Live and other Link-aware apps over the loca
 
 ---
 
+## MIDI clock sync & phase-lock
+
+External MIDI-clock slave sync, rebuilt on the shared `phase_chase.h` controller (the same loop Ableton Link uses), so a fractional-tempo master cannot drift the engine. Enabled by `midi_in_sync` (follow start/stop) + `midi_in_sync_chase_tempo` (derive tempo and phase-lock); the `--midi-clock <name|index>` CLI flag opens a port and turns both on.
+
+- **Observer architecture** (`src/midi_clock_sync.{cpp,h}`). The MIDI-in callback thread only **records** what arrived into `std::atomic` counters (`g_mclk_clocks`, `g_mclk_last_clock_ms`, `g_mclk_start_req` / `_continue_req` / `_stop_req`, `g_mclk_spp_raw` / `_seq`) — same advisory contract as `player::stop_count`. Every decision (consume transport requests, estimate master tempo, phase-lock) happens in `zt_midi_clock_pump()` on the **main thread**, once per frame, next to `zt_ableton_link_pump()`. Atomics make the cross-thread reads ThreadSanitizer-clean (a TSan CI job guards this); the pump relies only on per-counter atomicity, tolerating a bump seen a frame late.
+- **Position, not just rate.** 24 clocks/beat = 4 subticks/clock, so counting clocks since the consumed START gives an exact "expected position" (the MIDI-clock analogue of Link's `beatAtTime`). `phase_chase_step()` returns a bounded skew applied to `player::chase_skew_us`: inaudible inside `PHASE_CHASE_DEADBAND_US`, slewing hard on a deliberate move (offset slider / tempo step).
+- **Hardware timestamps** (`src/midi_timestamp.h`, macOS). The clock-arrival time comes from the CoreMIDI packet stamp (`mach_absolute_time`) converted into the `SDL_GetTicks()` ms epoch, not from sampling a software clock inside the callback — removing OS-scheduling jitter from the lock. **Sanity-gated**: a wild/garbage stamp falls back to the software clock instead of poisoning the phase lock.
+- **Hardening.** Warm re-lock + snap-on-discontinuity so a brief clock dropout or a transport jump recovers cleanly rather than chasing forever.
+- **Observability.** Six-state lock model (`zt_sync_state`: off / waiting / dropout / transport / chasing / locked) surfaced by `zt_midi_clock_get_status()` → the **F11 lock meter** (state + master BPM + signed offset) and the Lua `zt.transport.sync_state` / `sync_bpm` / `sync_offset_ms` read-only fields + the `sync` notifier event. Plays early by `sync_offset_ms`, identically to Link.
+
+> **Status:** this subsystem ships with the `esa/midi-clock-phase-lock` branch (commits `4199985`, `436e479`, `e549eb3`, `01e54ff`, `d18ef2a`, `9e9847a`); it is documented here ahead of that merge. The three test suites below land with it.
+
+---
+
 ## Test harness
 
 `tests/` builds a growing set of CTest suites. **`ctest --test-dir build -N` is the source of truth for the current list** (the count drifts as suites are added). As of the last sync there are 14:
@@ -212,6 +229,12 @@ Tempo + transport sync with Ableton Live and other Link-aware apps over the loca
 - `keyjazz_map` — Ableton/Logic PianoKey layout + the two layouts' mutual exclusivity.
 - `ableton_link` — Ableton Link config + precedence (`ZT_TEST_NO_SDL`).
 - `lua_api` — full Lua API self-test: drives the real `zt` binary headless (`--headless --lua-test`) against a scratch song, runs `lua/selftest.lua`, asserts exit 0.
+
+Three more land with the **MIDI clock sync & phase-lock** feature (`esa/midi-clock-phase-lock`), bringing the total to 17:
+
+- `phase_chase` — the shared closed-loop controller: deadband tiers, feedback clamps, rate-error cancellation, skew ceiling.
+- `midi_timestamp` — `mach_absolute_time` → `SDL_GetTicks()` ms conversion + the sanity gate (future-dated packet, missing timebase, garbage stamp all fall back safely).
+- `midi_clock_sync` — closed-loop lock-quality simulation: feeds synthetic clock streams and asserts the engine locks within the deadband.
 
 Run all: `ctest --test-dir build --output-on-failure`. Linux CI runs the SDL-free suites after every push; the `lua_api` self-test runs on macOS CI.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,11 +203,12 @@ External MIDI-clock slave sync, rebuilt on the shared `phase_chase.h` controller
 
 - **Observer architecture** (`src/midi_clock_sync.{cpp,h}`). The MIDI-in callback thread only **records** what arrived into `std::atomic` counters (`g_mclk_clocks`, `g_mclk_last_clock_ms`, `g_mclk_start_req` / `_continue_req` / `_stop_req`, `g_mclk_spp_raw` / `_seq`) — same advisory contract as `player::stop_count`. Every decision (consume transport requests, estimate master tempo, phase-lock) happens in `zt_midi_clock_pump()` on the **main thread**, once per frame, next to `zt_ableton_link_pump()`. Atomics make the cross-thread reads ThreadSanitizer-clean (a TSan CI job guards this); the pump relies only on per-counter atomicity, tolerating a bump seen a frame late.
 - **Position, not just rate.** 24 clocks/beat = 4 subticks/clock, so counting clocks since the consumed START gives an exact "expected position" (the MIDI-clock analogue of Link's `beatAtTime`). `phase_chase_step()` returns a bounded skew applied to `player::chase_skew_us`: inaudible inside `PHASE_CHASE_DEADBAND_US`, slewing hard on a deliberate move (offset slider / tempo step).
+- **Tempo estimate.** A least-squares regression over a ~1 s sliding window of clock-*arrival* samples (Chris Micali's estimator, merged in #169) — a single jitter-delayed edge carries only 1/n of the weight rather than swinging the estimate. Retune anti-flap hysteresis (>0.6 BPM held, >3.0 BPM immediate) keeps the engine nominal steady when the master sits on a rounding boundary like 124.5.
 - **Hardware timestamps** (`src/midi_timestamp.h`, macOS). The clock-arrival time comes from the CoreMIDI packet stamp (`mach_absolute_time`) converted into the `SDL_GetTicks()` ms epoch, not from sampling a software clock inside the callback — removing OS-scheduling jitter from the lock. **Sanity-gated**: a wild/garbage stamp falls back to the software clock instead of poisoning the phase lock.
 - **Hardening.** Warm re-lock + snap-on-discontinuity so a brief clock dropout or a transport jump recovers cleanly rather than chasing forever.
 - **Observability.** Six-state lock model (`zt_sync_state`: off / waiting / dropout / transport / chasing / locked) surfaced by `zt_midi_clock_get_status()` → the **F11 lock meter** (state + master BPM + signed offset) and the Lua `zt.transport.sync_state` / `sync_bpm` / `sync_offset_ms` read-only fields + the `sync` notifier event. Plays early by `sync_offset_ms`, identically to Link.
 
-> **Status:** this subsystem ships with the `esa/midi-clock-phase-lock` branch (commits `4199985`, `436e479`, `e549eb3`, `01e54ff`, `d18ef2a`, `9e9847a`); it is documented here ahead of that merge. The three test suites below land with it.
+> **Status:** this subsystem ships via the integration PR **#169**, which merges this hardening/observability work with Chris Micali's independent phase-chase rewrite (`cmicali/midi-sync-improvements`) — both converged on a byte-identical `phase_chase.h`. #169 adopts Chris's least-squares tempo estimator + retune hysteresis as the base and keeps the atomics / warm re-lock / snap / hardware timestamps / lock observability above. Documented here ahead of that merge; the four test suites below land with it.
 
 ---
 
@@ -230,11 +231,12 @@ External MIDI-clock slave sync, rebuilt on the shared `phase_chase.h` controller
 - `ableton_link` — Ableton Link config + precedence (`ZT_TEST_NO_SDL`).
 - `lua_api` — full Lua API self-test: drives the real `zt` binary headless (`--headless --lua-test`) against a scratch song, runs `lua/selftest.lua`, asserts exit 0.
 
-Three more land with the **MIDI clock sync & phase-lock** feature (`esa/midi-clock-phase-lock`), bringing the total to 17:
+Four more land with the **MIDI clock sync & phase-lock** feature (integration PR #169), bringing the total to 18:
 
 - `phase_chase` — the shared closed-loop controller: deadband tiers, feedback clamps, rate-error cancellation, skew ceiling.
 - `midi_timestamp` — `mach_absolute_time` → `SDL_GetTicks()` ms conversion + the sanity gate (future-dated packet, missing timebase, garbage stamp all fall back safely).
 - `midi_clock_sync` — closed-loop lock-quality simulation: feeds synthetic clock streams and asserts the engine locks within the deadband.
+- `midi_clock_estimator` — Chris Micali's estimator/hysteresis/dropout unit suite (least-squares convergence, rounding-boundary anti-flap, warm re-lock).
 
 Run all: `ctest --test-dir build --output-on-failure`. Linux CI runs the SDL-free suites after every push; the `lua_api` self-test runs on macOS CI.
 


### PR DESCRIPTION
## Summary

Documents the **MIDI clock sync & phase-lock** subsystem in both `CLAUDE.md` and the `ztrackerprime` skill. Docs-only.

The subsystem itself lives on `esa/midi-clock-phase-lock` (commits `4199985`, `436e479`, `e549eb3`, `01e54ff`, `d18ef2a`, `9e9847a`). This PR documents it **ahead of that merge**, on a separate docs branch, so the docs and the implementation can land independently. The merged-suite count stays honest (14) and the 3 clock suites are listed as pending (→ 17).

## What's documented

- **`phase_chase.h`** — the shared closed-loop position controller used by **both** Ableton Link and MIDI clock sync. Returns a bounded skew that cancels rate error (int-BPM rounding, crystal drift); deadband-tiered feedback (inaudible inside the deadband, hard slew on a deliberate move).
- **`midi_clock_sync.{cpp,h}`** — observer architecture: the MIDI-in thread only records into `std::atomic` `g_mclk_*` counters; all decisions run in `zt_midi_clock_pump()` on the main thread once/frame (ThreadSanitizer-clean, TSan CI). 24 clocks/beat = a position reference, not just a rate. Six-state lock model (`zt_sync_state`: off/waiting/dropout/transport/chasing/locked).
- **`midi_timestamp.h`** — sanity-gated macOS hardware timestamps (`mach_absolute_time` → `SDL_GetTicks()` epoch); a garbage stamp falls back to the software clock instead of poisoning the phase lock.
- **Observability** — F11 lock meter (state + master BPM + signed offset), Lua `zt.transport.sync_state` / `sync_bpm` / `sync_offset_ms` + the `sync` notifier, `sync_offset_ms` conf key.
- Key-files table, F11 sub-mode note, and test-harness list updated in both files.

## Test plan

- [x] Docs-only — no source, build, or test impact.
- [x] Every documented symbol/file cross-checked against the source on `esa/midi-clock-phase-lock` (`phase_chase.h`, `midi_clock_sync.h`, `midi_timestamp.h`, `lua_engine.cpp`, `CUI_Songconfig.cpp`, `conf.{h,cpp}`).
- [x] Merged-suite count left at 14; the 3 clock suites are marked as landing with the feature.

## Note on merge order

This PR only touches `CLAUDE.md` + `SKILL.md`; the phase-lock code PR touches only `src/` + `tests/`. No file overlap, so no conflict regardless of which merges first — once the code lands, these docs simply become live.
