### PR TITLE
build: guard macOS XP cross-build against shipping a UCRT (non-XP) zt.exe

### DIFF
--- a/build-win32-macos.sh
+++ b/build-win32-macos.sh
@@ -143,6 +143,16 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 add_compile_definitions(_WIN32_WINNT=0x0501 WINVER=0x0501)
 # Static-link the MinGW C++/pthread runtime so zt.exe does not depend on
 # libwinpthread-1.dll / libgcc_s_*-1.dll / libstdc++-6.dll sitting next to it.
+#
+# NOTE: this produces an XP-RUNNABLE binary ONLY if the toolchain's C runtime
+# is legacy msvcrt. Homebrew's mingw-w64 is built --with-default-msvcrt=ucrt
+# and its libstdc++ is UCRT-coupled (e.g. <cstdlib> needs at_quick_exit), so it
+# emits a Universal-CRT binary that imports api-ms-win-crt-*.dll -- which DO NOT
+# EXIST on XP (launch dies: "api-ms-win-crt-...-l1-1-0.dll was not found"), and
+# it cannot be forced to msvcrt with -mcrtdll without breaking the libstdc++
+# build. The post-build guard below catches a UCRT binary and refuses to stage
+# it. CI's Ubuntu mingw-w64 defaults to msvcrt, so the guaranteed-good XP build
+# is the CI artifact ztrackerprime-windows-x86-xp (see guard message).
 add_link_options(-static -static-libgcc -static-libstdc++)
 EOF
 echo "[build-win32-macos] wrote $TOOLCHAIN_FILE"
@@ -164,6 +174,26 @@ cmake --build "$BUILD_DIR" --config Release -j
 EXE="$BUILD_DIR/Program/zt.exe"
 if [[ ! -f "$EXE" ]]; then
   echo "ERROR: build completed but $EXE not found." >&2
+  exit 1
+fi
+
+# Guard: a UCRT-linked binary imports api-ms-win-crt-*.dll and will NOT launch
+# on Windows XP. Refuse to stage one so it can never be silently deployed.
+OBJDUMP="${MINGW_PREFIX}-objdump"
+command -v "$OBJDUMP" >/dev/null 2>&1 || OBJDUMP=objdump
+# Capture imports into a variable and match with a pure-shell `case` (no pipe):
+# piping into `grep -q` makes grep close the pipe early, the producer takes
+# SIGPIPE, and `set -o pipefail` reports the pipeline as failed -- which would
+# silently skip this guard. A glob match avoids the pipe entirely.
+EXE_IMPORTS="$("$OBJDUMP" -p "$EXE" 2>/dev/null || true)"
+if [[ "$EXE_IMPORTS" == *api-ms-win-crt* ]]; then
+  echo "ERROR: $EXE imports api-ms-win-crt-*.dll (Universal CRT) and will NOT" >&2
+  echo "       run on Windows XP -- launch fails with" >&2
+  echo "       'api-ms-win-crt-...-l1-1-0.dll was not found'." >&2
+  echo "       This Homebrew mingw-w64 is UCRT-default and cannot target legacy" >&2
+  echo "       msvcrt. For a guaranteed-good XP binary, pull the CI artifact:" >&2
+  echo "         gh run download --repo m6502/ztrackerprime \\" >&2
+  echo "           --name ztrackerprime-windows-x86-xp -D dist/ztrackerprime-windows-x86-xp" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
`build-win32-macos.sh` could silently produce a Windows `zt.exe` that **does not launch on Windows XP** — the symptom seen in the field was the box throwing:

> This application has failed to start because **api-ms-win-crt-convert-l1-1-1-0.dll** was not found.

## Root cause
`api-ms-win-crt-*.dll` are the **Universal CRT (UCRT)** forwarders — present on Win10/11, **absent on XP** (which only ships legacy `msvcrt.dll`). Homebrew's `mingw-w64` is configured `--with-default-msvcrt=ucrt` and its `libstdc++` is UCRT-coupled, so the default link emits a UCRT binary (~15 MB, imports a dozen `api-ms-win-crt-*.dll`). A correct XP binary (~4 MB) imports `msvcrt.dll`.

`-mcrtdll=msvcrt-os` cannot rescue it: legacy-msvcrt headers lack `at_quick_exit`/`quick_exit` that libstdc++ `<cstdlib>` requires, so the compile fails. **Homebrew's toolchain simply can't target XP for this C++ app.** CI's Ubuntu `mingw-w64` defaults to legacy msvcrt, so the **CI artifact `ztrackerprime-windows-x86-xp` is the guaranteed-good XP binary.**

## Fix
- Add a **post-build guard**: inspect the linked imports; if any `api-ms-win-crt-*` is present, **refuse to stage** and point at the CI artifact (`gh run download … --name ztrackerprime-windows-x86-xp`).
- Document the UCRT-vs-msvcrt trap in the toolchain comment.
- The guard reads `objdump -p` into a variable and matches with a **pure-shell glob**, not `objdump | grep -q`: under `set -o pipefail`, `grep -q` closes the pipe early → producer takes SIGPIPE → pipeline reports failure → the check would be silently skipped. (Hit this exact bug twice while writing the guard.)

## Test plan
- [x] `bash -n build-win32-macos.sh` clean.
- [x] On Homebrew (UCRT-default) mingw: script builds then **aborts at staging** with the guidance message (exit 1) instead of shipping a broken exe.
- [x] `--help` still parses (exit 0).
- [x] CI artifact `zt.exe` verified: imports `msvcrt.dll` only, **no `api-ms-win-crt-*`** — deployed to the XP box and resolves the original launch error.
- [x] No CI impact — CI builds via `.github/workflows/build.yml`, not this script; on an msvcrt-default toolchain the guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)