### PR TITLE
audio: warning-clean the audio path + re-enable _ENABLE_AUDIO (fun sounds run again)

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,17 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_06_17 (Audio: warning-clean, re-enabled so the fun sounds actually run)
+----------------------------------------------------------------------------
+
+        * Re-enable _ENABLE_AUDIO. It had been turned off (#undef) to suppress
+          the compiler warnings that compiling the audio path introduced, which
+          also compiled the fun-sounds easter egg out entirely. Those were all
+          -Wunused-parameter in the TestTone / NoiseMaker stub methods; their
+          unused note/chan/vol/msg/etc. parameter names are now dropped (and
+          NoiseMaker::work marks udata unused), so the audio path builds clean.
+          The fun sounds (Ctrl+Alt+F / ESC menu) work again, warning-free.
+
 zt 2026_06_17 (Fun sounds: ESC-menu entry + macOS fullscreen-collision fix)
 ----------------------------------------------------------------------------
 

--- a/src/OutputDevices.cpp
+++ b/src/OutputDevices.cpp
@@ -237,22 +237,21 @@ void TestToneOutputDevice::reset(void) {
 void TestToneOutputDevice::hardpanic(void) {
     panic();
 }
-void TestToneOutputDevice::send(unsigned int msg) {
+void TestToneOutputDevice::send(unsigned int) {
 }
-void TestToneOutputDevice::noteOn(unsigned char note, unsigned char chan, unsigned char vol) {
+void TestToneOutputDevice::noteOn(unsigned char, unsigned char, unsigned char) {
     makenoise=1;
-    //Mix_PlayChannel(-1,smp,0);
 }
-void TestToneOutputDevice::noteOff(unsigned char note, unsigned char chan, unsigned char vol) {
+void TestToneOutputDevice::noteOff(unsigned char, unsigned char, unsigned char) {
     makenoise=0;
 }
-void TestToneOutputDevice::afterTouch(unsigned char note, unsigned char chan, unsigned char vol) {
+void TestToneOutputDevice::afterTouch(unsigned char, unsigned char, unsigned char) {
 }
-void TestToneOutputDevice::pitchWheel(unsigned char chan, unsigned short int value) {
+void TestToneOutputDevice::pitchWheel(unsigned char, unsigned short int) {
 }
-void TestToneOutputDevice::progChange(int program, int bank, unsigned char chan) {
+void TestToneOutputDevice::progChange(int, int, unsigned char) {
 }
-void TestToneOutputDevice::sendCC(unsigned char cc, unsigned char value,unsigned char chan) {
+void TestToneOutputDevice::sendCC(unsigned char, unsigned char, unsigned char) {
 }
 void TestToneOutputDevice::work( void *udata, Uint8 *stream, int len) {
     (void)udata;
@@ -308,23 +307,24 @@ void NoiseOutputDevice::reset(void) {
 void NoiseOutputDevice::hardpanic(void) {
     panic();
 }
-void NoiseOutputDevice::send(unsigned int msg) {
+void NoiseOutputDevice::send(unsigned int) {
 }
-void NoiseOutputDevice::noteOn(unsigned char note, unsigned char chan, unsigned char vol) {
+void NoiseOutputDevice::noteOn(unsigned char, unsigned char, unsigned char) {
     makenoise=1;
 }
-void NoiseOutputDevice::noteOff(unsigned char note, unsigned char chan, unsigned char vol) {
+void NoiseOutputDevice::noteOff(unsigned char, unsigned char, unsigned char) {
     makenoise=0;
 }
-void NoiseOutputDevice::afterTouch(unsigned char note, unsigned char chan, unsigned char vol) {
+void NoiseOutputDevice::afterTouch(unsigned char, unsigned char, unsigned char) {
 }
-void NoiseOutputDevice::pitchWheel(unsigned char chan, unsigned short int value) {
+void NoiseOutputDevice::pitchWheel(unsigned char, unsigned short int) {
 }
-void NoiseOutputDevice::progChange(int program, int bank, unsigned char chan) {
+void NoiseOutputDevice::progChange(int, int, unsigned char) {
 }
-void NoiseOutputDevice::sendCC(unsigned char cc, unsigned char value,unsigned char chan) {
+void NoiseOutputDevice::sendCC(unsigned char, unsigned char, unsigned char) {
 }
 void NoiseOutputDevice::work( void *udata, Uint8 *stream, int len) {
+    (void)udata;
     if (makenoise) {
         for(int i=0;i<len;i++) {
             stream[i] = rand()&0x3F;

--- a/src/zt.h
+++ b/src/zt.h
@@ -119,9 +119,10 @@ static inline void zt_text_input_stop(void) {
 #endif
 #define ZTRACKER_VERSION                "zTracker' v" ZT_BUILD_DATE
 
-// audio path: dormant by default (no device opened at boot); woken lazily by the Ctrl+Alt+F fun-sounds easter egg
-// #define _ENABLE_AUDIO                 1
-#undef _ENABLE_AUDIO
+// Audio path: compiled in, but dormant at boot (no output device opened). The
+// fun-sounds easter egg (Ctrl+Alt+F) wakes it lazily on first use, and the
+// sampler opens it when audio_enabled. Compiles warning-clean.
+#define _ENABLE_AUDIO                 1
 
 #define ZOOM                            (zt_config_globals.zoom)
 


### PR DESCRIPTION
## Why
After #171 turned `_ENABLE_AUDIO` on, it was disabled again in `2d8e51b` ("audio: disable by default to suppress new warnings introduced"). That `#undef` also compiled the **fun-sounds easter egg out entirely** (everything is behind `#ifdef _ENABLE_AUDIO`) — so on master the Ctrl+Alt+F shortcut and the ESC-menu entry do nothing.

This addresses the maintainer's actual concern (warnings) so the gate can stay on.

## What
- **Silenced the warnings at the source.** They were all `-Wunused-parameter` in the legacy `TestTone` / `NoiseMaker` stub methods (`send`/`noteOn`/`noteOff`/`afterTouch`/`pitchWheel`/`progChange`/`sendCC` ignore their MIDI args) plus `NoiseMaker::work`'s `udata`. Dropped the unused parameter names in those definitions; `(void)udata` in `work`. No behavior change.
- **Re-enabled `_ENABLE_AUDIO`** — the audio path now compiles with **zero new warnings**, so the fun sounds run again.

## Verified
- Build is warning-clean (`grep warning:` over a forced rebuild of the audio TUs → empty, except the pre-existing benign `ld: ... zlib ... search path` note unrelated to this).
- **18/18 ctest** pass.
- Headless (dummy audio): `Ctrl+Alt+F` flips the status line to **"Fun sounds: ON (warble)"**; the ESC menu shows the **"Fun Sounds (warble)"** entry again.

## Note re audio-on-by-default
This keeps `_ENABLE_AUDIO` compiled in, but **no audio device is opened at boot** — the fun-sounds easter egg opens it lazily on first use, and the sampler opens it only when `audio_enabled`. A normal MIDI-only session still never grabs an output device. If you'd prefer the path stay compiled-out, that's your call — but then the fun sounds can't ship.
