### PR TITLE
perf: Implement thread priorities and disable AppNap on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,7 @@ endif()
 # when the binary was actually built, instead of a stale hardcoded value.
 string(TIMESTAMP ZT_BUILD_DATE "%Y_%m_%d" UTC)
 target_compile_definitions(zt PRIVATE ZT_BUILD_DATE="${ZT_BUILD_DATE}")
+
 find_package(PkgConfig QUIET)
 if(PkgConfig_FOUND)
   pkg_check_modules(SDL3PC QUIET IMPORTED_TARGET sdl3)
@@ -384,18 +385,20 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 endif()
 
 if(APPLE)
+  string(TIMESTAMP ZT_BUILD_VERSION "%Y.%m.%d" UTC)
   target_link_libraries(zt PRIVATE "-framework CoreMIDI" "-framework CoreFoundation" "-framework Cocoa")
   # Turn the macOS build into a proper .app bundle with icon + Info.plist.
   set_target_properties(zt PROPERTIES
     MACOSX_BUNDLE TRUE
     MACOSX_BUNDLE_BUNDLE_NAME "zTracker"
     MACOSX_BUNDLE_GUI_IDENTIFIER "com.github.m6502.ztrackerprime"
-    MACOSX_BUNDLE_BUNDLE_VERSION "2026.02.23"
-    MACOSX_BUNDLE_SHORT_VERSION_STRING "2026.02.23"
-    MACOSX_BUNDLE_LONG_VERSION_STRING "zTracker 2026.02.23"
+    MACOSX_BUNDLE_BUNDLE_VERSION "${ZT_BUILD_VERSION}"
+    MACOSX_BUNDLE_SHORT_VERSION_STRING "${ZT_BUILD_VERSION}"
+    MACOSX_BUNDLE_LONG_VERSION_STRING "zTracker ${ZT_BUILD_VERSION}"
     MACOSX_BUNDLE_COPYRIGHT "(c) 2000-2026 zTracker contributors"
     MACOSX_BUNDLE_ICON_FILE "zt.icns"
     MACOSX_BUNDLE_INFO_STRING "zTracker - tracker-style music composition"
+    MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/cmake/Info.plist.in"
   )
 endif()
 

--- a/cmake/Info.plist.in
+++ b/cmake/Info.plist.in
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+	<key>CFBundleGetInfoString</key>
+	<string>${MACOSX_BUNDLE_INFO_STRING}</string>
+	<key>CFBundleIconFile</key>
+	<string>${MACOSX_BUNDLE_ICON_FILE}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleLongVersionString</key>
+	<string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
+	<key>CFBundleName</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+	<key>LSAppNapIsDisabled</key>
+	<true/>
+</dict>
+</plist>

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,12 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_06_16 (macOS: real thread priorities for the timing threads)
+----------------------------------------------------------------------------
+
+        * macOS: Implement thread priroities for the timing threads and
+          add a Info.plist that disables App Nap
+
 zt 2026_06_16 (Fun sounds easter egg: Ctrl+Alt+F)
 ----------------------------------------------------------------------------
 

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -152,6 +152,7 @@ void zt_show_error(const char *title, const char *message)
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sched.h>
 #include <atomic>
 #include <unordered_map>
 #include <mutex>
@@ -414,7 +415,7 @@ static int zt_tier_for_qos(qos_class_t q)
         case QOS_CLASS_USER_INITIATED:   return ZT_THREAD_PRIORITY_ABOVE_NORMAL;
         case QOS_CLASS_UTILITY:
         case QOS_CLASS_BACKGROUND:       return ZT_THREAD_PRIORITY_BELOW_NORMAL;
-        default:                         return 0;
+        default:                         return ZT_THREAD_PRIORITY_DEFAULT;
     }
 }
 
@@ -436,11 +437,71 @@ void zt_thread_set_current_priority(int priority)
 
 #else
 
-// Non-Apple POSIX (Linux): elevating to SCHED_FIFO/RR needs privileges we
-// can't assume, so priority requests stay advisory no-ops as before.
-void zt_thread_set_priority(zt_thread_handle, int) {}
-int zt_thread_get_current_priority(void) { return 0; }
-void zt_thread_set_current_priority(int) {}
+// There are no POSIX priority constants like on win/macOS, so we
+// use the standard sched_get_priority_min/sched_get_priority_max
+// to get actual values. They are divided by 5 and 10 to be deliberately
+// modest, well under the kernel's IRQ/watchdog band. Only threads that
+// request RT (the 1 ms timer heartbeat and the buffer-fill counter thread)
+// sleep every iteration, so are serviced first and don't peg a CPU.
+static bool zt_posix_rt_prio_for_tier(int tier, int *out_prio)
+{
+    int lo = sched_get_priority_min(SCHED_FIFO);
+    int hi = sched_get_priority_max(SCHED_FIFO);
+    if (lo < 0 || hi < 0) return false;
+    int span = hi - lo;
+    if (tier >= ZT_THREAD_PRIORITY_TIME_CRITICAL) { *out_prio = lo + span / 5;  return true; }
+    if (tier >= ZT_THREAD_PRIORITY_ABOVE_NORMAL) { *out_prio = lo + span / 10;  return true; }
+    return false;
+}
+
+static void zt_posix_apply_priority(pthread_t t, int tier)
+{
+    struct sched_param sp;
+    int prio;
+    if (zt_posix_rt_prio_for_tier(tier, &prio)) {
+        sp.sched_priority = prio;
+        int rc = pthread_setschedparam(t, SCHED_FIFO, &sp);
+        if (rc != 0) {
+            static std::atomic<bool> warned{false};
+            if (!warned.exchange(true)) {
+                fprintf(stderr,
+                    "zt: real-time thread priority denied (%s); using normal scheduling "
+                    "(grant RT via rtprio in limits.conf or CAP_SYS_NICE for tighter timing)\n",
+                    strerror(rc));
+            }
+        }
+    } else {
+        // NORMAL/BELOW_NORMAL, or restoring a saved priority: return to the
+        // default time-sharing scheduler (also clears any earlier RT boost).
+        sp.sched_priority = 0;
+        pthread_setschedparam(t, SCHED_OTHER, &sp);
+    }
+}
+
+void zt_thread_set_priority(zt_thread_handle thread, int priority)
+{
+    zt_posix_thread *t = (zt_posix_thread *)thread;
+    if (t) zt_posix_apply_priority(t->thread, priority);
+}
+
+void zt_thread_set_current_priority(int priority)
+{
+    zt_posix_apply_priority(pthread_self(), priority);
+}
+
+int zt_thread_get_current_priority(void)
+{
+    int policy;
+    struct sched_param sp;
+    if (pthread_getschedparam(pthread_self(), &policy, &sp) != 0) return 0;
+    if (policy == SCHED_FIFO) {
+        int lo = sched_get_priority_min(SCHED_FIFO);
+        int hi = sched_get_priority_max(SCHED_FIFO);
+        if (lo >= 0 && hi >= 0 && sp.sched_priority >= lo + (hi - lo) / 5)
+            return ZT_THREAD_PRIORITY_TIME_CRITICAL;
+    }
+    return ZT_THREAD_PRIORITY_DEFAULT;
+}
 
 #endif
 

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -155,6 +155,9 @@ void zt_show_error(const char *title, const char *message)
 #include <atomic>
 #include <unordered_map>
 #include <mutex>
+#if defined(__APPLE__)
+#include <pthread/qos.h>
+#endif
 
 struct zt_posix_thread {
     pthread_t thread;
@@ -205,6 +208,8 @@ static void zt_timespec_add_ns(struct timespec *ts, long ns)
 
 static void *zt_posix_timer_main(void *arg)
 {
+    zt_thread_set_current_priority(ZT_THREAD_PRIORITY_TIME_CRITICAL);
+
     zt_posix_timer *timer = (zt_posix_timer *)arg;
     const long interval_ns = (long)timer->interval_ms * 1000000L;
     struct timespec next_deadline;
@@ -392,9 +397,52 @@ void zt_thread_close(zt_thread_handle thread)
     free(t);
 }
 
+#if defined(__APPLE__)
+
+static qos_class_t zt_qos_for_tier(int tier)
+{
+    if (tier >= ZT_THREAD_PRIORITY_TIME_CRITICAL) return QOS_CLASS_USER_INTERACTIVE;
+    if (tier >= ZT_THREAD_PRIORITY_ABOVE_NORMAL)  return QOS_CLASS_USER_INITIATED;
+    if (tier <= ZT_THREAD_PRIORITY_BELOW_NORMAL)  return QOS_CLASS_UTILITY;
+    return QOS_CLASS_DEFAULT;
+}
+
+static int zt_tier_for_qos(qos_class_t q)
+{
+    switch (q) {
+        case QOS_CLASS_USER_INTERACTIVE: return ZT_THREAD_PRIORITY_TIME_CRITICAL;
+        case QOS_CLASS_USER_INITIATED:   return ZT_THREAD_PRIORITY_ABOVE_NORMAL;
+        case QOS_CLASS_UTILITY:
+        case QOS_CLASS_BACKGROUND:       return ZT_THREAD_PRIORITY_BELOW_NORMAL;
+        default:                         return 0;
+    }
+}
+
+// QoS on macOS is self-only -- there is no supported way to set another
+// pthread's QoS class. The sole cross-thread caller is the save/load helper
+// elevation (CUI_SaveMsg/LoadMsg), which only affects save responsiveness,
+// not playback timing, so a best-effort no-op here is acceptable.
+void zt_thread_set_priority(zt_thread_handle, int) {}
+
+int zt_thread_get_current_priority(void)
+{
+    return zt_tier_for_qos(qos_class_self());
+}
+
+void zt_thread_set_current_priority(int priority)
+{
+    pthread_set_qos_class_self_np(zt_qos_for_tier(priority), 0);
+}
+
+#else
+
+// Non-Apple POSIX (Linux): elevating to SCHED_FIFO/RR needs privileges we
+// can't assume, so priority requests stay advisory no-ops as before.
 void zt_thread_set_priority(zt_thread_handle, int) {}
 int zt_thread_get_current_priority(void) { return 0; }
 void zt_thread_set_current_priority(int) {}
+
+#endif
 
 zt_timer_handle zt_timer_start(zt_timer_handle timer_id, unsigned int interval_ms, zt_timer_callback callback)
 {

--- a/src/platform.h
+++ b/src/platform.h
@@ -26,6 +26,7 @@ typedef void (*zt_timer_callback)(void);
 
 enum {
     ZT_THREAD_PRIORITY_BELOW_NORMAL = -1,
+    ZT_THREAD_PRIORITY_DEFAULT = 0,
     ZT_THREAD_PRIORITY_ABOVE_NORMAL = 1,
     ZT_THREAD_PRIORITY_TIME_CRITICAL = 15
 };


### PR DESCRIPTION
* Implement the POSIX thread priority setting on macOS (linux stays NOP)
* Disable AppNap in the Info.plist