### PR TITLE
build: clean up external dependency fetch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,11 +84,11 @@ jobs:
             libdecor-0-dev libdbus-1-dev libibus-1.0-dev \
             libudev-dev libsndio-dev
 
-      - name: Fetch Ableton Link
+      - name: Fetch External Dependencies
         shell: bash
         run: |
           set -euo pipefail
-          bash .github/scripts/fetch-ableton-link.sh
+          bash fetch-ext-deps.sh
 
       - name: Cache SDL3 source tarball
         id: cache-sdl3-src
@@ -199,7 +199,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          bash .github/scripts/fetch-ableton-link.sh
+          bash fetch-ext-deps.sh
 
       - name: Configure
         run: |
@@ -282,11 +282,11 @@ jobs:
           brew update
           brew install cmake ninja pkg-config sdl3
 
-      - name: Fetch Ableton Link
+      - name: Fetch External Dependencies
         shell: bash
         run: |
           set -euo pipefail
-          bash .github/scripts/fetch-ableton-link.sh
+          bash fetch-ext-deps.sh
 
       - name: Configure
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,65 @@
+# MacOS
 .DS_Store
+
+# JetBrains
+.idea/*
+cmake-build-*/
+
+# CMake
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+CMakeUserPresets.json
+
+# Build directories
 /build/
 /build-mac/
 /build-linux/
 /build-win32/
 /build-windows/
-__pycache__/
-*.pyc
 /build-win32-macos/
+
+/tests/build/
+
+/Program/
 /sdl3-mingw/
 /toolchain-mingw-i686-macos.cmake
 /dist/ztrackerprime-windows-x86-xp/
-# Ableton Link source tree — fetched on demand by
-# .github/scripts/fetch-ableton-link.sh, never committed (same policy as the
-# libpng/zlib extlibs). Keeps the ~2k-file Link+asio checkout out of git.
-/extlibs/link/
+
+__pycache__/
+*.pyc
+
+# System temporary files
+.DS_Store
+*~
+*.swp
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Clean build directories
+
+build_dir_mac="${BUILD_DIR:-"$script_dir/build-mac"}"
+build_dir_linux="${BUILD_DIR:-"$script_dir/build-linux"}"
+build_dir_win32="${BUILD_DIR:-"$script_dir/build-win32"}"
+build_dir_windows="${BUILD_DIR:-"$script_dir/build-windows"}"
+build_dir_dist="${BUILD_DIR:-"$script_dir/dist"}"
+
+rm -rf "$build_dir_mac"
+rm -rf "$build_dir_linux"
+rm -rf "$build_dir_win32"
+rm -rf "$build_dir_windows"
+rm -rf "$build_dir_dist"
+
+# Clean CMake artifacts
+
+cmake_build_dirs="${BUILD_DIR:-"$script_dir/cmake-build"}"
+rm -rf "$cmake_build_dirs-*"
+
+rm -rf "$script_dir/Makefile"
+rm -rf "$script_dir/cmake_install.cmake"
+rm -rf "$script_dir/CTestTestfile.cmake"
+rm -rf "$script_dir/compile_commands.json"

--- a/extlibs/.gitignore
+++ b/extlibs/.gitignore
@@ -1,0 +1,5 @@
+# Large or optional external depdencies
+
+link/
+
+

--- a/extlibs/fetch-ableton-link.sh
+++ b/extlibs/fetch-ableton-link.sh
@@ -17,16 +17,16 @@
 #   LINK_VERSION   default Link-4.0   (a tag in github.com/Ableton/link)
 #
 # Layout produced:
-#   extlibs/link/AbletonLinkConfig.cmake
-#   extlibs/link/include/ableton/Link.hpp
-#   extlibs/link/modules/asio-standalone/asio/include/asio.hpp
+#   link/AbletonLinkConfig.cmake
+#   link/include/ableton/Link.hpp
+#   link/modules/asio-standalone/asio/include/asio.hpp
 
 set -euo pipefail
 
 : "${LINK_VERSION:=Link-4.0}"
 
 root="$(pwd)"
-dest="$root/extlibs/link"
+dest="$root/link"
 repo="https://github.com/Ableton/link.git"
 
 # If a valid tree is already present (developer already fetched, or a cached
@@ -60,9 +60,9 @@ if [ "$ok" -ne 1 ]; then
 fi
 
 required=(
-  extlibs/link/AbletonLinkConfig.cmake
-  extlibs/link/include/ableton/Link.hpp
-  extlibs/link/modules/asio-standalone/asio/include/asio.hpp
+  link/AbletonLinkConfig.cmake
+  link/include/ableton/Link.hpp
+  link/modules/asio-standalone/asio/include/asio.hpp
 )
 missing=0
 for f in "${required[@]}"; do

--- a/fetch-ext-deps.sh
+++ b/fetch-ext-deps.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# fetch any additional large or optional dependencies, like ableton link
+
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")" && pwd)"
+extlibs="$root/extlibs"
+
+scripts=(
+  fetch-ableton-link.sh
+)
+
+for s in "${scripts[@]}"; do
+  echo "=== Running $s ==="
+  (cd "$extlibs" && "./$s")
+done
+exit


### PR DESCRIPTION
This PR does 2 things:

1. Cleans up the ableton-link dependency fetch (moves script from .github/ to extlibs/ and adds a helper script)
2. Adds a clean.sh and updated .gitignore 
