### PR TITLE
macOS: universal Intel + Apple Silicon build, deployment floor 10.13

### DIFF
--- a/.claude/skills/ztrackerprime/SKILL.md
+++ b/.claude/skills/ztrackerprime/SKILL.md
@@ -13,7 +13,7 @@ triggers:
 
 # zTracker Prime Development Skill
 
-> **Last verified: 2026-06-15.** If this date is more than ~7 days old when you load this skill, your first move is to check what merged since: `gh pr list --repo m6502/ztrackerprime --state merged --json number,title,mergedAt --jq '[.[] | select(.mergedAt > "<this date>")]'`. Reconcile any architecture / shortcut / invariant claims below against current `master` before acting on them. Then bump this date in the same PR that fixes the drift.
+> **Last verified: 2026-06-23.** If this date is more than ~7 days old when you load this skill, your first move is to check what merged since: `gh pr list --repo m6502/ztrackerprime --state merged --json number,title,mergedAt --jq '[.[] | select(.mergedAt > "<this date>")]'`. Reconcile any architecture / shortcut / invariant claims below against current `master` before acting on them. Then bump this date in the same PR that fixes the drift.
 >
 > **What lives elsewhere on purpose:** the open-PR list and merged landmarks are NOT in this skill — they go stale fast. For current state run `gh pr list --repo m6502/ztrackerprime` (open) or `gh pr list --repo m6502/ztrackerprime --state merged --limit 30` (recent landings). The skill stays timeless: architecture, invariants, foot-guns, conventions.
 
@@ -41,6 +41,8 @@ ctest --output-on-failure      # unit-test harness (Linux CI runs this)
 `open <path>/zt.app` (or `open <path>/zt`) — gives the app its own session. Avoid `./zt &` from a non-interactive shell; it can exit silently when stdin is detached.
 
 `scripts/zt-screenshot.sh` (macOS) launches zt.app and captures F1/F2/F3/F11/F12/Ctrl+F12 via `screencapture -R` + AppleScript. Output at `/tmp/zt-shots/`. Use it to self-verify layout changes.
+
+**Deployment floor (PR #176):** the macOS `.app` is a **universal** binary (Intel x86_64 + Apple Silicon arm64), floor **10.13** on x86_64 / **11.0** on arm64. Pinned via `CMAKE_OSX_DEPLOYMENT_TARGET=10.13` set *before* `project()`. SDL3 is built universal from source in CI and **bundled** into `Contents/Frameworks` (the app is self-contained — `otool -L` shows only `@rpath` + system frameworks). An explicit `-DSDL3_LIBRARY` overrides pkg-config. El Capitan (10.11) is out of reach (SDL3's floor is 10.13). To build universal locally: `-DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"` + a universal `-DSDL3_LIBRARY` (a Homebrew single-arch SDL3 will fail the universal link).
 
 ### Headless framebuffer screenshots
 
@@ -162,6 +164,8 @@ palettes against an actual screenshot; don't trust the 16→18 slot mapping.
 | `src/CUI_*.cpp` | Other pages (Sysconfig, Songconfig, Help, InstEditor, MainMenu, Playsong, etc.) |
 | `src/CUI_Page.{h,cpp}` | Base class for pages |
 | `src/UserInterface.{h,cpp}` | Widget classes — `CheckBox`, `ValueSlider`, `TextInput`, `Frame`, `Button`, `TextBox`, `ListBox`, `MidiOutDeviceOpener`, `SkinSelector`, `VUPlay`. Fix rendering bugs HERE, not in callers. |
+| `src/fs_compat.{h,cpp}` | Filesystem facade (`ztfs::`). POSIX backend on Apple (libc++ marks `std::filesystem` unavailable below macOS 10.15 — using it would pin the deploy floor there); `std::filesystem` backend on Linux/Windows (unchanged). **Never reintroduce a direct `std::filesystem` call in Apple-compiled code** — add to `ztfs::`. Tested via `fs_compat` (forced POSIX on Linux CI with `-DZTFS_FORCE_POSIX`). PR #176. |
+| `cmake/bundle_sdl3_macos.cmake` | POST_BUILD `-P` step bundling SDL3 into the `.app` (copy → rewrite install names → rpath → ad-hoc re-sign); robust to Homebrew-absolute and from-source-`@rpath`. Gated by `ZT_MACOS_BUNDLE_SDL3` (default ON). PR #176. |
 | `src/keybuffer.{h,cpp}` | Key state (KS_ALT/KS_CTRL/KS_META/KS_SHIFT) + `KS_HAS_ALT` macro. `ZT_TEST_NO_SDL` guard for SDL-free unit tests. |
 | `src/font.cpp` | `print()` / `printtitle()` / `printBG()` drawing primitives |
 | `src/zt.h` | STATE_/CMD_ enums, page globals (`UIP_CcConsole`, `UIP_SysExLibrarian`, ...), layout macros, `g_cc_drawmode` |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,8 @@
 # Builds `zt` on every push and every PR against master, across:
 #   - Windows x86 (32-bit, XP-compatible) -- MinGW-w64 cross from Ubuntu
 #   - Windows x64 (modern)                -- MSVC on windows-latest
-#   - macOS arm64                          -- Apple Silicon (macos-14)
-#   - macOS x86_64                         -- Intel (macos-26-intel)
+#   - macOS universal (Intel x86_64 + Apple Silicon arm64) -- one self-contained
+#       .app, floor 10.13 (x86_64) / 11.0 (arm64); built on macos-14
 #   - Linux x86_64                         -- ubuntu-24.04
 #
 # Each job uploads an artifact containing:
@@ -19,9 +19,11 @@
 #     binaries that work on XP per upstream docs.
 #   * Windows x64 uses MSVC + the SDL3-devel-VC release zip (the standard
 #     modern Windows path).
-#   * macOS: ship two separate single-arch artifacts instead of a universal
-#     binary, because Homebrew's SDL3 is single-arch -- combining would
-#     require building SDL3 from source twice, which is overkill.
+#   * macOS: ONE universal artifact. Homebrew's SDL3 is single-arch and minos-15,
+#     so we build a universal SDL3 from source at the 10.13 target and bundle it
+#     into the .app (self-contained). A hard-gate verify step asserts the binary
+#     is universal, the per-slice floors are 10.13/11.0, and no Homebrew dep
+#     leaks. Ableton Link is header-only, compiled into both slices.
 #   * Linux: Ubuntu 24.04's apt does not yet ship libsdl3-dev, so we build
 #     SDL3 from source (same tarball as Windows) into a local prefix and
 #     pass -DSDL3_INCLUDE_DIR / -DSDL3_LIBRARY like Windows does.
@@ -197,10 +199,17 @@ jobs:
           if-no-files-found: error
 
   # ---------------------------------------------------------------------------
-  # macOS arm64 (Apple Silicon)
+  # macOS universal (Intel x86_64 + Apple Silicon arm64), one self-contained app
   # ---------------------------------------------------------------------------
-  macos-arm64:
-    name: macOS arm64
+  # Floor: macOS 10.13 on the x86_64 slice, 11.0 on the arm64 slice (the linker
+  # auto-clamps arm64 -- no arm64 exists below Big Sur). Built against a
+  # universal SDL3 compiled from source at the same 10.13 target (Homebrew's
+  # SDL3 is single-arch and minos-15, so it cannot be used here). SDL3 is bundled
+  # into the .app, so the artifact runs with no Homebrew / system SDL3 present.
+  # The verify step is a HARD GATE: the job fails if the binary is not universal,
+  # the per-slice floors are wrong, or the app is not self-contained.
+  macos-universal:
+    name: macOS universal (Intel + Apple Silicon)
     runs-on: macos-14
     steps:
       - name: Checkout
@@ -209,7 +218,7 @@ jobs:
       - name: Install build deps
         run: |
           brew update
-          brew install cmake ninja pkg-config sdl3
+          brew install cmake ninja
 
       - name: Fetch Ableton Link
         shell: bash
@@ -217,11 +226,51 @@ jobs:
           set -euo pipefail
           bash fetch-ext-deps.sh
 
-      - name: Configure
+      - name: Cache SDL3 source tarball
+        id: cache-sdl3-src
+        uses: actions/cache@v4
+        with:
+          path: sdl3-src-cache
+          key: sdl3-src-${{ env.SDL3_VERSION }}
+
+      - name: Download + build universal SDL3 from source (10.13)
+        id: sdl3
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p sdl3-src-cache
+          TARBALL="sdl3-src-cache/SDL3-${SDL3_VERSION}.tar.gz"
+          if [ ! -f "$TARBALL" ]; then
+            curl -fL -o "$TARBALL" \
+              "https://github.com/libsdl-org/SDL/releases/download/release-${SDL3_VERSION}/SDL3-${SDL3_VERSION}.tar.gz"
+          fi
+          rm -rf sdl3-src
+          mkdir -p sdl3-src
+          tar xf "$TARBALL" -C sdl3-src --strip-components=1
+          cmake -S sdl3-src -B sdl3-build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$(pwd)/sdl3-prefix" \
+            -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 \
+            -DSDL_SHARED=ON -DSDL_STATIC=OFF \
+            -DSDL_TESTS=OFF -DSDL_EXAMPLES=OFF
+          cmake --build sdl3-build -j
+          cmake --install sdl3-build
+          PREFIX="$(pwd)/sdl3-prefix"
+          {
+            echo "include=$PREFIX/include"
+            echo "lib=$PREFIX/lib/libSDL3.0.dylib"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Configure (universal, 10.13, Ableton Link ON)
         run: |
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_OSX_ARCHITECTURES=arm64
+            -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 \
+            -DZT_ENABLE_ABLETON_LINK=ON \
+            -DSDL3_INCLUDE_DIR="${{ steps.sdl3.outputs.include }}" \
+            -DSDL3_LIBRARY="${{ steps.sdl3.outputs.lib }}"
 
       - name: Build
         run: cmake --build build --config Release -j
@@ -229,22 +278,67 @@ jobs:
       - name: Run unit tests (incl. Lua API self-test, headless)
         run: ctest --test-dir build --output-on-failure
 
+      - name: Verify universal + low floor + self-contained (HARD GATE)
+        shell: bash
+        run: |
+          set -euo pipefail
+          BIN=build/Program/zt.app/Contents/MacOS/zt
+          APP=build/Program/zt.app
+          fail=0
+
+          echo "== architectures =="
+          archs="$(lipo -archs "$BIN")"; echo "  $archs"
+          echo "$archs" | grep -q x86_64 && echo "$archs" | grep -q arm64 \
+            || { echo "  FAIL: not universal"; fail=1; }
+
+          echo "== per-slice deployment floor =="
+          slice_min () { vtool -arch "$1" -show-build "$BIN" 2>/dev/null | awk '/(minos|version) /{print $2; exit}'; }
+          X="$(slice_min x86_64)"; A="$(slice_min arm64)"
+          echo "  x86_64=$X (want 10.13)   arm64=$A (want 11.0)"
+          [ "$X" = "10.13" ] || { echo "  FAIL: x86_64 floor"; fail=1; }
+          [ "$A" = "11.0" ]  || { echo "  FAIL: arm64 floor"; fail=1; }
+
+          echo "== self-contained (no Homebrew / /usr/local deps) =="
+          if otool -L "$BIN" | grep -E "/opt/|/usr/local/"; then
+            echo "  FAIL: non-system absolute dependency remains"; fail=1
+          else
+            echo "  OK"
+          fi
+
+          echo "== bundled SDL3 is universal =="
+          sdlarchs="$(lipo -archs "$APP/Contents/Frameworks/libSDL3.0.dylib" 2>/dev/null || true)"
+          echo "  SDL3: $sdlarchs"
+          echo "$sdlarchs" | grep -q x86_64 && echo "$sdlarchs" | grep -q arm64 \
+            || { echo "  FAIL: bundled SDL3 not universal"; fail=1; }
+
+          echo "== ad-hoc signature valid =="
+          codesign --verify --deep "$APP" && echo "  OK" || { echo "  FAIL: signature"; fail=1; }
+
+          echo "== arm64 renders headless =="
+          printf 'wait 400\nkey F11\nwait 200\nshot %s\nquit\n' "$PWD/zt-ci-smoke.png" > zt-ci.script
+          arch -arm64 "$BIN" --headless --script zt-ci.script >/dev/null 2>&1 || true
+          [ -s zt-ci-smoke.png ] && echo "  OK ($(stat -f%z zt-ci-smoke.png) bytes)" \
+            || { echo "  FAIL: no framebuffer rendered"; fail=1; }
+
+          [ "$fail" -eq 0 ] || { echo "VERIFY FAILED"; exit 1; }
+          echo "VERIFY PASSED: universal, 10.13/11.0, self-contained, Link ON, renders"
+
       - name: Stage release
         run: |
-          mkdir -p dist/ztrackerprime-macos-arm64
-          cp -R build/Program/zt.app dist/ztrackerprime-macos-arm64/
-          cp zt.conf                 dist/ztrackerprime-macos-arm64/
-          cp -R skins                dist/ztrackerprime-macos-arm64/
-          cp -R doc                  dist/ztrackerprime-macos-arm64/
+          mkdir -p dist/ztrackerprime-macos-universal
+          cp -R build/Program/zt.app dist/ztrackerprime-macos-universal/
+          cp zt.conf                 dist/ztrackerprime-macos-universal/
+          cp -R skins                dist/ztrackerprime-macos-universal/
+          cp -R doc                  dist/ztrackerprime-macos-universal/
           # macOS users hit "zt.app is damaged" because the build is unsigned
           # (no Apple Developer Program). README explains the xattr fix.
-          cp .github/release-notes/README-MAC.txt dist/ztrackerprime-macos-arm64/
+          cp .github/release-notes/README-MAC.txt dist/ztrackerprime-macos-universal/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ztrackerprime-macos-arm64
-          path: dist/ztrackerprime-macos-arm64
+          name: ztrackerprime-macos-universal
+          path: dist/ztrackerprime-macos-universal
           if-no-files-found: error
 
       - name: Package release (zip + unsigned DMG)
@@ -254,92 +348,7 @@ jobs:
           set -euo pipefail
           cd dist
           TAG="${RELEASE_TAG}"
-          ARCH="arm64"
-          # Zip of the full staged dir (zt.app + zt.conf + skins + doc + README-MAC.txt).
-          # ditto preserves .app bundle structure and resource forks.
-          ditto -c -k --sequesterRsrc --keepParent \
-            "ztrackerprime-macos-${ARCH}" \
-            "ztrackerprime-${TAG}-macos-${ARCH}.zip"
-          # Unsigned DMG: zt.app + README-MAC.txt side by side, so the user sees
-          # the quarantine-fix instructions immediately on mounting the DMG.
-          mkdir -p "dmg-staging-${ARCH}"
-          cp -R "ztrackerprime-macos-${ARCH}/zt.app"         "dmg-staging-${ARCH}/"
-          cp    "ztrackerprime-macos-${ARCH}/README-MAC.txt" "dmg-staging-${ARCH}/"
-          hdiutil create \
-            -volname "zTracker ${TAG} (${ARCH})" \
-            -srcfolder "dmg-staging-${ARCH}" \
-            -fs HFS+ -format UDZO -ov \
-            "ztrackerprime-${TAG}-macos-${ARCH}.dmg"
-
-      - name: Upload release asset (macos-arm64)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-macos-arm64
-          path: |
-            dist/ztrackerprime-*-macos-arm64.zip
-            dist/ztrackerprime-*-macos-arm64.dmg
-          if-no-files-found: error
-
-  # ---------------------------------------------------------------------------
-  # macOS x86_64 (Intel)
-  # ---------------------------------------------------------------------------
-  macos-x86_64:
-    name: macOS x86_64
-    # macos-13 / macos-12 Intel runners have been retired; macos-26-intel is
-    # the supported Intel image. (macos-14+ are Apple Silicon.)
-    runs-on: macos-26-intel
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install build deps
-        run: |
-          brew update
-          brew install cmake ninja pkg-config sdl3
-
-      - name: Fetch External Dependencies
-        shell: bash
-        run: |
-          set -euo pipefail
-          bash fetch-ext-deps.sh
-
-      - name: Configure
-        run: |
-          cmake -S . -B build -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_OSX_ARCHITECTURES=x86_64
-
-      - name: Build
-        run: cmake --build build --config Release -j
-
-      - name: Run unit tests (incl. Lua API self-test, headless)
-        run: ctest --test-dir build --output-on-failure
-
-      - name: Stage release
-        run: |
-          mkdir -p dist/ztrackerprime-macos-x86_64
-          cp -R build/Program/zt.app dist/ztrackerprime-macos-x86_64/
-          cp zt.conf                 dist/ztrackerprime-macos-x86_64/
-          cp -R skins                dist/ztrackerprime-macos-x86_64/
-          cp -R doc                  dist/ztrackerprime-macos-x86_64/
-          cp .github/release-notes/README-MAC.txt dist/ztrackerprime-macos-x86_64/
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ztrackerprime-macos-x86_64
-          path: dist/ztrackerprime-macos-x86_64
-          if-no-files-found: error
-
-      - name: Package release (zip + unsigned DMG)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
-        shell: bash
-        run: |
-          set -euo pipefail
-          cd dist
-          TAG="${RELEASE_TAG}"
-          ARCH="x86_64"
+          ARCH="universal"
           ditto -c -k --sequesterRsrc --keepParent \
             "ztrackerprime-macos-${ARCH}" \
             "ztrackerprime-${TAG}-macos-${ARCH}.zip"
@@ -352,14 +361,14 @@ jobs:
             -fs HFS+ -format UDZO -ov \
             "ztrackerprime-${TAG}-macos-${ARCH}.dmg"
 
-      - name: Upload release asset (macos-x86_64)
+      - name: Upload release asset (macos-universal)
         if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/pr-release-packaging'
         uses: actions/upload-artifact@v4
         with:
-          name: release-macos-x86_64
+          name: release-macos-universal
           path: |
-            dist/ztrackerprime-*-macos-x86_64.zip
-            dist/ztrackerprime-*-macos-x86_64.dmg
+            dist/ztrackerprime-*-macos-universal.zip
+            dist/ztrackerprime-*-macos-universal.dmg
           if-no-files-found: error
 
   # ---------------------------------------------------------------------------
@@ -606,8 +615,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs:
       - linux-x86_64
-      - macos-arm64
-      - macos-x86_64
+      - macos-universal
       - windows-x86-xp
       - windows-x64
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file is loaded automatically by Claude Code (and other AI agents that suppo
 
 **This file is self-contained** — you do not need the skill to contribute. For *deeper* material — headless-screenshot recipes, the full list-pane construction idiom (with code), effect reference, glossary — see [`.claude/skills/ztrackerprime/SKILL.md`](.claude/skills/ztrackerprime/SKILL.md) and the `references/` + `recipes/` directories alongside it. The skill is the continuously-maintained companion; CLAUDE.md is the standalone briefing that mirrors its essentials for agents and humans who don't load skills.
 
-> **Last synced with the codebase: 2026-06-15.** If that date is more than ~2 weeks old when you read this, your first move is to check what merged since — `gh pr list --repo m6502/ztrackerprime --state merged --json number,title,mergedAt` — and reconcile the key-files table, shortcut map, feature sections, and test list below against current `master` before relying on them. Bump this date in the same commit that fixes any drift. (This guard exists because CLAUDE.md silently fell ~7 weeks out of date once: it duplicated the skill's content but, unlike the skill, had no reconcile step.)
+> **Last synced with the codebase: 2026-06-23.** If that date is more than ~2 weeks old when you read this, your first move is to check what merged since — `gh pr list --repo m6502/ztrackerprime --state merged --json number,title,mergedAt` — and reconcile the key-files table, shortcut map, feature sections, and test list below against current `master` before relying on them. Bump this date in the same commit that fixes any drift. (This guard exists because CLAUDE.md silently fell ~7 weeks out of date once: it duplicated the skill's content but, unlike the skill, had no reconcile step.)
 
 ---
 
@@ -57,6 +57,8 @@ CMake option `ZT_BUILD_TESTS` (default ON) controls whether the `tests/` subdire
 | `src/CUI_Page.{h,cpp}` | Base class for all `CUI_*` pages. |
 | `src/CUI_*.cpp` | Other pages: Sysconfig, Songconfig, Help, About, InstEditor, MainMenu, etc. |
 | `src/UserInterface.{h,cpp}` | Widget classes — `CheckBox`, `ValueSlider`, `TextInput`, `Frame`, `Button`, `TextBox`, `ListBox`, `MidiOutDeviceOpener`, `SkinSelector`, `VUPlay`. **Fix rendering bugs in the widget class, not at every caller.** |
+| `src/fs_compat.{h,cpp}` | Filesystem facade (`ztfs::`) replacing direct `std::filesystem` calls. POSIX backend on Apple (libc++ marks `std::filesystem` unavailable below macOS 10.15, which would pin the deploy floor there); `std::filesystem` backend on Linux/Windows (unchanged). Built with `-DZTFS_FORCE_POSIX` in the `fs_compat` test so the POSIX path is CI-covered on Linux. |
+| `cmake/bundle_sdl3_macos.cmake` | POST_BUILD step (`-P`) that bundles SDL3 into the macOS `.app` (copy → rewrite install names → add rpath → ad-hoc re-sign), making the app self-contained. Robust to Homebrew-absolute and from-source-`@rpath` SDL3 references. Gated by `ZT_MACOS_BUNDLE_SDL3` (default ON). |
 | `src/keybuffer.{h,cpp}` | Key buffer + KS_ALT/KS_CTRL/KS_META/KS_SHIFT state. `KS_HAS_ALT(s)` macro accepts ALT or macOS Cmd. Header has a `ZT_TEST_NO_SDL` guard so it can be compiled into SDL-free unit tests via `tests/sdl_stub.h`. |
 | `src/font.cpp` | `print()` / `printtitle()` / `printBG()` drawing primitives. |
 | `src/zt.h` | Kitchen-sink: `STATE_*` enum (incl. `STATE_CCCONSOLE`, `STATE_SYSEX_LIB`), `CMD_*` enum, page globals (`UIP_CcConsole`, `UIP_SysExLibrarian`), `g_cc_drawmode`, layout macros. |
@@ -80,12 +82,22 @@ CMake option `ZT_BUILD_TESTS` (default ON) controls whether the `tests/` subdire
 | `src/editor_layout.h` | Shared character-grid constants for F4/Shift+F4 editors. |
 | `assets/ccizer/` | Bundled CCizer banks (Paketti subset) + README. CMake POST_BUILD copies into `.app Resources/ccizer` and `<exe-dir>/ccizer`. |
 | `assets/syx/` | Bundled SysEx files. `request_universal_inquiry.syx` for first-test handshakes. |
-| `tests/` | CTest unit-test executables. **8 suites**: presets / selector / page_sync / save_key / keybuffer / ccizer / sysex_inq / sysex_macro. Linux CI runs them. |
+| `tests/` | CTest unit-test executables (run `ctest -N` for the live list). Includes `fs_compat` (the `ztfs::` POSIX backend, forced on via `-DZTFS_FORCE_POSIX` so Linux CI exercises Apple's path). Linux CI runs the SDL-free suites. |
 | `doc/help.txt` | In-app F1 help. **Update this when adding keybinds or CLI flags.** |
 | `doc/CHANGELOG.txt` | Release notes, chronological. |
 | `.github/workflows/build.yml` | CI: 5-platform build matrix + Linux ctest run. |
 
 ---
+
+## macOS deployment floor & universal build
+
+The macOS `.app` is a **universal binary** (Intel x86_64 + Apple Silicon arm64) with a deployment floor of **10.13 (High Sierra)** on the x86_64 slice and **11.0 (Big Sur)** on the arm64 slice (the linker auto-clamps arm64 — no arm64 exists below Big Sur). Three things conspired to keep the old floor at 15.0, all now fixed:
+
+1. **No deployment target** was set → `CMakeLists.txt` now pins `CMAKE_OSX_DEPLOYMENT_TARGET=10.13` (before `project()`, so the flag is baked into every object; setting it after is too late). Override with `-DCMAKE_OSX_DEPLOYMENT_TARGET=`.
+2. **Homebrew SDL3** is minos-15 and single-arch. CI builds a **universal SDL3 from source at 10.13** and passes `-DSDL3_LIBRARY`. An explicit `SDL3_LIBRARY` now overrides pkg-config (otherwise a Homebrew `sdl3.pc` silently wins and pulls in its single-arch dylib, which fails to link universal).
+3. **`std::filesystem`** is marked unavailable below 10.15 by libc++ → routed through `src/fs_compat.{h,cpp}` (`ztfs::`) on Apple. **Never reintroduce a direct `std::filesystem` call** in code compiled on Apple; add to `ztfs::` instead.
+
+SDL3 is bundled into `Contents/Frameworks` (see `cmake/bundle_sdl3_macos.cmake`) so the app is self-contained. The CI macOS job hard-gates every run on: universal, per-slice floor 10.13/11.0, no Homebrew dep leak, renders headless. **El Capitan (10.11) and older are out of reach — SDL3's own floor is 10.13.**
 
 ## Coordinate system (read this; it has tripped us up multiple times)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,17 @@
 cmake_minimum_required(VERSION 3.20)
 
+# Pin the macOS deployment floor BEFORE project() so the compiler/linker bake
+# -mmacosx-version-min into every object (setting it after project() is too late
+# -- the toolchain default is already chosen). zTracker's own code (since the
+# std::filesystem -> src/fs_compat.cpp move) and SDL3 both build down to macOS
+# 10.13, so the shipped binary advertises 10.13 (LC_VERSION_MIN_MACOSX) instead
+# of inheriting the builder's SDK default. The linker auto-clamps arm64 slices
+# to 11.0 (no arm64 exists below Big Sur). Ignored on non-Apple platforms.
+# Override with -DCMAKE_OSX_DEPLOYMENT_TARGET= on the command line.
+if(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum macOS version")
+endif()
+
 set(MINGW_ROOT "W:/MINGW64" CACHE PATH "MinGW root directory (used with MinGW Makefiles generator)")
 
 if(CMAKE_GENERATOR MATCHES "MinGW Makefiles")
@@ -39,6 +51,11 @@ option(ZT_ENABLE_SANITIZERS "Enable AddressSanitizer + UndefinedBehaviorSanitize
 # the real wrapper. When OFF or the tree is absent, the wrapper builds as a
 # safe stub so the binary still works without Link.
 option(ZT_ENABLE_ABLETON_LINK "Sync tempo/transport with Ableton Link peers on the LAN" ON)
+
+# Bundle the SDL3 dylib into the macOS .app so a double-clicked app is
+# self-contained (no Homebrew / system SDL3 required). ON by default; turn OFF
+# only if you deliberately ship SDL3 separately. See cmake/bundle_sdl3_macos.cmake.
+option(ZT_MACOS_BUNDLE_SDL3 "Bundle SDL3 into the macOS .app for a self-contained build" ON)
 
 set(ZT_WINDOWS_LIB_DIR "${CMAKE_SOURCE_DIR}/extlibs" CACHE PATH "Directory containing Windows SDL libraries (.lib/.dll)")
 set(SDL3_INCLUDE_DIR "" CACHE PATH "Path containing SDL3/SDL.h (or SDL.h with SDL3 include root)")
@@ -98,6 +115,7 @@ set(ZT_SOURCES
   src/conf.cpp
   src/edit_cols.cpp
   src/font.cpp
+  src/fs_compat.cpp
   src/img_sdl3.cpp
   src/keybindings.cpp
   src/keybuffer.cpp
@@ -301,7 +319,12 @@ string(TIMESTAMP ZT_BUILD_DATE "%Y_%m_%d" UTC)
 target_compile_definitions(zt PRIVATE ZT_BUILD_DATE="${ZT_BUILD_DATE}")
 
 find_package(PkgConfig QUIET)
-if(PkgConfig_FOUND)
+# An explicitly-provided SDL3_LIBRARY (e.g. a universal build-from-source passed
+# by CI) takes precedence over pkg-config. Without this, a Homebrew sdl3.pc on
+# the builder's machine would win and silently pull in its single-arch dylib --
+# which fails to link into a universal binary. Only fall back to pkg-config when
+# the caller did not pin SDL3_LIBRARY.
+if(PkgConfig_FOUND AND (NOT DEFINED SDL3_LIBRARY OR SDL3_LIBRARY STREQUAL ""))
   pkg_check_modules(SDL3PC QUIET IMPORTED_TARGET sdl3)
 endif()
 
@@ -416,6 +439,21 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   target_link_libraries(zt PRIVATE asound)
 endif()
 
+# Resolve the on-disk SDL3 dylib so the macOS bundling step (below) can find it
+# even when the binary references it via @rpath (built-from-source SDL3). For a
+# Homebrew build the binary carries the absolute id and this hint is unused.
+set(ZT_SDL3_DYLIB_HINT "")
+if(APPLE)
+  if(DEFINED SDL3_LIBRARY AND NOT SDL3_LIBRARY STREQUAL "" AND SDL3_LIBRARY MATCHES "\\.dylib$")
+    set(ZT_SDL3_DYLIB_HINT "${SDL3_LIBRARY}")
+  elseif(PkgConfig_FOUND)
+    pkg_get_variable(ZT_SDL3_LIBDIR sdl3 libdir)
+    if(ZT_SDL3_LIBDIR AND EXISTS "${ZT_SDL3_LIBDIR}/libSDL3.0.dylib")
+      set(ZT_SDL3_DYLIB_HINT "${ZT_SDL3_LIBDIR}/libSDL3.0.dylib")
+    endif()
+  endif()
+endif()
+
 if(APPLE)
   string(TIMESTAMP ZT_BUILD_VERSION "%Y.%m.%d" UTC)
   target_link_libraries(zt PRIVATE "-framework CoreMIDI" "-framework CoreFoundation" "-framework Cocoa")
@@ -468,6 +506,15 @@ if(APPLE)
       "$<TARGET_BUNDLE_CONTENT_DIR:zt>/Resources/lua"
     VERBATIM
   )
+  # Stamp LSMinimumSystemVersion to match the deployment target. CMake's
+  # Info.plist template only substitutes the MACOSX_BUNDLE_* keys, so set this
+  # one out-of-band. Runs before the SDL3 bundle step's codesign so the final
+  # signature covers the edited plist.
+  add_custom_command(TARGET zt POST_BUILD
+    COMMAND plutil -replace LSMinimumSystemVersion -string "${CMAKE_OSX_DEPLOYMENT_TARGET}"
+      "$<TARGET_BUNDLE_CONTENT_DIR:zt>/Info.plist"
+    VERBATIM
+  )
   if(ZT_ICON_COMPOSER)
     # Compile the Icon Composer source into the bundle: Assets.car (used on
     # macOS 26+) plus a refreshed zt.icns, overwriting the embedded fallback.
@@ -478,6 +525,20 @@ if(APPLE)
         --platform macosx
         --minimum-deployment-target 26.0
         --output-partial-info-plist "${CMAKE_BINARY_DIR}/zt-icon-partial.plist"
+      VERBATIM
+    )
+  endif()
+  if(ZT_MACOS_BUNDLE_SDL3)
+    # Last macOS step: copy SDL3 into Contents/Frameworks, fix install names,
+    # add the rpath, and re-sign the whole bundle (must run after resources +
+    # icon are in place). Robust to Homebrew (absolute id) and from-source
+    # (@rpath id, resolved via ZT_SDL3_DYLIB_HINT). See the helper script.
+    add_custom_command(TARGET zt POST_BUILD
+      COMMAND ${CMAKE_COMMAND}
+        "-DZT_BIN=$<TARGET_FILE:zt>"
+        "-DZT_APP=$<TARGET_BUNDLE_DIR:zt>"
+        "-DZT_SDL3_HINT=${ZT_SDL3_DYLIB_HINT}"
+        -P "${CMAKE_SOURCE_DIR}/cmake/bundle_sdl3_macos.cmake"
       VERBATIM
     )
   endif()

--- a/cmake/bundle_sdl3_macos.cmake
+++ b/cmake/bundle_sdl3_macos.cmake
@@ -1,0 +1,70 @@
+# Make the macOS .app self-contained by bundling the SDL3 dylib it links
+# against into Contents/Frameworks, rewriting install names, adding an
+# @executable_path rpath, and ad-hoc re-signing. Invoked at POST_BUILD via
+# `cmake -P` (see CMakeLists.txt, ZT_MACOS_BUNDLE_SDL3).
+#
+# Robust to both SDL3 reference styles:
+#   * an absolute id  (Homebrew: /opt/homebrew/opt/sdl3/lib/libSDL3.0.dylib)
+#   * an @rpath id     (built-from-source SDL3, with ZT_SDL3_HINT supplying the
+#                       real on-disk path)
+# If SDL3 cannot be resolved it WARNS but does not fail the build, so a
+# developer build never breaks over bundling.
+#
+# Args (passed with -D):
+#   ZT_BIN        full path to the executable (…/zt.app/Contents/MacOS/zt)
+#   ZT_APP        bundle root (…/zt.app)
+#   ZT_SDL3_HINT  optional absolute path to the source libSDL3*.dylib
+
+if(NOT EXISTS "${ZT_BIN}")
+  message(WARNING "bundle_sdl3_macos: binary not found: ${ZT_BIN}")
+  return()
+endif()
+
+# 1. Find the SDL3 dependency reference inside the binary.
+execute_process(COMMAND otool -L "${ZT_BIN}" OUTPUT_VARIABLE _otool ERROR_QUIET)
+string(REGEX MATCH "[^\n\t ]*libSDL3[^\n\t ]*\\.dylib" _ref "${_otool}")
+if(NOT _ref)
+  message(STATUS "bundle_sdl3_macos: no dynamic SDL3 dependency (static link?) — nothing to bundle")
+  return()
+endif()
+get_filename_component(_refname "${_ref}" NAME)
+
+# 2. Resolve the real on-disk dylib: absolute reference wins, else the hint.
+set(_src "")
+if(IS_ABSOLUTE "${_ref}" AND EXISTS "${_ref}")
+  set(_src "${_ref}")
+elseif(ZT_SDL3_HINT AND EXISTS "${ZT_SDL3_HINT}")
+  set(_src "${ZT_SDL3_HINT}")
+endif()
+if(NOT _src)
+  message(WARNING "bundle_sdl3_macos: cannot resolve SDL3 dylib "
+                  "(ref='${_ref}', hint='${ZT_SDL3_HINT}') — app is NOT self-contained")
+  return()
+endif()
+
+# 3. Copy the real file (resolve symlinks) into Contents/Frameworks.
+get_filename_component(_real "${_src}" REALPATH)
+set(_fw "${ZT_APP}/Contents/Frameworks")
+file(MAKE_DIRECTORY "${_fw}")
+set(_bundled "${_fw}/${_refname}")
+file(REMOVE "${_bundled}")
+configure_file("${_real}" "${_bundled}" COPYONLY)
+execute_process(COMMAND chmod u+w "${_bundled}")
+
+# 4. Rewrite install names so the binary finds the bundled copy via rpath.
+execute_process(COMMAND install_name_tool -id "@rpath/${_refname}" "${_bundled}")
+execute_process(COMMAND install_name_tool -change "${_ref}" "@rpath/${_refname}" "${ZT_BIN}")
+execute_process(COMMAND install_name_tool -add_rpath "@executable_path/../Frameworks" "${ZT_BIN}"
+                ERROR_QUIET)   # harmless if the rpath already exists
+
+# 5. Re-sign (ad-hoc): editing the Mach-O invalidates any prior signature.
+execute_process(COMMAND codesign --remove-signature "${_bundled}" ERROR_QUIET)
+execute_process(COMMAND codesign --sign - --force "${_bundled}" ERROR_QUIET)
+execute_process(COMMAND codesign --sign - --force --deep "${ZT_APP}" ERROR_QUIET)
+
+# 6. Verify the result is self-contained (no non-system absolute dep left).
+execute_process(COMMAND otool -L "${ZT_BIN}" OUTPUT_VARIABLE _after ERROR_QUIET)
+if(_after MATCHES "/opt/|/usr/local/")
+  message(WARNING "bundle_sdl3_macos: a non-system absolute dependency remains — check otool -L")
+endif()
+message(STATUS "bundle_sdl3_macos: bundled ${_refname} from ${_real}")

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,33 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_06_23 (macOS back-compat: universal Intel + Apple Silicon, floor 10.13)
+------------------------------------------------------------------------------
+
+        + macOS builds are now a single UNIVERSAL .app (Intel x86_64 +
+          Apple Silicon arm64) instead of two separate single-arch artifacts.
+          The deployment floor drops from macOS 15.0 to macOS 10.13 (High Sierra)
+          on the Intel slice and 11.0 (Big Sur) on the Apple Silicon slice -- so
+          zTracker now runs on High Sierra, Mojave, Catalina and everything newer.
+
+        + The macOS .app is now self-contained: SDL3 is bundled into
+          Contents/Frameworks (rewritten install names + ad-hoc re-sign), so a
+          double-clicked app no longer needs Homebrew or a system SDL3 installed.
+
+        * The macOS deployment floor was previously pinned at 15.0 only because
+          (a) no deployment target was set, (b) Homebrew's SDL3 is minos-15 and
+          single-arch, and (c) the code used std::filesystem, which libc++ marks
+          unavailable below macOS 10.15. std::filesystem is now routed through a
+          POSIX facade (src/fs_compat.{h,cpp}) on Apple; Linux and Windows keep
+          their std::filesystem path unchanged. New test suite: fs_compat.
+
+        ! CI builds the universal SDL3 from source at the 10.13 target and gates
+          every macOS run on a hard verification: universal, per-slice floor
+          10.13/11.0, self-contained, renders headless. Ableton Link (header-only)
+          is compiled into both slices. El Capitan (10.11) and older remain
+          out of reach -- SDL3's own floor is 10.13.
+
+
 zt 2026_06_21 (Track properties, dynamic positioning fixes and improvements)
 ----------------------------------------------------------------------------
 

--- a/src/CUI_PaletteEditor.cpp
+++ b/src/CUI_PaletteEditor.cpp
@@ -3,7 +3,7 @@
 #include "Skins.h"
 #include <stdio.h>
 #include <string.h>
-#include <filesystem>
+#include "fs_compat.h"
 #include <algorithm>
 #include <vector>
 #include <string>
@@ -265,26 +265,23 @@ void CUI_PaletteEditor::rebuild_preset_list(void) {
 #else
     snprintf(skinroot, sizeof(skinroot), "%s/skins", cur_dir ? cur_dir : ".");
 #endif
-    std::error_code ec;
-    if (std::filesystem::is_directory(skinroot, ec)) {
-        std::vector<std::filesystem::path> skin_dirs;
-        for (auto &entry : std::filesystem::directory_iterator(skinroot, ec)) {
-            if (ec) break;
-            if (!entry.is_directory()) continue;
-            auto colors = entry.path() / "colors.conf";
-            if (std::filesystem::exists(colors, ec)) {
-                skin_dirs.push_back(entry.path());
+    if (ztfs::is_directory(skinroot)) {
+        std::vector<std::string> skin_dirs;
+        for (auto &entry : ztfs::list_directory(skinroot)) {
+            if (!entry.is_directory) continue;
+            if (ztfs::exists(ztfs::join(entry.path, "colors.conf"))) {
+                skin_dirs.push_back(entry.path);
             }
         }
         std::sort(skin_dirs.begin(), skin_dirs.end());
         for (auto &p : skin_dirs) {
             if (num_presets >= 64) break;
-            std::string name = p.filename().string();
+            std::string name = ztfs::filename(p);
             snprintf(preset_label[num_presets], sizeof(preset_label[0]),
                      "[skin] %s", name.c_str());
-            auto colors = p / "colors.conf";
+            std::string colors = ztfs::join(p, "colors.conf");
             snprintf(preset_path[num_presets], sizeof(preset_path[0]),
-                     "%s", colors.string().c_str());
+                     "%s", colors.c_str());
             preset_is_skin[num_presets] = 1;
             num_presets++;
         }

--- a/src/FileList.cpp
+++ b/src/FileList.cpp
@@ -2,7 +2,7 @@
 #include "FileList.h"
 #include <assert.h>
 
-#include <filesystem>
+#include "fs_compat.h"
 #include <algorithm>
 
 
@@ -100,9 +100,9 @@ void DriveList::OnChange()
 //
 void DriveList::OnSelect(LBNode *selected) {
 #ifdef _WIN32
-    std::filesystem::current_path(&selected->caption[2]);
+    ztfs::set_current_path(&selected->caption[2]);
 #else
-    std::filesystem::current_path(selected->caption);
+    ztfs::set_current_path(selected->caption);
 #endif
     OnChange();
     updated++;
@@ -168,15 +168,9 @@ void DirList::draw(Drawable *S, int active) {
 // ------------------------------------------------------------------------------------------------
 //
 //
-bool is_root_directory(const std::filesystem::path &dir_path)
+bool is_root_directory(const std::string &dir_path)
 {
-    if (std::filesystem::exists(dir_path) && std::filesystem::is_directory(dir_path)) {
-
-        bool result = (dir_path == dir_path.root_path()) ;
-        return result ;
-    }
-
-    return false;
+    return ztfs::is_root_directory(dir_path);
 }
 
 
@@ -189,19 +183,16 @@ void DirList::OnChange()
 {
     clear();
 
-    std::filesystem::path current_dir = std::filesystem::current_path();
+    std::string current_dir = ztfs::current_path();
 
     if(!is_root_directory(current_dir))
     {
         insertItem((char *)"..");
     }
 
-    for (const auto& entry : std::filesystem::directory_iterator(".")) {
-
-        if (entry.is_directory()) {
-
-            const std::string dirName = entry.path().filename().string();
-            insertItem((char *)dirName.c_str());
+    for (const auto& entry : ztfs::list_directory(".")) {
+        if (entry.is_directory) {
+            insertItem((char *)entry.name.c_str());
         }
     }
 
@@ -227,7 +218,7 @@ void DirList::OnChange()
 //
 //
 void DirList::OnSelect(LBNode *selected) {
-    std::filesystem::current_path(selected->caption);
+    ztfs::set_current_path(selected->caption);
     OnChange();
     updated++;
     char d[1024];
@@ -372,12 +363,12 @@ void FileList::AddFiles(const char *pattern, TColor c)
     std::string wanted_ext = pattern ? pattern : "";
     std::transform(wanted_ext.begin(), wanted_ext.end(), wanted_ext.begin(), ::tolower);
 
-    for (const auto& entry : std::filesystem::directory_iterator(".")) {
-        std::string ext = entry.path().extension().string();
+    for (const auto& entry : ztfs::list_directory(".")) {
+        std::string ext = ztfs::extension(entry.name);
         std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
 
-        if (entry.is_regular_file() && ext == wanted_ext) {
-            LBNode* p = insertItem((char *)entry.path().filename().string().c_str());
+        if (entry.is_regular_file && ext == wanted_ext) {
+            LBNode* p = insertItem((char *)entry.name.c_str());
             p->int_data = c; // Set the integer data
         }
     }

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -37,7 +37,7 @@
  *
  ******/
 
-#include <filesystem>
+#include "fs_compat.h"
 #include <fstream>
 #include <set>
 #include <string>
@@ -2794,16 +2794,16 @@ void SkinSelector::OnChange() {
     std::string skins_dir = std::string(cur_dir) + "/skins";
 
     // Iterate through the directory entries
-    for (const auto& entry : std::filesystem::directory_iterator(skins_dir)) {
-        
-        const std::string dir_name = entry.path().filename().string();
+    for (const auto& entry : ztfs::list_directory(skins_dir)) {
+
+        const std::string &dir_name = entry.name;
 
         // Ignore "." and ".." directories
         if (dir_name[0] != '.') {
-            std::string config_file = entry.path().string() + "/colors.conf";
+            std::string config_file = ztfs::join(entry.path, "colors.conf");
 
             // Check if the "colors.conf" file exists in the subdirectory
-            if (std::filesystem::exists(config_file)) {
+            if (ztfs::exists(config_file)) {
                 LBNode *p = insertItem((char *)dir_name.c_str());
                 if (zcmp(p->caption,zt_config_globals.skin))
                     p->checked = true;

--- a/src/fs_compat.cpp
+++ b/src/fs_compat.cpp
@@ -1,0 +1,179 @@
+#include "fs_compat.h"
+
+#if defined(__APPLE__) || defined(ZTFS_FORCE_POSIX)
+#define ZTFS_POSIX 1
+#endif
+
+namespace ztfs {
+
+// --- lexical helpers (shared by both backends) -------------------------------
+
+static char path_sep() {
+#if defined(_WIN32)
+    return '\\';
+#else
+    return '/';
+#endif
+}
+
+static bool is_sep(char c) { return c == '/' || c == '\\'; }
+
+std::string filename(const std::string &p) {
+    size_t pos = p.find_last_of("/\\");
+    return pos == std::string::npos ? p : p.substr(pos + 1);
+}
+
+std::string extension(const std::string &p) {
+    const std::string fn = filename(p);
+    size_t dot = fn.find_last_of('.');
+    if (dot == std::string::npos || dot == 0) return "";
+    return fn.substr(dot);
+}
+
+std::string join(const std::string &a, const std::string &b) {
+    if (a.empty()) return b;
+    if (b.empty()) return a;
+    if (is_sep(a.back())) return a + b;
+    return a + path_sep() + b;
+}
+
+} // namespace ztfs
+
+#ifdef ZTFS_POSIX
+// ---------------------------------------------------------------------------
+// POSIX backend (Apple + forced test builds): no libc++ filesystem dependency.
+// ---------------------------------------------------------------------------
+#include <dirent.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <cstdio>
+
+namespace ztfs {
+
+std::string current_path() {
+    char buf[4096];
+    if (getcwd(buf, sizeof(buf)) == nullptr) return "";
+    return std::string(buf);
+}
+
+bool set_current_path(const std::string &p) {
+    return chdir(p.c_str()) == 0;
+}
+
+bool exists(const std::string &p) {
+    struct stat st;
+    return stat(p.c_str(), &st) == 0;
+}
+
+bool is_directory(const std::string &p) {
+    struct stat st;
+    if (stat(p.c_str(), &st) != 0) return false;
+    return S_ISDIR(st.st_mode);
+}
+
+std::vector<DirEntry> list_directory(const std::string &dir) {
+    std::vector<DirEntry> out;
+    DIR *d = opendir(dir.c_str());
+    if (!d) return out;
+    struct dirent *de;
+    while ((de = readdir(d)) != nullptr) {
+        const std::string name = de->d_name;
+        if (name == "." || name == "..") continue;
+        DirEntry e;
+        e.name = name;
+        e.path = join(dir, name);
+        struct stat st;                 // stat() follows symlinks, matching directory_entry
+        if (stat(e.path.c_str(), &st) == 0) {
+            e.is_directory = S_ISDIR(st.st_mode);
+            e.is_regular_file = S_ISREG(st.st_mode);
+        }
+        out.push_back(std::move(e));
+    }
+    closedir(d);
+    return out;
+}
+
+bool remove(const std::string &p) {
+    return ::remove(p.c_str()) == 0;
+}
+
+bool rename(const std::string &from, const std::string &to) {
+    return ::rename(from.c_str(), to.c_str()) == 0;
+}
+
+bool is_root_directory(const std::string &p) {
+    if (!is_directory(p)) return false;
+    return p == "/";
+}
+
+} // namespace ztfs
+
+#else
+// ---------------------------------------------------------------------------
+// std::filesystem backend (Linux + Windows): behaviour unchanged from before.
+// ---------------------------------------------------------------------------
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+namespace ztfs {
+
+std::string current_path() {
+    std::error_code ec;
+    fs::path p = fs::current_path(ec);
+    return ec ? std::string() : p.string();
+}
+
+bool set_current_path(const std::string &p) {
+    std::error_code ec;
+    fs::current_path(p, ec);
+    return !ec;
+}
+
+bool exists(const std::string &p) {
+    std::error_code ec;
+    return fs::exists(p, ec);
+}
+
+bool is_directory(const std::string &p) {
+    std::error_code ec;
+    return fs::is_directory(p, ec);
+}
+
+std::vector<DirEntry> list_directory(const std::string &dir) {
+    std::vector<DirEntry> out;
+    std::error_code ec;
+    for (const auto &entry : fs::directory_iterator(dir, ec)) {
+        if (ec) break;
+        DirEntry e;
+        e.name = entry.path().filename().string();
+        e.path = entry.path().string();
+        std::error_code ec2;
+        e.is_directory = entry.is_directory(ec2);
+        e.is_regular_file = entry.is_regular_file(ec2);
+        out.push_back(std::move(e));
+    }
+    return out;
+}
+
+bool remove(const std::string &p) {
+    std::error_code ec;
+    return fs::remove(p, ec) && !ec;
+}
+
+bool rename(const std::string &from, const std::string &to) {
+    std::error_code ec;
+    fs::rename(from, to, ec);
+    return !ec;
+}
+
+bool is_root_directory(const std::string &p) {
+    std::error_code ec;
+    if (!fs::exists(p, ec) || !fs::is_directory(p, ec)) return false;
+    fs::path path(p);
+    return path == path.root_path();
+}
+
+} // namespace ztfs
+
+#endif

--- a/src/fs_compat.cpp
+++ b/src/fs_compat.cpp
@@ -1,6 +1,21 @@
 #include "fs_compat.h"
 
-#if defined(__APPLE__) || defined(ZTFS_FORCE_POSIX)
+#if defined(__APPLE__)
+#include <Availability.h>   // __MAC_OS_X_VERSION_MIN_REQUIRED (the deployment target)
+#endif
+
+// Use the POSIX backend only when std::filesystem is genuinely unavailable, so
+// modern builds get the standard library and ztfs is purely the old-floor
+// fallback (addresses cmicali's review note):
+//   * Apple with a deployment target below macOS 10.15 -- libc++ marks
+//     std::filesystem _unavailable_ before Catalina, so an older floor (e.g.
+//     the 10.13 universal build) cannot link it. A target >= 10.15 falls
+//     through to std::filesystem, exactly like Linux and Windows.
+//   * Or when forced for the test build (ZTFS_FORCE_POSIX, run on Linux CI),
+//     so the POSIX path never rots untested.
+#if defined(ZTFS_FORCE_POSIX) || \
+    (defined(__APPLE__) && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || \
+                            __MAC_OS_X_VERSION_MIN_REQUIRED < 101500))
 #define ZTFS_POSIX 1
 #endif
 

--- a/src/fs_compat.h
+++ b/src/fs_compat.h
@@ -1,0 +1,51 @@
+#pragma once
+
+// Minimal filesystem facade so the codebase does not call std::filesystem
+// directly. On Apple, std::filesystem is annotated _unavailable_ below macOS
+// 10.15 (libc++ ships the symbols only from Catalina on), which would pin the
+// deployment floor at 10.15 and block High Sierra / Mojave. This facade is
+// implemented with POSIX (opendir/stat/getcwd/...) on Apple so the floor drops
+// to SDL3's own 10.13, and with std::filesystem everywhere else so Linux and
+// Windows behaviour is unchanged. See fs_compat.cpp.
+//
+// SDL-free and exception-free: every call reports failure by return value, so
+// it is safe in the unit-test harness (ZT_TEST_NO_SDL) and in the headless
+// renderer. The POSIX path is also exercised on Linux CI via -DZTFS_FORCE_POSIX
+// (see tests/test_fs_compat.cpp) so it never rots untested.
+
+#include <string>
+#include <vector>
+
+namespace ztfs {
+
+struct DirEntry {
+    std::string name;            // filename component only ("colors.conf")
+    std::string path;            // dir joined with name, matching std::filesystem
+    bool is_directory = false;
+    bool is_regular_file = false;
+};
+
+// Current working directory. current_path() returns "" on failure;
+// set_current_path() returns false on failure. Neither throws.
+std::string current_path();
+bool set_current_path(const std::string &p);
+
+bool exists(const std::string &p);
+bool is_directory(const std::string &p);
+
+// Directory listing. Skips "." and ".." (like std::filesystem::directory_iterator).
+// Returns an empty vector on any error (a non-existent or unreadable directory),
+// never throws. is_directory / is_regular_file follow symlinks, matching
+// directory_entry's default behaviour.
+std::vector<DirEntry> list_directory(const std::string &dir);
+
+bool remove(const std::string &p);                              // unlink a file; false on failure
+bool rename(const std::string &from, const std::string &to);    // false on failure
+
+// Path string helpers (lexical only — no disk access).
+std::string filename(const std::string &p);   // component after the last separator
+std::string extension(const std::string &p);  // ".ext" including the dot, or "" (a leading-dot name has none)
+std::string join(const std::string &a, const std::string &b);
+bool is_root_directory(const std::string &p);  // exists, is a directory, and equals the filesystem root
+
+} // namespace ztfs

--- a/src/fs_compat.h
+++ b/src/fs_compat.h
@@ -3,10 +3,12 @@
 // Minimal filesystem facade so the codebase does not call std::filesystem
 // directly. On Apple, std::filesystem is annotated _unavailable_ below macOS
 // 10.15 (libc++ ships the symbols only from Catalina on), which would pin the
-// deployment floor at 10.15 and block High Sierra / Mojave. This facade is
-// implemented with POSIX (opendir/stat/getcwd/...) on Apple so the floor drops
-// to SDL3's own 10.13, and with std::filesystem everywhere else so Linux and
-// Windows behaviour is unchanged. See fs_compat.cpp.
+// deployment floor at 10.15 and block High Sierra / Mojave. So this facade has
+// a POSIX backend (opendir/stat/getcwd/...) selected ONLY when std::filesystem
+// is unavailable -- i.e. an Apple build whose deployment target is below 10.15
+// (the 10.13 universal build) -- which drops the floor to SDL3's own 10.13.
+// Every other build (Linux, Windows, and Apple targeting >= 10.15) uses
+// std::filesystem unchanged. See the gate at the top of fs_compat.cpp.
 //
 // SDL-free and exception-free: every call reports failure by return value, so
 // it is safe in the unit-test harness (ZT_TEST_NO_SDL) and in the headless

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,7 @@
 #include <cmath>
 #include <ctime>
 #include <algorithm>
-#include <filesystem>
+#include "fs_compat.h"
 #include <mutex>
 #include <unordered_map>
 #include <vector>
@@ -2568,7 +2568,7 @@ int postAction ()
 	static char tt[256];
     conf DeviceConfig((char *)"devices.conf");
 
-    std::filesystem::current_path(cur_dir);
+    ztfs::set_current_path(cur_dir);
     for (i=0;i<MAX_MIDI_OUTS;i++) {
         sprintf(name,"open_out_device_%d",i);
         DeviceConfig.remove(&name[0]);
@@ -3184,12 +3184,9 @@ static int zt_autosave_now(void)
         return 0;
     }
 
-    std::error_code ec;
-    std::filesystem::remove(autosave_file, ec);
-    ec.clear();
-    std::filesystem::rename(autosave_tmp_file, autosave_file, ec);
-    if (ec) {
-        ZT_DEBUG_LOG("[autosave] rename failed: %s\n", ec.message().c_str());
+    ztfs::remove(autosave_file);
+    if (!ztfs::rename(autosave_tmp_file, autosave_file)) {
+        ZT_DEBUG_LOG("[autosave] rename failed\n");
         return 0;
     }
 
@@ -3217,33 +3214,28 @@ static std::string zt_make_autosave_filename(void)
 
 static void zt_prune_autosaves(size_t keep_count)
 {
-    std::vector<std::filesystem::path> autosaves;
-    std::error_code ec;
-    const std::filesystem::path cwd = std::filesystem::current_path(ec);
-    if (ec) {
+    const std::string cwd = ztfs::current_path();
+    if (cwd.empty()) {
         return;
     }
 
-    for (const auto &entry : std::filesystem::directory_iterator(cwd, ec)) {
-        if (ec) {
-            return;
-        }
-        if (!entry.is_regular_file()) {
+    std::vector<ztfs::DirEntry> autosaves;
+    for (auto &entry : ztfs::list_directory(cwd)) {
+        if (!entry.is_regular_file) {
             continue;
         }
-        const std::string fn = entry.path().filename().string();
+        const std::string &fn = entry.name;
         if (fn.rfind("__autosave_", 0) == 0 && fn.size() > 13 && fn.substr(fn.size() - 3) == ".zt") {
-            autosaves.push_back(entry.path());
+            autosaves.push_back(std::move(entry));
         }
     }
 
-    std::sort(autosaves.begin(), autosaves.end(), [](const std::filesystem::path &a, const std::filesystem::path &b) {
-        return a.filename().string() > b.filename().string();
+    std::sort(autosaves.begin(), autosaves.end(), [](const ztfs::DirEntry &a, const ztfs::DirEntry &b) {
+        return a.name > b.name;
     });
 
     for (size_t i = keep_count; i < autosaves.size(); ++i) {
-        std::filesystem::remove(autosaves[i], ec);
-        ec.clear();
+        ztfs::remove(autosaves[i].path);
     }
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,22 @@ target_compile_definitions(test_keybuffer PRIVATE ZT_TEST_NO_SDL)
 target_compile_features(test_keybuffer PRIVATE cxx_std_17)
 add_test(NAME keybuffer COMMAND test_keybuffer)
 
+# Filesystem facade (src/fs_compat.cpp). Built with -DZTFS_FORCE_POSIX so the
+# POSIX backend Apple ships (to keep the deployment floor at 10.13 rather than
+# std::filesystem's 10.15) is exercised on Linux/macOS CI, not only on a Mac.
+# Not built on Windows -- the POSIX backend needs <dirent.h>/<unistd.h>; Windows
+# keeps the std::filesystem backend it has always used.
+if(NOT WIN32)
+    add_executable(test_fs_compat
+        test_fs_compat.cpp
+        "${CMAKE_SOURCE_DIR}/src/fs_compat.cpp"
+    )
+    target_include_directories(test_fs_compat PRIVATE "${CMAKE_SOURCE_DIR}/src")
+    target_compile_definitions(test_fs_compat PRIVATE ZTFS_FORCE_POSIX)
+    target_compile_features(test_fs_compat PRIVATE cxx_std_17)
+    add_test(NAME fs_compat COMMAND test_fs_compat)
+endif()
+
 # CCizer parser, sidecar, MIDI byte builder, folder resolution. Pure C/C++
 # (no SDL). The test pulls ccizer.cpp in via #include so the same translation
 # unit lands in the test binary; no need to add it to the source list.

--- a/tests/test_fs_compat.cpp
+++ b/tests/test_fs_compat.cpp
@@ -1,0 +1,157 @@
+// Unit tests for src/fs_compat.cpp.
+//
+// Compiled with -DZTFS_FORCE_POSIX so the POSIX backend (the one Apple ships,
+// to keep the deployment floor at 10.13 instead of std::filesystem's 10.15) is
+// exercised here on Linux/macOS CI -- not just on a developer's Mac. Not built
+// on Windows (the POSIX backend needs <dirent.h>/<unistd.h>); the std::filesystem
+// backend Windows uses is the same one it has always used.
+
+#include "fs_compat.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <algorithm>
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+static int g_failures = 0;
+static int g_checks = 0;
+
+#define CHECK(cond)                                                            \
+    do {                                                                       \
+        ++g_checks;                                                            \
+        if (!(cond)) {                                                         \
+            std::printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond);        \
+            ++g_failures;                                                      \
+        }                                                                      \
+    } while (0)
+
+static void write_file(const std::string &path, const char *contents) {
+    FILE *f = std::fopen(path.c_str(), "wb");
+    if (f) {
+        std::fputs(contents, f);
+        std::fclose(f);
+    }
+}
+
+static bool has_entry(const std::vector<ztfs::DirEntry> &v, const std::string &name) {
+    return std::any_of(v.begin(), v.end(),
+                       [&](const ztfs::DirEntry &e) { return e.name == name; });
+}
+
+static const ztfs::DirEntry *find_entry(const std::vector<ztfs::DirEntry> &v,
+                                        const std::string &name) {
+    for (const auto &e : v)
+        if (e.name == name) return &e;
+    return nullptr;
+}
+
+int main() {
+    // --- lexical helpers (no disk) -------------------------------------------
+    CHECK(ztfs::filename("/a/b/c.txt") == "c.txt");
+    CHECK(ztfs::filename("c.txt") == "c.txt");
+    CHECK(ztfs::filename("/a/b/") == "");
+    CHECK(ztfs::extension("song.zt") == ".zt");
+    CHECK(ztfs::extension("a.tar.gz") == ".gz");
+    CHECK(ztfs::extension("noext") == "");
+    CHECK(ztfs::extension(".hidden") == "");      // leading dot is not an extension
+    CHECK(ztfs::extension("/a/b/song.IT") == ".IT");
+    CHECK(ztfs::join("/a/b", "c") == "/a/b/c");
+    CHECK(ztfs::join("/a/b/", "c") == "/a/b/c");  // no doubled separator
+    CHECK(ztfs::join(".", "x") == "./x");
+    CHECK(ztfs::join("", "c") == "c");
+    CHECK(ztfs::join("/a", "") == "/a");
+
+    // --- build a scratch tree ------------------------------------------------
+    char tmpl[] = "/tmp/ztfs_test_XXXXXX";
+    char *base = mkdtemp(tmpl);
+    CHECK(base != nullptr);
+    if (!base) {
+        std::printf("could not create temp dir; aborting\n");
+        return 1;
+    }
+    const std::string root = base;
+
+    const std::string saved_cwd = ztfs::current_path();
+    CHECK(!saved_cwd.empty());
+
+    // cwd round-trip
+    CHECK(ztfs::set_current_path(root));
+    // macOS resolves /tmp -> /private/tmp, so compare via a sentinel file
+    // rather than string-equality of current_path().
+    write_file("cwd_probe", "x");
+    CHECK(ztfs::exists("cwd_probe"));
+
+    // files + subdirs
+    write_file(ztfs::join(root, "song.zt"), "data");
+    write_file(ztfs::join(root, "tune.it"), "data");
+    write_file(ztfs::join(root, "readme"), "data");
+    CHECK(mkdir(ztfs::join(root, "skins").c_str(), 0755) == 0);
+    write_file(ztfs::join(ztfs::join(root, "skins"), "colors.conf"), "data");
+
+    // --- exists / is_directory ----------------------------------------------
+    CHECK(ztfs::exists(ztfs::join(root, "song.zt")));
+    CHECK(!ztfs::exists(ztfs::join(root, "does_not_exist")));
+    CHECK(ztfs::is_directory(ztfs::join(root, "skins")));
+    CHECK(!ztfs::is_directory(ztfs::join(root, "song.zt")));
+    CHECK(!ztfs::is_directory(ztfs::join(root, "nope")));
+
+    // --- list_directory ------------------------------------------------------
+    auto entries = ztfs::list_directory(root);
+    CHECK(!has_entry(entries, "."));      // never yields . or ..
+    CHECK(!has_entry(entries, ".."));
+    CHECK(has_entry(entries, "song.zt"));
+    CHECK(has_entry(entries, "skins"));
+    CHECK(has_entry(entries, "cwd_probe"));
+
+    const ztfs::DirEntry *song = find_entry(entries, "song.zt");
+    CHECK(song != nullptr);
+    if (song) {
+        CHECK(song->is_regular_file);
+        CHECK(!song->is_directory);
+        CHECK(song->path == ztfs::join(root, "song.zt"));
+    }
+    const ztfs::DirEntry *skins = find_entry(entries, "skins");
+    CHECK(skins != nullptr);
+    if (skins) {
+        CHECK(skins->is_directory);
+        CHECK(!skins->is_regular_file);
+    }
+
+    // listing a non-existent directory yields empty, no throw/crash
+    CHECK(ztfs::list_directory(ztfs::join(root, "nope")).empty());
+
+    // --- remove / rename -----------------------------------------------------
+    const std::string a = ztfs::join(root, "to_rename");
+    const std::string b = ztfs::join(root, "renamed");
+    write_file(a, "data");
+    CHECK(ztfs::exists(a));
+    CHECK(ztfs::rename(a, b));
+    CHECK(!ztfs::exists(a));
+    CHECK(ztfs::exists(b));
+    CHECK(ztfs::remove(b));
+    CHECK(!ztfs::exists(b));
+    CHECK(!ztfs::remove(ztfs::join(root, "already_gone")));  // false, no throw
+
+    // --- is_root_directory ---------------------------------------------------
+    CHECK(ztfs::is_root_directory("/"));
+    CHECK(!ztfs::is_root_directory(root));
+    CHECK(!ztfs::is_root_directory(ztfs::join(root, "song.zt")));
+
+    // --- clean up ------------------------------------------------------------
+    ztfs::set_current_path(saved_cwd);
+    ztfs::remove(ztfs::join(root, "song.zt"));
+    ztfs::remove(ztfs::join(root, "tune.it"));
+    ztfs::remove(ztfs::join(root, "readme"));
+    ztfs::remove(ztfs::join(root, "cwd_probe"));
+    ztfs::remove(ztfs::join(ztfs::join(root, "skins"), "colors.conf"));
+    rmdir(ztfs::join(root, "skins").c_str());
+    rmdir(root.c_str());
+
+    std::printf("%s: %d checks, %d failures\n",
+                g_failures == 0 ? "PASS" : "FAIL", g_checks, g_failures);
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Makes the macOS build a **single universal binary** (Intel x86_64 + Apple Silicon arm64) and drops the deployment floor from **macOS 15.0 → 10.13 (High Sierra)** on the Intel slice / **11.0 (Big Sur)** on the Apple Silicon slice. The `.app` is now self-contained (SDL3 bundled), so it runs on High Sierra, Mojave, Catalina, and everything newer — Intel and Apple Silicon — with no Homebrew/system SDL3 required.

> Why it said "Requires macOS 15.0": nothing in the code needed 15.0. The Finder line came straight from the Mach-O `minos` load command, driven by build choices — not source.

## Root cause (three independent pins, all fixed)

1. **No deployment target.** CMake set neither `CMAKE_OSX_DEPLOYMENT_TARGET` nor `CMAKE_OSX_ARCHITECTURES`, so the binary inherited the builder's SDK default (15.0) and host arch (arm64 only).
   → Pin `CMAKE_OSX_DEPLOYMENT_TARGET=10.13` **before `project()`** (after is too late — the flag must be baked into every object). arm64 is auto-clamped to 11.0 by the linker (no arm64 below Big Sur).
2. **Homebrew SDL3** is `minos 15.0` and single-arch, and wasn't even bundled (the shipped app linked `/opt/homebrew/...`).
   → CI builds a **universal SDL3 from source at 10.13**; an explicit `SDL3_LIBRARY` now **overrides pkg-config** (otherwise a stray Homebrew `sdl3.pc` silently wins and pulls in its single-arch dylib, which fails the universal link). SDL3 is bundled into `Contents/Frameworks` (`cmake/bundle_sdl3_macos.cmake`: copy → rewrite install names → add rpath → ad-hoc re-sign).
3. **`std::filesystem`** is marked unavailable below 10.15 by libc++ (`error: 'current_path' is unavailable: introduced in macOS 10.15`).
   → All `std::filesystem` use is routed through a POSIX facade `src/fs_compat.{h,cpp}` (`ztfs::`) on Apple. **Linux and Windows keep their `std::filesystem` path byte-for-byte unchanged.** The POSIX backend is also compiled+tested on Linux CI (`-DZTFS_FORCE_POSIX`) so Apple's path never rots untested.

Ableton Link is header-only, so it compiles directly into both slices — verified building universal at 10.13 with Link ON.

## What's in here

- `src/fs_compat.{h,cpp}` + `tests/test_fs_compat.cpp` (new `fs_compat` suite), and the migration of the 4 files that used `std::filesystem` (`main.cpp`, `FileList.cpp`, `CUI_PaletteEditor.cpp`, `UserInterface.cpp`).
- `CMakeLists.txt`: 10.13 default target, `SDL3_LIBRARY`-over-pkg-config, `ZT_MACOS_BUNDLE_SDL3` (default ON), `LSMinimumSystemVersion` stamping.
- `cmake/bundle_sdl3_macos.cmake`: robust self-contained bundling (handles Homebrew-absolute and from-source-`@rpath`).
- CI: the two single-arch macOS jobs collapse into one **universal** job that builds SDL3 universal from source and **hard-gates** every run on: universal, per-slice floor 10.13/11.0, self-contained (no Homebrew leak), bundled SDL3 universal, valid ad-hoc signature, and renders headless.

## Test plan

Proven locally on an Apple Silicon Mac (every claim built, not theorized):

- [x] Universal build at 10.13: `vtool` shows **x86_64 → 10.13**, **arm64 → 11.0**; `lipo -archs` shows both.
- [x] `std::filesystem` floor confirmed empirically: 10.13 build *failed* on `current_path`/`remove`/`rename` before the refactor; *passes* after.
- [x] Self-contained: `otool -L` shows only `@rpath/libSDL3.0.dylib` + system frameworks; bundled SDL3 is itself universal.
- [x] `codesign --verify --deep` valid after all install_name/plist edits.
- [x] Both slices render headless (arm64 native; x86_64 under Rosetta) — F11/F12 incl. the skin list (`SkinSelector::OnChange`, a refactored path) populates correctly.
- [x] `ctest`: **19/19 pass** (incl. new `fs_compat` and the end-to-end `lua_api`).
- [x] Dev path unchanged: a plain `cmake -G Ninja -B build` (Homebrew/pkg-config) still builds + bundles + passes all tests.

## Out of scope

El Capitan (10.11) and older: **not feasible with SDL3** (its own floor is 10.13). Would require an SDL2 backport.
