### PR TITLE
feat: fun-sounds easter egg (Ctrl+Alt+F)

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,22 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_06_16 (Fun sounds easter egg: Ctrl+Alt+F)
+----------------------------------------------------------------------------
+
+        + Ctrl+Alt+F wakes zTracker's normally-dormant SDL3 audio path and
+          toggles the bundled TestTone generator -- a deliberately warbly
+          square-ish tone (the 8-bit-into-S16 aliasing the enable-audio spike
+          turned up). Press again to stop. Lazy + non-fatal: a normal
+          MIDI-only session never opens an output device unless you press it,
+          and a machine with no audio device just stays silent (no crash).
+
+        * Audio plugins are now registered AFTER the MIDI devices in
+          InitializePlugins (they used to sit at indices 0,1 ahead of MIDI).
+          With _ENABLE_AUDIO on, that previously shifted every MIDI device
+          index and broke device selection; appending audio keeps MIDI indices
+          stable. (Fixes the gotcha the spike documented.)
+
 zt 2026_06_16 (MIDI clock sync: merge of the two independent phase-chase rewrites)
 ----------------------------------------------------------------------------
 

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -246,6 +246,14 @@
  Zxxyy : Send midimacro xx with parameter yy.  00 repeats the last used
          value
 
+|L|%==|H|Easter Eggs|L|==%|U|
+
+ CTRL-ALT-F : Fun sounds. Wakes zTracker's normally-dormant SDL3 audio
+              path on first press and toggles the "TestTone" generator --
+              a deliberately warbly square-ish tone (8-bit aliased into the
+              16-bit output). Press again to stop. A normal MIDI-only
+              session never opens an audio device unless you press this.
+
 |L|%==|H|Command-Line Arguments|L|==%|U|
 
  zt [options] [song.zt]

--- a/src/OutputDevices.cpp
+++ b/src/OutputDevices.cpp
@@ -14,12 +14,11 @@ void AddPlugin(midiOut *mout, OutputDevice *o)
 
 void InitializePlugins(midiOut *mout)
 {
-    
-#ifdef _ENABLE_AUDIO    
-    AddPlugin(mout, new NoiseOutputDevice());
-    AddPlugin(mout, new TestToneOutputDevice());
-#endif
-    
+    // MIDI devices first, so their indices match midiOutGetNumDevs() order --
+    // the device picker and saved selections index by position. Audio plugins
+    // are appended AFTER, so enabling _ENABLE_AUDIO never shifts a MIDI device
+    // index (the selection-breaking bug the enable-audio spike found when the
+    // audio plugins sat at indices 0,1 ahead of MIDI).
     unsigned int i = mout->numOuputDevices;
     unsigned int devs = midiOutGetNumDevs();
     unsigned int total = i+devs;
@@ -27,6 +26,11 @@ void InitializePlugins(midiOut *mout)
     for (;i<total;i++) {
         mout->outputDevices[i] = new MidiOutputDevice(i);
     }
+
+#ifdef _ENABLE_AUDIO
+    AddPlugin(mout, new NoiseOutputDevice());
+    AddPlugin(mout, new TestToneOutputDevice());
+#endif
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -363,6 +363,9 @@ CUI_SongMessage *UIP_SongMessage = NULL;
 CUI_Arpeggioeditor *UIP_Arpeggioeditor = NULL;
 CUI_Midimacroeditor *UIP_Midimacroeditor = NULL;
 CUI_LuaConsole *UIP_LuaConsole = NULL;
+#ifdef _ENABLE_AUDIO
+static void zt_fun_sounds_toggle(void);   // fun-sounds easter egg; defined with the audio backend
+#endif
 CUI_KeyBindings *UIP_KeyBindings = NULL;
 CUI_CcConsole *UIP_CcConsole = NULL;
 CUI_SysExLibrarian *UIP_SysExLibrarian = NULL;
@@ -1736,6 +1739,16 @@ void global_keys(Drawable *S)
                     command = CMD_SWITCH_KEYBINDINGS;
                     key = Keys.getkey();
                 }
+                break;
+
+            case SDLK_F: // Fun sounds easter egg (Ctrl+Alt+F)
+#ifdef _ENABLE_AUDIO
+                if ((kstate & KS_CTRL) && (kstate & KS_ALT)) {
+                    zt_fun_sounds_toggle();
+                    key = Keys.getkey();
+                    need_refresh++;
+                }
+#endif
                 break;
 
 #ifndef DISABLE_UNFINISHED_F10_SONG_MESSAGE_EDITOR
@@ -3858,6 +3871,37 @@ static void zt_backend_audio_stop(void)
     g_audio_stream = NULL;
   }
 }
+
+// --- Fun sounds easter egg (Ctrl+Alt+F) ------------------------------------
+// Wakes the dormant SDL3 audio path on first use and toggles the TestTone
+// generator -- the deliberately aliased 8-bit-into-S16 "warble" the
+// enable-audio spike turned up. Lazy + non-fatal: a normal MIDI-only session
+// never opens an output device unless you ask for fun.
+static bool g_fun_audio_up = false;
+static bool g_fun_playing  = false;
+static int  g_fun_dev      = -1;
+
+static void zt_fun_sounds_toggle(void)
+{
+  if (!g_fun_audio_up) {
+    if (!zt_backend_audio_start())
+      return;                         // no output device -> stay silent, never crash
+    g_fun_audio_up = true;
+    for (unsigned int d = 0; d < MidiOut->numOuputDevices; d++) {
+      if (MidiOut->outputDevices[d]->type == OUTPUTDEVICE_TYPE_AUDIO &&
+          strstr(MidiOut->outputDevices[d]->szName, "TestTone")) {
+        g_fun_dev = (int)d;
+        break;
+      }
+    }
+    if (g_fun_dev >= 0)
+      MidiOut->AddDevice(g_fun_dev);  // open() + enlist into the live mix
+  }
+  if (g_fun_dev < 0) return;
+  g_fun_playing = !g_fun_playing;
+  if (g_fun_playing) MidiOut->outputDevices[g_fun_dev]->noteOn(60, 0, 127);
+  else               MidiOut->outputDevices[g_fun_dev]->noteOff(60, 0, 0);
+}
 #endif
 
 static void zt_backend_release_frame_resources(void)
@@ -4279,9 +4323,9 @@ int main(int argc, char *argv[])
     }
 
 #ifdef _ENABLE_AUDIO
-    if (!zt_backend_audio_start()) {
-      return(-1);
-    }
+    // Audio stays dormant at boot: the fun-sounds easter egg (Ctrl+Alt+F)
+    // calls zt_backend_audio_start() lazily on first press, so a normal
+    // MIDI-only session never opens an output device.
 #endif
 
     while (1) {

--- a/src/zt.h
+++ b/src/zt.h
@@ -119,7 +119,7 @@ static inline void zt_text_input_stop(void) {
 #endif
 #define ZTRACKER_VERSION                "zTracker' v" ZT_BUILD_DATE
 
-//#define _ENABLE_AUDIO                 1  // this enables audio init and audio plugins
+#define _ENABLE_AUDIO                 1  // audio path: dormant by default (no device opened at boot); woken lazily by the Ctrl+Alt+F fun-sounds easter egg
 
 #define ZOOM                            (zt_config_globals.zoom)
 


### PR DESCRIPTION
## Summary

A standalone easter egg: **Ctrl+Alt+F** plays the "fun sounds" — the deliberately warbly tone from the `enable-audio` spike. zTracker has a complete-but-dormant SDL3 audio path behind `_ENABLE_AUDIO`; the spike proved it works and turned up a `TestTone` generator that writes 8-bit values into the S16 stereo buffer, producing an aliased **warble**. This wires that up to a button.

## What it does
- **Ctrl+Alt+F** toggles the warble on/off.
- **Lazy + non-fatal:** the audio device is opened only on the *first* press, so a normal MIDI-only session never grabs an output device. A machine with no audio device just stays silent — no crash.

## Changes
- `src/zt.h` — enable `_ENABLE_AUDIO` (compiles in the dormant `TestTone`/`Noise`/`audio_mixer` path).
- `src/main.cpp` — removed the old **eager, fatal** `zt_backend_audio_start()` at init (it `exit(-1)`'d the whole app if audio failed to open). Added `zt_fun_sounds_toggle()`: lazy audio start → find the `TestTone` device → `AddDevice` (open + enlist) → toggle `noteOn`/`noteOff`. Bound to `Ctrl+Alt+F` next to the existing Ctrl+Alt+L/K chords.
- `src/OutputDevices.cpp` — **the gotcha fix.** `InitializePlugins` used to register the audio plugins at indices 0,1 *ahead* of MIDI devices, so turning on `_ENABLE_AUDIO` shifted every MIDI device index and broke device selection. Now MIDI is registered first and audio plugins are appended, keeping MIDI indices stable.
- `doc/help.txt`, `doc/CHANGELOG.txt` — documented.

## Test plan
- [x] Full `zt` binary builds with `_ENABLE_AUDIO` on.
- [x] Headless boot renders the Pattern Editor cleanly with audio compiled in (dummy audio driver) — confirms the `InitializePlugins` reorder didn't break startup/MIDI enumeration.
- [x] `ctest` — 19/19 pass.
- [ ] **Press Ctrl+Alt+F and confirm the warble is suitably fun** — needs human ears (audio output can't be self-verified headlessly).

## Notes for the maintainer
This flips `_ENABLE_AUDIO` on, but deliberately keeps zTracker MIDI-only *in practice*: no audio device is opened unless the user presses the button. If you'd rather the flag stay off entirely, this can be reworked to gate the easter egg behind its own flag — happy to adjust. Provenance: the design doc + spike findings are in #140 (`doc/sample-playback-design.md`).
