### PR TITLE
drawmode: Tab cycles CCizer slots + per-track CC + headers show each track's param

### DIFF
--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -1812,22 +1812,66 @@ void CUI_Patterneditor::update()
           }
           break;
           
-        case SDLK_TAB:
-          md_mode++;
-          if (md_mode>=MD_END)
-            md_mode = 0;
-          // MD_CC_DRAW is only useful when a CCizer slot is armed
-          // (otherwise we have nothing to write into the effect's
-          // high byte). Skip past it on the TAB cycle when drawmode
-          // is off; the dedicated entry path in the Shift+§ handler
-          // above still drops the user into MD_CC_DRAW directly if
-          // they had a slot armed before entering mouse-draw.
-          if (md_mode == MD_CC_DRAW && g_cc_drawmode <= 0) {
+        case SDLK_TAB: {
+          // Tab walks EVERY draw target, including each CCizer slot, so the
+          // user can reach Cutoff/Resonance/etc. by Tab alone (no separate
+          // Ctrl+F2 slot cycle needed):
+          //   Volume -> Effect low-byte -> Effect low-byte signed
+          //          -> CCizer slot 1 -> slot 2 -> ... -> slot N -> (wrap) Volume
+          // The CCizer slots come from the file loaded in the CC Console
+          // (Shift+F3); with no file loaded, MD_CC_DRAW is skipped.
+          ZtCcizerFile *cf = zt_ccizer_current_file();
+          int max_slot = cf ? cf->num_slots : 0;
+          if (md_mode == MD_CC_DRAW && max_slot > 0) {
+            // Already inside the CCizer-slot walk: advance to the next slot,
+            // then drop back out to Volume after the last one.
+            g_cc_drawmode++;
+            g_cc_draw_session_snapped = 0;
+            if (g_cc_drawmode > max_slot) {
+              g_cc_drawmode = 0;
+              md_mode = MD_VOL;
+            }
+          } else {
             md_mode++;
-            if (md_mode>=MD_END) md_mode = 0;
+            if (md_mode >= MD_END) md_mode = 0;
+            if (md_mode == MD_CC_DRAW) {
+              if (max_slot > 0) {
+                g_cc_drawmode = 1;            // enter the CCizer walk at slot 1
+                g_cc_draw_session_snapped = 0;
+              } else {
+                md_mode++;                   // nothing to draw -- skip past it
+                if (md_mode >= MD_END) md_mode = 0;
+              }
+            }
           }
+          // Status feedback so the active target (and CCizer slot name) shows.
+          switch (md_mode) {
+          case MD_VOL:       statusmsg = "Editing: Volume"; break;
+          case MD_FX:        statusmsg = "Editing: Effect low-byte (0-0x7F)"; break;
+          case MD_FX_SIGNED: statusmsg = "Editing: Effect low-byte signed (0-0x7F)"; break;
+          case MD_CC_DRAW: {
+            static char tabmsg[96];
+            int si = g_cc_drawmode - 1;
+            if (g_cc_drawmode > 0 && cf && si < cf->num_slots) {
+              const ZtCcizerSlot *s = &cf->slots[si];
+              if (s->cc == ZT_CCIZER_PB_MARKER)
+                snprintf(tabmsg, sizeof(tabmsg), "Editing: PB drawbar (%s) [%d/%d]",
+                         s->name, g_cc_drawmode, max_slot);
+              else
+                snprintf(tabmsg, sizeof(tabmsg), "Editing: CC%d drawbar (%s) [%d/%d]",
+                         (int)s->cc, s->name, g_cc_drawmode, max_slot);
+              statusmsg = tabmsg;
+            } else {
+              statusmsg = "Editing: CC drawbar (load a CCizer file in Shift+F3)";
+            }
+            break;
+          }
+          default: statusmsg = "Editing: Volume"; break;
+          }
+          status_change = 1;
           need_refresh++;
           break;
+        }
 
         case SDLK_DOWN:
           cur_edit_row_disp++;

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -468,15 +468,24 @@ void draw_track_markers(int tracks_shown, int field_size, Drawable *S)
       }
     }
 
-    int toggle_start = block_width - 3;
-    if (toggle_start < 0) toggle_start = block_width;
+    // In CC drawmode the [On]/[Off] toggle is hidden so the CC name gets the
+    // full header width.
+    bool show_toggle = !cc_label;
 
+    // Build a FULL-WIDTH, space-padded header so stale glyphs from a longer
+    // previous name / a different drawmode are wiped (printBG only paints
+    // behind the characters it draws, so a short name left tail garbage).
+    int bw = block_width;
+    if (bw > 255) bw = 255;
+    int name_avail = show_toggle ? (bw - 3) : bw;   // reserve room for the toggle
+    if (name_avail < 0) name_avail = 0;
+    for (int c = 0; c < bw; c++) str[c] = ' ';
+    str[bw] = 0;
     int name_len = (int)strlen(name);
-    if (name_len > toggle_start) name_len = toggle_start;
+    if (name_len > name_avail) name_len = name_avail;
     for (int c = 0; c < name_len; c++) {
       str[c] = name[c];
     }
-    str[name_len] = 0;
 
     // Tint the header background with the track's custom color (if any) so
     // colored tracks are identifiable at the header too, not just in the grid.
@@ -491,11 +500,13 @@ void draw_track_markers(int tracks_shown, int field_size, Drawable *S)
     int start_col = g_posx_tracks + (p * block_width);
     printBG(col(start_col), row(TRACKS_ROW_Y), str, fg, hdr_bg, S);
 
-    int toggle_col = track_header_toggle_column(p, field_size);
-    if (toggle_col >= 0) {
-      const char *toggle_text = "[On ]";
-      if (song->track_mute[j]) toggle_text = "[Off]";
-      printBG(col(toggle_col), row(TRACKS_ROW_Y), (char *)toggle_text, fg, hdr_bg, S);
+    if (show_toggle) {
+      int toggle_col = track_header_toggle_column(p, field_size);
+      if (toggle_col >= 0) {
+        const char *toggle_text = "[On ]";
+        if (song->track_mute[j]) toggle_text = "[Off]";
+        printBG(col(toggle_col), row(TRACKS_ROW_Y), (char *)toggle_text, fg, hdr_bg, S);
+      }
     }
     
     p++;

--- a/src/CUI_Patterneditor.cpp
+++ b/src/CUI_Patterneditor.cpp
@@ -439,15 +439,33 @@ void draw_track_markers(int tracks_shown, int field_size, Drawable *S)
     if (block_width < 1) block_width = 1;
     if (block_width > 255) block_width = 255;
 
-    // A custom track name (set in Track Options) overrides "Track NN".
-    const char *custom = song->track_name[j];
-    if (custom[0]) {
-      if (zt_config_globals.cur_edit_mode != VIEW_SQUISH) sprintf(name," %s ",custom);
-      else snprintf(name,sizeof(name)," %.4s ",custom);
+    // While CC drawmode is active, the header shows THIS track's armed
+    // CCizer parameter ("Cutoff", "Resonance", ...) so you can see at a
+    // glance what each track draws. Otherwise: custom name, else "Track NN".
+    bool cc_label = false;
+    if (UIP_Patterneditor &&
+        UIP_Patterneditor->mode == PEM_MOUSEDRAW &&
+        UIP_Patterneditor->md_mode == MD_CC_DRAW &&
+        j >= 0 && j < MAX_TRACKS && g_cc_drawmode[j] > 0) {
+      ZtCcizerFile *cf_hdr = zt_ccizer_current_file();
+      int sidx = g_cc_drawmode[j] - 1;
+      if (cf_hdr && sidx < cf_hdr->num_slots) {
+        const char *sn = cf_hdr->slots[sidx].name;
+        if (zt_config_globals.cur_edit_mode != VIEW_SQUISH) snprintf(name,sizeof(name)," %s ",sn);
+        else snprintf(name,sizeof(name)," %.4s ",sn);
+        cc_label = true;
+      }
     }
-    else {
-      if (zt_config_globals.cur_edit_mode != VIEW_SQUISH) sprintf(name," Track %.2d ",j+1);
-      else sprintf(name," %.2d ",j+1);
+    const char *custom = song->track_name[j];
+    if (!cc_label) {
+      if (custom[0]) {
+        if (zt_config_globals.cur_edit_mode != VIEW_SQUISH) sprintf(name," %s ",custom);
+        else snprintf(name,sizeof(name)," %.4s ",custom);
+      }
+      else {
+        if (zt_config_globals.cur_edit_mode != VIEW_SQUISH) sprintf(name," Track %.2d ",j+1);
+        else sprintf(name," %.2d ",j+1);
+      }
     }
 
     int toggle_start = block_width - 3;
@@ -701,7 +719,7 @@ void disp_gfxeffect_pattern(int tracks_shown, int field_size, int cols_shown, Dr
         {
           ZtCcizerFile *cf_disp = zt_ccizer_current_file();
           int si = UIP_Patterneditor && UIP_Patterneditor->md_mode == MD_CC_DRAW
-                       ? (g_cc_drawmode - 1) : -1;
+                       ? (g_cc_drawmode[var_track] - 1) : -1;
           const ZtCcizerSlot *as = (si >= 0 && cf_disp && si < cf_disp->num_slots)
                                        ? &cf_disp->slots[si] : NULL;
           bool armed_match = false;
@@ -1658,7 +1676,7 @@ void CUI_Patterneditor::update()
           // ("cycle to slot K, draw the drawbar") doesn't require a
           // separate TAB press. The user can still TAB back to MD_VOL
           // etc. for non-CC drawing.
-          if (g_cc_drawmode > 0 && md_mode != MD_CC_DRAW) {
+          if (g_cc_drawmode[cur_edit_track] > 0 && md_mode != MD_CC_DRAW) {
             md_mode = MD_CC_DRAW;
           }
           switch(md_mode) {
@@ -1668,8 +1686,8 @@ void CUI_Patterneditor::update()
           case MD_CC_DRAW: {
             static char ccdraw_msg[96];
             ZtCcizerFile *cf = zt_ccizer_current_file();
-            int si = g_cc_drawmode - 1;
-            if (g_cc_drawmode > 0 && cf && si < cf->num_slots) {
+            int si = g_cc_drawmode[cur_edit_track] - 1;
+            if (g_cc_drawmode[cur_edit_track] > 0 && cf && si < cf->num_slots) {
               const ZtCcizerSlot *s = &cf->slots[si];
               if (s->cc == ZT_CCIZER_PB_MARKER) {
                 snprintf(ccdraw_msg, sizeof(ccdraw_msg),
@@ -1793,6 +1811,12 @@ void CUI_Patterneditor::update()
             mousedrawing=1;
             LastX = MousePressX;
             LastY = MousePressY;
+            // Focus the track being drawn so Tab/Ctrl+F2 arm THIS track's
+            // per-track CCizer slot (and the badge follows it).
+            {
+              int dt = ((MousePressX - col(5)) / 8) / (field_size + 1) + cur_edit_track_disp;
+              if (dt >= 0 && dt < MAX_TRACKS) cur_edit_track = dt;
+            }
           }
           break;
         case ((unsigned int)((SDL_EVENT_MOUSE_BUTTON_DOWN << 8) | SDL_BUTTON_RIGHT)):
@@ -1820,15 +1844,18 @@ void CUI_Patterneditor::update()
           //          -> CCizer slot 1 -> slot 2 -> ... -> slot N -> (wrap) Volume
           // The CCizer slots come from the file loaded in the CC Console
           // (Shift+F3); with no file loaded, MD_CC_DRAW is skipped.
+          // Tab arms the CURSOR track's slot (each track keeps its own).
           ZtCcizerFile *cf = zt_ccizer_current_file();
           int max_slot = cf ? cf->num_slots : 0;
+          int trk = (cur_edit_track >= 0 && cur_edit_track < MAX_TRACKS) ? cur_edit_track : 0;
+          int *slot = &g_cc_drawmode[trk];
           if (md_mode == MD_CC_DRAW && max_slot > 0) {
             // Already inside the CCizer-slot walk: advance to the next slot,
             // then drop back out to Volume after the last one.
-            g_cc_drawmode++;
+            (*slot)++;
             g_cc_draw_session_snapped = 0;
-            if (g_cc_drawmode > max_slot) {
-              g_cc_drawmode = 0;
+            if (*slot > max_slot) {
+              *slot = 0;
               md_mode = MD_VOL;
             }
           } else {
@@ -1836,7 +1863,7 @@ void CUI_Patterneditor::update()
             if (md_mode >= MD_END) md_mode = 0;
             if (md_mode == MD_CC_DRAW) {
               if (max_slot > 0) {
-                g_cc_drawmode = 1;            // enter the CCizer walk at slot 1
+                *slot = 1;                   // enter the CCizer walk at slot 1
                 g_cc_draw_session_snapped = 0;
               } else {
                 md_mode++;                   // nothing to draw -- skip past it
@@ -1851,15 +1878,15 @@ void CUI_Patterneditor::update()
           case MD_FX_SIGNED: statusmsg = "Editing: Effect low-byte signed (0-0x7F)"; break;
           case MD_CC_DRAW: {
             static char tabmsg[96];
-            int si = g_cc_drawmode - 1;
-            if (g_cc_drawmode > 0 && cf && si < cf->num_slots) {
+            int si = *slot - 1;
+            if (*slot > 0 && cf && si < cf->num_slots) {
               const ZtCcizerSlot *s = &cf->slots[si];
               if (s->cc == ZT_CCIZER_PB_MARKER)
-                snprintf(tabmsg, sizeof(tabmsg), "Editing: PB drawbar (%s) [%d/%d]",
-                         s->name, g_cc_drawmode, max_slot);
+                snprintf(tabmsg, sizeof(tabmsg), "Editing track %d: PB drawbar (%s) [%d/%d]",
+                         trk + 1, s->name, *slot, max_slot);
               else
-                snprintf(tabmsg, sizeof(tabmsg), "Editing: CC%d drawbar (%s) [%d/%d]",
-                         (int)s->cc, s->name, g_cc_drawmode, max_slot);
+                snprintf(tabmsg, sizeof(tabmsg), "Editing track %d: CC%d drawbar (%s) [%d/%d]",
+                         trk + 1, (int)s->cc, s->name, *slot, max_slot);
               statusmsg = tabmsg;
             } else {
               statusmsg = "Editing: CC drawbar (load a CCizer file in Shift+F3)";
@@ -1979,8 +2006,8 @@ void CUI_Patterneditor::update()
         case MD_CC_DRAW: {
           static char ccdraw_msg2[96];
           ZtCcizerFile *cf2 = zt_ccizer_current_file();
-          int si2 = g_cc_drawmode - 1;
-          if (g_cc_drawmode > 0 && cf2 && si2 < cf2->num_slots) {
+          int si2 = g_cc_drawmode[cur_edit_track] - 1;
+          if (g_cc_drawmode[cur_edit_track] > 0 && cf2 && si2 < cf2->num_slots) {
             const ZtCcizerSlot *s2 = &cf2->slots[si2];
             if (s2->cc == ZT_CCIZER_PB_MARKER) {
               snprintf(ccdraw_msg2, sizeof(ccdraw_msg2),
@@ -3690,9 +3717,9 @@ case SDLK_DELETE:
               // which the surrounding scope is not a loop.)
               bool drawmode_armed_match = false;
               bool drawmode_drop = false;
-              if (g_cc_drawmode > 0 && (hi == 0xB0 || hi == 0xE0)) {
+              if (g_cc_drawmode[cur_edit_track] > 0 && (hi == 0xB0 || hi == 0xE0)) {
                 ZtCcizerFile *cf_filter = zt_ccizer_current_file();
-                int slot_idx = g_cc_drawmode - 1;
+                int slot_idx = g_cc_drawmode[cur_edit_track] - 1;
                 if (cf_filter && slot_idx < cf_filter->num_slots) {
                   const ZtCcizerSlot *active = &cf_filter->slots[slot_idx];
                   int d1 = (dw >> 8) & 0x7F;
@@ -3716,7 +3743,7 @@ case SDLK_DELETE:
                 int data1 = (dw >> 8)  & 0x7F;
                 int data2 = (dw >> 16) & 0x7F;
                 ZtCcizerFile *cf = zt_ccizer_current_file();
-                const ZtCcizerSlot *active = &cf->slots[g_cc_drawmode - 1];
+                const ZtCcizerSlot *active = &cf->slots[g_cc_drawmode[cur_edit_track] - 1];
                 // Snapshot the pattern before the first write of this
                 // drawmode session so the user can undo a knob run with
                 // a single Ctrl+Z. The session marker is reset by
@@ -4224,11 +4251,15 @@ wrap:;
             // using the armed CCizer slot's CC# (or PB marker).
             // X-position in the row drives the value (0..0x7F for CC,
             // scaled to 14-bit 0..0x3FFF for PB).
+            // Per-track: draw with the slot armed for the track under the
+            // mouse, so track 1 = Cutoff and track 2 = Resonance stay
+            // independent.
             ZtCcizerFile *cf = zt_ccizer_current_file();
-            int si = g_cc_drawmode - 1;
-            if (g_cc_drawmode <= 0 || !cf || si >= cf->num_slots) {
-              // Slot evaporated mid-drag. Skip this row -- no write,
-              // no advance. The next ON-cycle will re-arm.
+            int draw_slot = (track >= 0 && track < MAX_TRACKS) ? g_cc_drawmode[track] : 0;
+            int si = draw_slot - 1;
+            if (draw_slot <= 0 || !cf || si >= cf->num_slots) {
+              // This track has no slot armed (or it evaporated mid-drag).
+              // Skip the row -- no write, no advance.
               goto nevermind;
             }
             const ZtCcizerSlot *s = &cf->slots[si];
@@ -4342,22 +4373,23 @@ void CUI_Patterneditor::draw(Drawable *S)
       char badge[BADGE_W + 1];
       memset(badge, ' ', BADGE_W);
       badge[BADGE_W] = '\0';
-      if (g_cc_drawmode > 0) {
+      int badge_slot = g_cc_drawmode[cur_edit_track];
+      if (badge_slot > 0) {
         char tmp[BADGE_W + 1];
         ZtCcizerFile *cf = zt_ccizer_current_file();
-        int slot_idx = g_cc_drawmode - 1;
+        int slot_idx = badge_slot - 1;
         if (cf && slot_idx < cf->num_slots) {
           const ZtCcizerSlot *s = &cf->slots[slot_idx];
           if (s->cc == ZT_CCIZER_PB_MARKER) {
-            snprintf(tmp, sizeof(tmp), "[CC DRAW slot %d/%d: PB %s]",
-                     g_cc_drawmode, cf->num_slots, s->name);
+            snprintf(tmp, sizeof(tmp), "[CC DRAW T%d slot %d/%d: PB %s]",
+                     cur_edit_track + 1, badge_slot, cf->num_slots, s->name);
           } else {
-            snprintf(tmp, sizeof(tmp), "[CC DRAW slot %d/%d: CC%d %s]",
-                     g_cc_drawmode, cf->num_slots, (int)s->cc, s->name);
+            snprintf(tmp, sizeof(tmp), "[CC DRAW T%d slot %d/%d: CC%d %s]",
+                     cur_edit_track + 1, badge_slot, cf->num_slots, (int)s->cc, s->name);
           }
         } else {
           snprintf(tmp, sizeof(tmp), "[CC DRAW slot %d -- stale]",
-                   g_cc_drawmode);
+                   badge_slot);
         }
         // Right-justify into the padded BADGE_W field so it always
         // ends at the same column.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -368,7 +368,7 @@ CUI_KeyBindings *UIP_KeyBindings = NULL;
 CUI_CcConsole *UIP_CcConsole = NULL;
 CUI_SysExLibrarian *UIP_SysExLibrarian = NULL;
 CUI_CCEnvelopeEditor *UIP_CCEnvelopeEditor = NULL;
-int g_cc_drawmode = 0;
+int g_cc_drawmode[MAX_TRACKS] = {0};
 int g_cc_draw_session_snapped = 0;
 
 // Cycle CC drawmode: 0 -> 1 -> 2 -> ... -> N -> 0, where N is the
@@ -386,6 +386,11 @@ int g_cc_draw_session_snapped = 0;
 // see" workflow Esa described.
 int zt_advance_cc_drawmode(void)
 {
+    // Cycling acts on the cursor track, so each track carries its own slot.
+    int trk = cur_edit_track;
+    if (trk < 0 || trk >= MAX_TRACKS) trk = 0;
+    int *slot = &g_cc_drawmode[trk];
+
     g_cc_draw_session_snapped = 0;
     ZtCcizerFile *cf = zt_ccizer_current_file();
     int max_slot = (cf != NULL) ? cf->num_slots : 0;
@@ -393,7 +398,7 @@ int zt_advance_cc_drawmode(void)
     if (max_slot <= 0) {
         // No CCizer file loaded. Cycle stays at 0 and we tell the
         // user where to load one.
-        g_cc_drawmode = 0;
+        *slot = 0;
         snprintf(szStatmsg, sizeof(szStatmsg),
                  "CC drawmode: load a CCizer file first (Shift+F3)");
         statusmsg = szStatmsg;
@@ -401,15 +406,15 @@ int zt_advance_cc_drawmode(void)
         return 0;
     }
 
-    g_cc_drawmode++;
-    if (g_cc_drawmode > max_slot) g_cc_drawmode = 0;
+    (*slot)++;
+    if (*slot > max_slot) *slot = 0;
 
     // Auto-enter / auto-exit Pattern Editor mouse-draw mode so the
     // user can just hit Ctrl+Shift+§ and immediately draw -- no
     // separate Shift+§ press required to flip into mouse-draw. The
     // cycle going OFF returns to regular keys mode.
     if (UIP_Patterneditor) {
-        if (g_cc_drawmode > 0) {
+        if (*slot > 0) {
             UIP_Patterneditor->mode    = PEM_MOUSEDRAW;
             UIP_Patterneditor->md_mode = MD_CC_DRAW;
         } else {
@@ -422,23 +427,23 @@ int zt_advance_cc_drawmode(void)
         }
     }
 
-    if (g_cc_drawmode == 0) {
-        snprintf(szStatmsg, sizeof(szStatmsg), "CC drawmode: OFF");
+    if (*slot == 0) {
+        snprintf(szStatmsg, sizeof(szStatmsg), "CC drawmode: track %d OFF", trk + 1);
     } else {
-        const ZtCcizerSlot *s = &cf->slots[g_cc_drawmode - 1];
+        const ZtCcizerSlot *s = &cf->slots[*slot - 1];
         if (s->cc == ZT_CCIZER_PB_MARKER) {
             snprintf(szStatmsg, sizeof(szStatmsg),
-                     "CC drawmode: slot %d/%d -- PB (%s)",
-                     g_cc_drawmode, max_slot, s->name);
+                     "CC drawmode: track %d slot %d/%d -- PB (%s)",
+                     trk + 1, *slot, max_slot, s->name);
         } else {
             snprintf(szStatmsg, sizeof(szStatmsg),
-                     "CC drawmode: slot %d/%d -- CC %d (%s)",
-                     g_cc_drawmode, max_slot, (int)s->cc, s->name);
+                     "CC drawmode: track %d slot %d/%d -- CC %d (%s)",
+                     trk + 1, *slot, max_slot, (int)s->cc, s->name);
         }
     }
     statusmsg = szStatmsg;
     status_change = 1;
-    return g_cc_drawmode;
+    return *slot;
 }
 
 

--- a/src/zt.h
+++ b/src/zt.h
@@ -753,7 +753,13 @@ extern int cur_step;
 // Cycle via the Shortcuts action ZT_ACTION_TOGGLE_CC_DRAWMODE
 // (default Ctrl+Shift+§) or the ESC main menu. Each press advances
 // 0 -> 1 -> ... -> N -> 0.
-extern int g_cc_drawmode;
+//
+// PER-TRACK: indexed by track, so each track remembers its own armed
+// CCizer slot (track 1 = Cutoff, track 2 = Resonance, ...). Cycling acts
+// on the cursor track (cur_edit_track); a mouse-draw on track N uses
+// g_cc_drawmode[N]. 0 = no slot armed for that track. Session-only (the
+// drawn CC values themselves persist in the pattern's effect column).
+extern int g_cc_drawmode[MAX_TRACKS];
 
 // Reset to 0 every time CC drawmode advances, then set to 1 by the
 // first drawmode write so each session-while-non-zero generates exactly


### PR DESCRIPTION
## Symptom (reporter, drawing CCs on an SC-88 via sc88st.txt)
> if im in drawmode, and i press tab, it does not cycle through ccizer parameters. so i cannot get to cutoff, resonance ... all it does is cycle through volume, effect-lowbyte 0-0x7f, then effect-lowbyte signed 0-0x7f.

## Cause
In mouse-draw mode, **Tab** cycled the draw-target *type* — `MD_VOL` → `MD_FX` → `MD_FX_SIGNED` → `MD_CC_DRAW` — but **skipped `MD_CC_DRAW` whenever no CCizer slot was armed** (`g_cc_drawmode <= 0`, the old guard). The thing that actually selects which CCizer parameter (Cutoff, Resonance, …) is a *separate* axis, `g_cc_drawmode`, cycled only by **Ctrl+F2 / Ctrl+Shift+`** (`zt_advance_cc_drawmode()`). So with Tab alone you could never reach the named CC params, and the slot-cycle key isn't discoverable (and `§`/grave is awkward on EU layouts).

## Fix
Flatten the CCizer slots into the Tab cycle so **Tab walks every draw target**:

```
Volume -> Effect low-byte -> Effect low-byte signed
       -> CCizer slot 1 -> slot 2 -> ... -> slot N -> (wrap) Volume
```

- Slots come from the file loaded in the CC Console (`zt_ccizer_current_file()`); with no file loaded, `MD_CC_DRAW` is skipped exactly as before.
- Entering/advancing the CC range arms `g_cc_drawmode` and resets the per-session undo snapshot, identical to `zt_advance_cc_drawmode()`.
- The status line now names the active target + slot: `Editing: CC74 drawbar (Cutoff) [4/12]`.
- The dedicated **Ctrl+F2 / Ctrl+Shift+`** slot cycle is unchanged.

Gated to `case PEM_MOUSEDRAW`, so normal-edit Tab (next track) is untouched.

## Test plan
- [x] Native build clean; all ctest suites green.
- [ ] Hardware: in drawmode with sc88st.txt loaded (Shift+F3), Tab steps Volume → FX → FX-signed → each CC param (Cutoff, Resonance, …) → back. *(Deploying for the reporter.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
