### PR TITLE
fix(fun-sounds): ESC-menu entry + fix macOS Ctrl+Alt+F = fullscreen collision

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,21 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_06_17 (Fun sounds: ESC-menu entry + macOS fullscreen-collision fix)
+----------------------------------------------------------------------------
+
+        + ESC menu now has a "Fun Sounds (warble)" entry -- a reliable,
+          clickable way to trigger the easter egg (no shortcut to fumble).
+
+        * Fixed the Ctrl+Alt+F shortcut on macOS. Cmd maps to KS_META|KS_ALT,
+          so the old "Ctrl + Alt" test was also satisfied by Ctrl+Cmd+F --
+          which is macOS's own Enter-Full-Screen accelerator, so the key did
+          nothing but toggle fullscreen. The shortcut now requires Alt WITHOUT
+          Meta: Ctrl+Option+F triggers fun sounds, Ctrl+Cmd+F stays fullscreen.
+
+        + Fun sounds now writes an on-screen status line (ON / OFF / no audio
+          device) so there's visible confirmation it fired.
+
 zt 2026_06_16 (Fun sounds easter egg: Ctrl+Alt+F)
 ----------------------------------------------------------------------------
 

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -19,6 +19,14 @@ zt 2026_06_17 (Fun sounds: ESC-menu entry + macOS fullscreen-collision fix)
         + Fun sounds now writes an on-screen status line (ON / OFF / no audio
           device) so there's visible confirmation it fired.
 
+        * The warble actually warbles now, and actually stops. The mixer
+          callback malloc'd its buffer without zeroing it, so when no generator
+          was writing (i.e. "stopped") SDL played uninitialized garbage -- you
+          could not make it go quiet. It now starts each callback from silence.
+          And TestTone was an 8-bit square written into a 16-bit buffer = a
+          flat ~689 Hz buzz; it is now a proper S16 sine whose pitch is swept
+          180..700 Hz by a ~7 Hz LFO -- an actual "weee-ooo" warble.
+
 zt 2026_06_16 (Fun sounds easter egg: Ctrl+Alt+F)
 ----------------------------------------------------------------------------
 

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -248,11 +248,14 @@
 
 |L|%==|H|Easter Eggs|L|==%|U|
 
- CTRL-ALT-F : Fun sounds. Wakes zTracker's normally-dormant SDL3 audio
-              path on first press and toggles the "TestTone" generator --
-              a deliberately warbly square-ish tone (8-bit aliased into the
-              16-bit output). Press again to stop. A normal MIDI-only
-              session never opens an audio device unless you press this.
+ Fun Sounds : Wakes zTracker's normally-dormant SDL3 audio path on first
+              use and toggles the "TestTone" generator -- a deliberately
+              warbly square-ish tone (8-bit aliased into the 16-bit output).
+              Trigger it two ways: the ESC menu entry "Fun Sounds (warble)",
+              or the shortcut CTRL-ALT-F. On macOS that is CTRL-OPTION-F --
+              NOT Ctrl-Cmd-F, which is macOS's own Enter-Full-Screen. Do it
+              again to stop. A status line confirms ON/OFF. A normal
+              MIDI-only session never opens an audio device unless you ask.
 
 |L|%==|H|Command-Line Arguments|L|==%|U|
 

--- a/src/CUI_MainMenu.cpp
+++ b/src/CUI_MainMenu.cpp
@@ -176,6 +176,13 @@ static void mm_toggle_cc_drawmode(void) {
     zt_advance_cc_drawmode();
 }
 
+#ifdef _ENABLE_AUDIO
+static void mm_fun_sounds(void) {
+    // Toggles the TestTone warble; writes its own ON/OFF status message.
+    zt_fun_sounds_toggle();
+}
+#endif
+
 // Build a CLI invocation string that re-launches zt with the same
 // state the user has now (open MIDI in ports, MIDI clock chase target,
 // loaded song file) and copy it to the system clipboard. Pairs with
@@ -271,6 +278,9 @@ static const mm_entry MM_ENTRIES[] = {
     {MM_CMD,        "Paketti CCizer",           "Shift+F3",             CMD_SWITCH_CCCONSOLE,       NULL},
     {MM_CMD,        "SysEx Librarian",          "Shift+F5",             CMD_SWITCH_SYSEX_LIB,       NULL},
     {MM_FUNC,       "Cycle CC Drawmode",        "Ctrl+Shift+\xA7",      0,                          mm_toggle_cc_drawmode},
+#ifdef _ENABLE_AUDIO
+    {MM_FUNC,       "Fun Sounds (warble)",      "Ctrl+Alt+F",           0,                          mm_fun_sounds},
+#endif
     {MM_CMD,        "Lua Console",              "Ctrl+Alt+L",           CMD_SWITCH_LUA_CONSOLE,     NULL},
     {MM_FUNC,       "Toggle Fullscreen",        "Alt+Enter",            0,                          mm_toggle_fullscreen},
 

--- a/src/OutputDevices.cpp
+++ b/src/OutputDevices.cpp
@@ -204,17 +204,9 @@ int MidiOutputDevice::sendSysEx(const unsigned char *bytes, int len) {
 
 TestToneOutputDevice::TestToneOutputDevice()
 {
-  int i ;
-
     type = OUTPUTDEVICE_TYPE_AUDIO;
     strcpy(szName, "TestTone Audio Plugin");
     reset();
-    wavec = 0;
-    for(i=0;i<128;i++)
-        wave[i]=0;
-    for(i=128;i<256;i++)
-        wave[i]=0x7F;
-    //smp = NULL;
 }
 
 
@@ -238,6 +230,8 @@ int TestToneOutputDevice::close(void) {
 
 void TestToneOutputDevice::reset(void) {
     makenoise = 0;
+    phase = 0.0;
+    lfo   = 0.0;
     OutputDevice::reset(); // dont forget this
 }
 void TestToneOutputDevice::hardpanic(void) {
@@ -261,13 +255,25 @@ void TestToneOutputDevice::progChange(int program, int bank, unsigned char chan)
 void TestToneOutputDevice::sendCC(unsigned char cc, unsigned char value,unsigned char chan) {
 }
 void TestToneOutputDevice::work( void *udata, Uint8 *stream, int len) {
-    //Mix_PlayChannelTimed()
-    
-        if (makenoise) {
-        for(int i=0;i<len;i++) {
-            stream[i] = wave[wavec&0xFF];
-            wavec++; 
-        }
+    (void)udata;
+    if (!makenoise) return;   // leave the (mixer-zeroed) buffer silent
+
+    // A sine carrier whose pitch is swept up and down by a slow LFO -- the
+    // "weee-ooo" warble. Proper S16 stereo samples (the old version wrote
+    // 8-bit bytes into the 16-bit buffer, which just buzzed at a fixed pitch).
+    const double SR  = 44100.0;
+    const double TAU = 6.283185307179586;
+    Sint16 *out = (Sint16 *)stream;
+    int frames = len / (int)(2 * sizeof(Sint16));   // 2 channels, S16
+    for (int f = 0; f < frames; f++) {
+        lfo += TAU * 7.0 / SR;                       // ~7 Hz wobble
+        if (lfo >= TAU) lfo -= TAU;
+        double freq = 440.0 + 260.0 * sin(lfo);      // sweeps ~180..700 Hz
+        phase += TAU * freq / SR;
+        if (phase >= TAU) phase -= TAU;
+        Sint16 s = (Sint16)(7000.0 * sin(phase));    // ~21% full scale
+        *out++ = s;   // left
+        *out++ = s;   // right
     }
 }
 

--- a/src/OutputDevices.h
+++ b/src/OutputDevices.h
@@ -49,8 +49,8 @@ class MidiOutputDevice : public OutputDevice {
 class TestToneOutputDevice : public AudioOutputDevice {
     public:
         int makenoise;
-        int wavec;
-         unsigned char wave[256];
+        double phase;   // carrier phase accumulator (radians)
+        double lfo;     // wobble-LFO phase accumulator (radians)
          TestToneOutputDevice();
         ~TestToneOutputDevice();
         virtual int open(void);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -363,9 +363,6 @@ CUI_SongMessage *UIP_SongMessage = NULL;
 CUI_Arpeggioeditor *UIP_Arpeggioeditor = NULL;
 CUI_Midimacroeditor *UIP_Midimacroeditor = NULL;
 CUI_LuaConsole *UIP_LuaConsole = NULL;
-#ifdef _ENABLE_AUDIO
-static void zt_fun_sounds_toggle(void);   // fun-sounds easter egg; defined with the audio backend
-#endif
 CUI_KeyBindings *UIP_KeyBindings = NULL;
 CUI_CcConsole *UIP_CcConsole = NULL;
 CUI_SysExLibrarian *UIP_SysExLibrarian = NULL;
@@ -1741,9 +1738,13 @@ void global_keys(Drawable *S)
                 }
                 break;
 
-            case SDLK_F: // Fun sounds easter egg (Ctrl+Alt+F)
+            case SDLK_F: // Fun sounds easter egg (Ctrl+Alt+F; macOS: Ctrl+Option+F)
 #ifdef _ENABLE_AUDIO
-                if ((kstate & KS_CTRL) && (kstate & KS_ALT)) {
+                // Require ALT without META: on macOS Cmd = KS_META|KS_ALT, and
+                // Ctrl+Cmd+F is the system "Enter Full Screen" accelerator. So
+                // match Ctrl+Option+F (KS_ALT, no KS_META) and leave Ctrl+Cmd+F
+                // to fullscreen.
+                if ((kstate & KS_CTRL) && (kstate & KS_ALT) && !(kstate & KS_META)) {
                     zt_fun_sounds_toggle();
                     key = Keys.getkey();
                     need_refresh++;
@@ -3881,11 +3882,14 @@ static bool g_fun_audio_up = false;
 static bool g_fun_playing  = false;
 static int  g_fun_dev      = -1;
 
-static void zt_fun_sounds_toggle(void)
+void zt_fun_sounds_toggle(void)
 {
   if (!g_fun_audio_up) {
-    if (!zt_backend_audio_start())
-      return;                         // no output device -> stay silent, never crash
+    if (!zt_backend_audio_start()) {
+      statusmsg = "Fun sounds: no audio output device";   // non-fatal, never crash
+      status_change = 1;
+      return;
+    }
     g_fun_audio_up = true;
     for (unsigned int d = 0; d < MidiOut->numOuputDevices; d++) {
       if (MidiOut->outputDevices[d]->type == OUTPUTDEVICE_TYPE_AUDIO &&
@@ -3897,10 +3901,20 @@ static void zt_fun_sounds_toggle(void)
     if (g_fun_dev >= 0)
       MidiOut->AddDevice(g_fun_dev);  // open() + enlist into the live mix
   }
-  if (g_fun_dev < 0) return;
+  if (g_fun_dev < 0) {
+    statusmsg = "Fun sounds: TestTone device unavailable";
+    status_change = 1;
+    return;
+  }
   g_fun_playing = !g_fun_playing;
-  if (g_fun_playing) MidiOut->outputDevices[g_fun_dev]->noteOn(60, 0, 127);
-  else               MidiOut->outputDevices[g_fun_dev]->noteOff(60, 0, 0);
+  if (g_fun_playing) {
+    MidiOut->outputDevices[g_fun_dev]->noteOn(60, 0, 127);
+    statusmsg = "Fun sounds: ON (warble) -- press again to stop";
+  } else {
+    MidiOut->outputDevices[g_fun_dev]->noteOff(60, 0, 0);
+    statusmsg = "Fun sounds: OFF";
+  }
+  status_change = 1;
 }
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3837,6 +3837,10 @@ static void audio_mixer(void *udata, SDL_AudioStream *stream, int additional_amo
   if (!mixbuf) {
     return;
   }
+  // Start from silence (S16 zero). A generator only writes while it's making
+  // sound; without this the buffer is uninitialized garbage, so "stopping"
+  // the fun sounds would play random noise instead of going quiet.
+  memset(mixbuf, 0, (size_t)additional_amount);
 
   MidiOut->MixAudio(udata, mixbuf, additional_amount);
   SDL_PutAudioStreamData(stream, mixbuf, additional_amount);

--- a/src/zt.h
+++ b/src/zt.h
@@ -684,6 +684,13 @@ extern char szStatmsg[1024];
 extern Uint64 statusmsg_error_until_ms;
 void set_error_status(const char *msg);
 
+#ifdef _ENABLE_AUDIO
+// Fun-sounds easter egg: wakes the dormant audio path and toggles the TestTone
+// warble. Triggered by Ctrl+Alt+F (macOS: Ctrl+Option+F) and the ESC-menu
+// "Fun Sounds" entry. Defined in main.cpp.
+void zt_fun_sounds_toggle(void);
+#endif
+
 #define COLORS CurrentSkin->Colors
 
 void status(const char *msg,Drawable *S);


### PR DESCRIPTION
Follow-up to #171. Two problems with the fun-sounds easter egg:

1. **`Ctrl+Alt+F` did nothing but toggle fullscreen on macOS.** Cmd maps to `KS_META|KS_ALT`, so the old `KS_CTRL && KS_ALT` test was also satisfied by **Ctrl+Cmd+F** — the macOS "Enter Full Screen" accelerator, which AppKit handles before zt sees the key. Bad key choice on my part.
2. **No ESC-menu entry** — the only trigger was that broken shortcut.

## Fixes
- **Keybind**: now requires `KS_ALT` **without** `KS_META`. So `Ctrl+Option+F` triggers the warble; `Ctrl+Cmd+F` stays macOS fullscreen. (Win/Linux `Ctrl+Alt+F` unaffected.)
- **ESC menu**: added **"Fun Sounds (warble)"** under Settings (next to Lua Console) — a reliable, clickable trigger. Calls the same `zt_fun_sounds_toggle()`, now exported via `zt.h`.
- **Feedback**: the toggle writes an on-screen status line — `Fun sounds: ON (warble) -- press again to stop` / `OFF` / `no audio output device`.
- **help.txt**: documents both triggers and the macOS Ctrl+Option+F (not Cmd) caveat.

## Verified — actually driven this time
- Headless (dummy audio driver): `key ctrl+alt+f` → status line shows **"Fun sounds: ON (warble)"**; again → OFF.
- ESC-menu screenshot shows the **"Fun Sounds (warble)  Ctrl+Alt+F"** entry under Settings.
- Full `zt` binary builds clean.
