### PR TITLE
midi-in: fix phantom duplicate device row (stray 0x01 in name) + hard freeze on device disable

### DIFF
--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -4,6 +4,22 @@ Legend
    +  - Feature add
    *  - Fix/change
 
+zt 2026_06_23 (MIDI In device list: duplicate-name fix + disable-hang fix)
+--------------------------------------------------------------------------
+
+        * MIDI In/Out device names are now sanitized: a stray control byte in a
+          driver-reported name (e.g. "Unitor In 01" followed by a 0x01 that
+          rendered as a smiley glyph) is stripped. Such a byte previously made
+          an otherwise-identical name compare unequal, spawning a phantom
+          duplicate row in the MIDI In Device Selection list. Stale device.conf
+          entries carrying the bad byte self-heal on load.
+
+        * Fixed a hard freeze when disabling a MIDI In device. Closing the
+          device calls midiInReset(), which returns the input buffer through
+          the MIDI-in callback; the callback then re-armed that buffer with
+          midiInAddBuffer() mid-reset, wedging the WinMM driver and hanging the
+          UI. The callback now skips re-arming while the device is closing.
+
 zt 2026_06_21 (Track properties, dynamic positioning fixes and improvements)
 ----------------------------------------------------------------------------
 

--- a/src/OutputDevices.cpp
+++ b/src/OutputDevices.cpp
@@ -47,8 +47,10 @@ MidiOutputDevice::MidiOutputDevice(int deviceIndex) {
     m_runningStatus = reverse_bank_select = 0;
     handle = NULL;
     type = OUTPUTDEVICE_TYPE_MIDI;
-    if (!midiOutGetDevCaps(deviceIndex, &caps, sizeof(MIDIOUTCAPS)))
+    if (!midiOutGetDevCaps(deviceIndex, &caps, sizeof(MIDIOUTCAPS))) {
+        zt_sanitize_device_name(caps.szPname);
         strcpy(szName, caps.szPname);
+    }
 }
 MidiOutputDevice::~MidiOutputDevice() {
     close();

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -67,6 +67,14 @@ static void zt_collect_known_device_names(const char *prefix, std::set<std::stri
         while (!value.empty() && (value.front() == ' ' || value.front() == '\t')) value.erase(value.begin());
         while (!value.empty() && (value.back() == '\r' || value.back() == '\n' || value.back() == ' ' || value.back() == '\t')) value.pop_back();
 
+        // Truncate at the first control byte so a stale config carrying a
+        // stray 0x01 (e.g. "Unitor In 01\x01") self-heals to a clean name
+        // and collapses into its non-corrupt twin instead of spawning a
+        // phantom duplicate row.
+        std::string::size_type ctrl = 0;
+        while (ctrl < value.size() && (unsigned char)value[ctrl] >= 0x20) ctrl++;
+        value.erase(ctrl);
+
         if (key.rfind(key_prefix, 0) == 0 && !value.empty()) {
             out_names.insert(value);
         }

--- a/src/midi-io.cpp
+++ b/src/midi-io.cpp
@@ -431,7 +431,11 @@ void CALLBACK midiInCallback(HMIDIIN handle, UINT uMsg, DWORD_PTR dwInstance, DW
                     }
                 }
             }
-            midiInAddBuffer(handle, lpMIDIHeader, sizeof(MIDIHDR));
+            // Don't re-arm while the device is closing: midiInReset() returns
+            // this buffer to us via this very callback, and re-adding it mid-
+            // reset wedges the driver and hangs the UI on device disable.
+            if (dev && !dev->closing.load())
+                midiInAddBuffer(handle, lpMIDIHeader, sizeof(MIDIHDR));
             break;
         }
 
@@ -513,7 +517,7 @@ void CALLBACK midiInCallback(HMIDIIN handle, UINT uMsg, DWORD_PTR dwInstance, DW
               dev->SysXFlag = 0;
               dev->SysXAccumLen = 0;
           }
-          if (lpHdr) {
+          if (lpHdr && dev && !dev->closing.load()) {
               midiInAddBuffer(handle, lpHdr, sizeof(MIDIHDR));
           }
           break;
@@ -533,6 +537,15 @@ intlist::intlist(int k, intlist *n) {
 intlist::~intlist() {
 }
 
+void zt_sanitize_device_name(char *s) {
+    if (!s) return;
+    for (char *p = s; *p; ++p) {
+        if ((unsigned char)*p < 0x20) { *p = '\0'; break; }
+    }
+    size_t n = strlen(s);
+    while (n > 0 && (s[n - 1] == ' ' || s[n - 1] == '\t')) s[--n] = '\0';
+}
+
 midiInDevice::midiInDevice(int i) {
     devNum = i;
     szName = NULL;
@@ -540,8 +553,10 @@ midiInDevice::midiInDevice(int i) {
     opened = 0;
     SysXFlag = 0;
     SysXAccumLen = 0;
-    if (!midiInGetDevCaps(i, &caps, sizeof(MIDIINCAPS)))
+    if (!midiInGetDevCaps(i, &caps, sizeof(MIDIINCAPS))) {
+        zt_sanitize_device_name(caps.szPname);
         szName = caps.szPname;
+    }
 }
 
 midiInDevice::~midiInDevice(void) {
@@ -569,16 +584,20 @@ int midiInDevice::close(void) {
 //    char buffer[30000];
     unsigned long err;
     if (opened) {
+        // Tell the callback thread to stop re-arming the SysEx buffer while
+        // we drain it; re-adding a buffer mid-reset wedges the WinMM driver.
+        closing = true;
         //midiInStop(handle);
         midiInReset(handle);
         midiInUnprepareHeader(handle, &midiHdr, sizeof(MIDIHDR));
         err = midiInClose(handle);
         (void)err;
         //err = midiInGetErrorText(err, &buffer[0], 30000);
-        handle = NULL; 
+        handle = NULL;
         opened = 0;
+        closing = false;
         return 0;
-         
+
     }
 /*  if (!(err = midiInGetErrorText(err, &buffer[0], 30000)))
     {

--- a/src/midi-io.h
+++ b/src/midi-io.h
@@ -1,9 +1,17 @@
 #ifndef _MIDI_DEVICE_H
 #define _MIDI_DEVICE_H
 
+#include <atomic>
 #include <mutex>
 
 #include "winmm_compat.h"
+
+// Truncate a MIDI device name at the first control character and trim trailing
+// whitespace, in place. Drivers (and stale config) occasionally hand us names
+// with a stray control byte (e.g. 0x01) that renders as a garbage glyph and,
+// worse, makes an otherwise-identical name compare unequal -- spawning a
+// phantom duplicate row in the device list.
+void zt_sanitize_device_name(char *s);
 
 #define NB_OFF    0x000000
 #define NB_ON     0x010000
@@ -458,7 +466,12 @@ class midiInDevice {
         char *szName;
         int devNum;
         MIDIINCAPS caps;                      // The MIDIINCAPS structure describes the capabilities of a MIDI input device.
-        int opened;     
+        int opened;
+        // Set true on the main thread for the duration of close() so the
+        // MIDI-in callback (other thread) stops re-arming the SysEx buffer
+        // while midiInReset()/midiInClose() are draining it -- re-adding a
+        // buffer mid-reset wedges the WinMM driver and hangs the UI.
+        std::atomic<bool> closing{false};
 
         MIDIHDR         midiHdr;              // The MIDIHDR structure defines the header used to identify a MIDI system-exclusive or stream buffer.
         // 8 KB matches ZT_SYSEX_MAX_LEN in sysex_inq.h. The previous


### PR DESCRIPTION
## Symptom (reported on a Unitor 8 / Windows XP)
> see how unitor in 01 is shown twice. i enabled one of them, the top one, and the second one with the laughy-face was enabled too. i then tried to disable the top one ... and the result was that ztracker became completely unresponsive.

Two independent bugs in **MIDI In Device Selection**.

## Bug 1 - phantom duplicate row + smiley glyph
The list is built from a `std::set<std::string>` merging live driver names with remembered `devices.conf` names. A driver- (or stale-config-) reported name can carry a trailing **control byte** - here `0x01`, which renders as a CP437 smiley. `"Unitor In 01"` and `"Unitor In 01\x01"` are then **distinct** set keys -> two rows, and the `zcmp` name-match resolves both to the same device index (so enabling one shows both checked).

**Fix:** add `zt_sanitize_device_name()` (truncate at first control byte, trim trailing whitespace) and apply it where MIDI In / MIDI Out names are read from `MIDIINCAPS`/`MIDIOUTCAPS`. `zt_collect_known_device_names()` also truncates at the first control byte, so a stale `devices.conf` self-heals and the corrupt twin collapses into the clean name.

## Bug 2 - hard freeze when disabling a device
Disable -> `RemDevice()` -> `close()` -> `midiInReset()`, which returns the queued input buffer **through the MIDI-in callback**. The callback then re-armed that buffer with `midiInAddBuffer()` **mid-reset**, re-queuing a buffer the driver is draining -> WinMM wedges -> UI thread hangs.

**Fix:** add an atomic `closing` flag on `midiInDevice`, set for the duration of `close()`, and skip `midiInAddBuffer` in the `MIM_LONGDATA` / `MIM_LONGERROR` callback paths while it is set. (Atomic, so the cross-thread read stays TSan-clean.)

## Test plan
- [x] Native macOS build clean; all **18** ctest suites green.
- [x] Name sanitizer truncates at first control byte + trims trailing whitespace; out-side (`MidiOutputDevice`) gets the same treatment.
- [x] `closing` flag is `std::atomic<bool>`, set/cleared around the `midiInReset`/`midiInClose` window.
- [ ] Hardware: confirm on the Unitor 8 / XP box that the list shows each port once (no smiley) and disabling a device no longer hangs. *(Deploying a branch build for the reporter to verify.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
