### PR TITLE
build: external-dependency cleanup (one-up of #168, clean.sh fixes)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,11 +84,11 @@ jobs:
             libdecor-0-dev libdbus-1-dev libibus-1.0-dev \
             libudev-dev libsndio-dev
 
-      - name: Fetch Ableton Link
+      - name: Fetch External Dependencies
         shell: bash
         run: |
           set -euo pipefail
-          bash .github/scripts/fetch-ableton-link.sh
+          bash fetch-ext-deps.sh
 
       - name: Cache SDL3 source tarball
         id: cache-sdl3-src
@@ -215,7 +215,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          bash .github/scripts/fetch-ableton-link.sh
+          bash fetch-ext-deps.sh
 
       - name: Configure
         run: |
@@ -298,11 +298,11 @@ jobs:
           brew update
           brew install cmake ninja pkg-config sdl3
 
-      - name: Fetch Ableton Link
+      - name: Fetch External Dependencies
         shell: bash
         run: |
           set -euo pipefail
-          bash .github/scripts/fetch-ableton-link.sh
+          bash fetch-ext-deps.sh
 
       - name: Configure
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,65 @@
+# MacOS
 .DS_Store
+
+# JetBrains
+.idea/*
+cmake-build-*/
+
+# CMake
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+CMakeUserPresets.json
+
+# Build directories
 /build/
 /build-mac/
 /build-linux/
 /build-win32/
 /build-windows/
-__pycache__/
-*.pyc
 /build-win32-macos/
+
+/tests/build/
+
+/Program/
 /sdl3-mingw/
 /toolchain-mingw-i686-macos.cmake
 /dist/ztrackerprime-windows-x86-xp/
-# Ableton Link source tree — fetched on demand by
-# .github/scripts/fetch-ableton-link.sh, never committed (same policy as the
-# libpng/zlib extlibs). Keeps the ~2k-file Link+asio checkout out of git.
-/extlibs/link/
+
+__pycache__/
+*.pyc
+
+# System temporary files
+.DS_Store
+*~
+*.swp
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/clean.sh
+++ b/clean.sh
@@ -3,24 +3,33 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Clean build directories
+# Clean build directories.
+# build/ is the documented out-of-source tree (CLAUDE.md / the ztrackerprime
+# skill: `cmake -S . -B build`); the build-<os> variants match the per-OS
+# layout the dist scripts use. Tests build under build/, but a stray in-source
+# tests/build/ is swept too.
 
+build_dir_default="${BUILD_DIR:-"$script_dir/build"}"
 build_dir_mac="${BUILD_DIR:-"$script_dir/build-mac"}"
 build_dir_linux="${BUILD_DIR:-"$script_dir/build-linux"}"
 build_dir_win32="${BUILD_DIR:-"$script_dir/build-win32"}"
 build_dir_windows="${BUILD_DIR:-"$script_dir/build-windows"}"
 build_dir_dist="${BUILD_DIR:-"$script_dir/dist"}"
 
+rm -rf "$build_dir_default"
 rm -rf "$build_dir_mac"
 rm -rf "$build_dir_linux"
 rm -rf "$build_dir_win32"
 rm -rf "$build_dir_windows"
 rm -rf "$build_dir_dist"
+rm -rf "$script_dir/tests/build"
 
-# Clean CMake artifacts
+# Clean CMake artifacts.
+# Unquote the wildcard so the glob actually expands (cmake-build-Debug, etc.);
+# "$var-*" would target a literal path ending in "-*".
 
 cmake_build_dirs="${BUILD_DIR:-"$script_dir/cmake-build"}"
-rm -rf "$cmake_build_dirs-*"
+rm -rf "$cmake_build_dirs"-*
 
 rm -rf "$script_dir/Makefile"
 rm -rf "$script_dir/cmake_install.cmake"

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Clean build directories
+
+build_dir_mac="${BUILD_DIR:-"$script_dir/build-mac"}"
+build_dir_linux="${BUILD_DIR:-"$script_dir/build-linux"}"
+build_dir_win32="${BUILD_DIR:-"$script_dir/build-win32"}"
+build_dir_windows="${BUILD_DIR:-"$script_dir/build-windows"}"
+build_dir_dist="${BUILD_DIR:-"$script_dir/dist"}"
+
+rm -rf "$build_dir_mac"
+rm -rf "$build_dir_linux"
+rm -rf "$build_dir_win32"
+rm -rf "$build_dir_windows"
+rm -rf "$build_dir_dist"
+
+# Clean CMake artifacts
+
+cmake_build_dirs="${BUILD_DIR:-"$script_dir/cmake-build"}"
+rm -rf "$cmake_build_dirs-*"
+
+rm -rf "$script_dir/Makefile"
+rm -rf "$script_dir/cmake_install.cmake"
+rm -rf "$script_dir/CTestTestfile.cmake"
+rm -rf "$script_dir/compile_commands.json"

--- a/extlibs/.gitignore
+++ b/extlibs/.gitignore
@@ -1,0 +1,5 @@
+# Large or optional external depdencies
+
+link/
+
+

--- a/extlibs/fetch-ableton-link.sh
+++ b/extlibs/fetch-ableton-link.sh
@@ -17,16 +17,16 @@
 #   LINK_VERSION   default Link-4.0   (a tag in github.com/Ableton/link)
 #
 # Layout produced:
-#   extlibs/link/AbletonLinkConfig.cmake
-#   extlibs/link/include/ableton/Link.hpp
-#   extlibs/link/modules/asio-standalone/asio/include/asio.hpp
+#   link/AbletonLinkConfig.cmake
+#   link/include/ableton/Link.hpp
+#   link/modules/asio-standalone/asio/include/asio.hpp
 
 set -euo pipefail
 
 : "${LINK_VERSION:=Link-4.0}"
 
 root="$(pwd)"
-dest="$root/extlibs/link"
+dest="$root/link"
 repo="https://github.com/Ableton/link.git"
 
 # If a valid tree is already present (developer already fetched, or a cached
@@ -60,9 +60,9 @@ if [ "$ok" -ne 1 ]; then
 fi
 
 required=(
-  extlibs/link/AbletonLinkConfig.cmake
-  extlibs/link/include/ableton/Link.hpp
-  extlibs/link/modules/asio-standalone/asio/include/asio.hpp
+  link/AbletonLinkConfig.cmake
+  link/include/ableton/Link.hpp
+  link/modules/asio-standalone/asio/include/asio.hpp
 )
 missing=0
 for f in "${required[@]}"; do

--- a/fetch-ext-deps.sh
+++ b/fetch-ext-deps.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# fetch any additional large or optional dependencies, like ableton link
+
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")" && pwd)"
+extlibs="$root/extlibs"
+
+scripts=(
+  fetch-ableton-link.sh
+)
+
+for s in "${scripts[@]}"; do
+  echo "=== Running $s ==="
+  (cd "$extlibs" && "./$s")
+done
+exit


### PR DESCRIPTION
## Summary

A one-up of #168 (@cmicali's build-dependency cleanup) — same work, **rebased onto current `master`**, plus the `clean.sh` review fixes applied so it's ready to merge as-is. @cmicali — flagging for your review since the base commit is yours; this just lands your cleanup with the feedback addressed.

Supersedes **#168** (which is now behind master and has the issues below open in review).

## What's in here

**From @cmicali (`cmicali/build-deps-cleanup`, unchanged):**
- Consolidate external-dep fetching: move `fetch-ableton-link.sh` into `extlibs/`, add a top-level `fetch-ext-deps.sh` dispatcher, point CI at it.
- Add `clean.sh` + `extlibs/.gitignore`, expand the root `.gitignore`.

**Fixes on top (this PR's one extra commit):**
- **`clean.sh` now cleans `build/`.** The original swept `build-mac`/`build-linux`/`build-win32`/`build-windows`/`dist` but **not** `build/` — the out-of-source tree `CLAUDE.md` and the `ztrackerprime` skill tell contributors to use (`cmake -S . -B build`). So `./clean.sh` was a no-op on the dir people actually have. Added `build/` (and a stray in-source `tests/build/`).
- **Fixed the `cmake-build-*` glob.** `rm -rf "$cmake_build_dirs-*"` had the wildcard inside the quotes → it targeted a literal `…/cmake-build-*` path and matched nothing. Unquoted the glob so it sweeps `cmake-build-Debug` etc.

## Considered, left as-is
The broad root `*.a` / `*.o` / `*.lib` / `*.so` ignores: fine today — the in-tree libpng/zlib (from #162) are committed as **source**, not artifacts, so nothing tracked is affected. Flagging only so a future re-vendor that drops a prebuilt `.a`/`.o` into `extlibs/` doesn't get silently ignored. No change made.

## Test plan
- [x] All three shell scripts pass `bash -n`.
- [x] Rebased clean onto current `master` (0 behind).
- [x] Build/gitignore/CI-script only — no source changes; CI exercises `fetch-ext-deps.sh` on all platforms.
