### PR TITLE
macOS: native menu bar + fullscreen / HiDPI rendering improvements

### DIFF
--- a/src/CUI_MainMenu.cpp
+++ b/src/CUI_MainMenu.cpp
@@ -62,6 +62,7 @@ struct ResPreset {
 };
 static const ResPreset MM_RES_PRESETS[] = {
     // label                              W     H    zoom    internal    chars cell on-screen
+    { "Small      840x480  1.0x",       840,  480, 1.0f }, //  840x480     8 px
     { "Compact    1024x640  1.0x",     1024,  640, 1.0f }, //  1024x640    8 px
     { "Default    1280x800  1.0x",     1280,  800, 1.0f }, //  1280x800    8 px
     { "Medium     1440x900  1.5x",     1440,  900, 1.5f }, //   960x600   12 px
@@ -133,6 +134,37 @@ static void mm_res_2(void) { mm_apply_resolution(2); }
 static void mm_res_3(void) { mm_apply_resolution(3); }
 static void mm_res_4(void) { mm_apply_resolution(4); }
 static void mm_res_5(void) { mm_apply_resolution(5); }
+static void mm_res_6(void) { mm_apply_resolution(6); }
+
+// Hooks for the macOS menu bar (src/macos_menu.mm). They arm the SAME
+// deferred change the in-app Window Size menu uses, so a menu click applies
+// safely at the next frame (set_video_mode mid-frame would crash, see above).
+extern "C" void zt_view_apply_size_preset(int idx) {
+    mm_apply_resolution(idx);
+}
+
+// Let the macOS Size menu build itself from MM_RES_PRESETS so the two never
+// drift (e.g. when a preset is added).
+extern "C" int zt_view_size_preset_count(void) {
+    return MM_RES_PRESET_COUNT;
+}
+
+extern "C" const char *zt_view_size_preset_label(int idx) {
+    if (idx < 0 || idx >= MM_RES_PRESET_COUNT) return "";
+    return MM_RES_PRESETS[idx].label;
+}
+
+// Change only the zoom factor, keeping the current window dimensions.
+extern "C" void zt_view_apply_zoom(float zoom) {
+    g_pending_res.armed = true;
+    g_pending_res.w     = zt_config_globals.screen_width;
+    g_pending_res.h     = zt_config_globals.screen_height;
+    g_pending_res.zoom  = zoom;
+    snprintf(szStatmsg, sizeof(szStatmsg), "Setting zoom to %.2fx...", zoom);
+    statusmsg = szStatmsg;
+    status_change = 1;
+    need_refresh++;
+}
 
 // ----------------------------------------------------------------------
 // Functions that don't have a dedicated CMD_* enum. Implemented inline
@@ -286,12 +318,13 @@ static const mm_entry MM_ENTRIES[] = {
 
     {MM_SEPARATOR,  NULL,                       NULL,                   0,                          NULL},
     {MM_SUBHEADING, "Window Size & Zoom",       NULL,                   0,                          NULL},
-    {MM_FUNC,       MM_RES_PRESETS[0].label,    NULL,                   0,                          mm_res_0},
-    {MM_FUNC,       MM_RES_PRESETS[1].label,    NULL,                   0,                          mm_res_1},
-    {MM_FUNC,       MM_RES_PRESETS[2].label,    NULL,                   0,                          mm_res_2},
-    {MM_FUNC,       MM_RES_PRESETS[3].label,    NULL,                   0,                          mm_res_3},
-    {MM_FUNC,       MM_RES_PRESETS[4].label,    NULL,                   0,                          mm_res_4},
-    {MM_FUNC,       MM_RES_PRESETS[5].label,    NULL,                   0,                          mm_res_5},
+    {MM_FUNC,       MM_RES_PRESETS[0].label,         NULL,                   0,                          mm_res_0},
+    {MM_FUNC,       MM_RES_PRESETS[1].label,         NULL,                   0,                          mm_res_1},
+    {MM_FUNC,       MM_RES_PRESETS[2].label,         NULL,                   0,                          mm_res_2},
+    {MM_FUNC,       MM_RES_PRESETS[3].label,         NULL,                   0,                          mm_res_3},
+    {MM_FUNC,       MM_RES_PRESETS[4].label,         NULL,                   0,                          mm_res_4},
+    {MM_FUNC,       MM_RES_PRESETS[5].label,         NULL,                   0,                          mm_res_5},
+    {MM_FUNC,       MM_RES_PRESETS[6].label,         NULL,                   0,                          mm_res_6},
 
     {MM_SEPARATOR,  NULL,                       NULL,                   0,                          NULL},
     {MM_FUNC,       "Quit",                     "Ctrl+Q",               0,                          mm_quit},

--- a/src/macos_menu.mm
+++ b/src/macos_menu.mm
@@ -1,16 +1,127 @@
 // macos_menu.mm
 //
-// Strip the Cmd-Q key equivalent from the auto-created NSApp menu so that
-// Cmd-Q can be used as a Pattern Editor Transpose-Up shortcut (Cmd is
-// treated as Alt-equivalent via KS_HAS_ALT). Quit is still reachable from
-// the keyboard via Ctrl-Q (or Ctrl-Alt-Q) and from the macOS app-menu
-// click — only the keyboard shortcut on the menu item is cleared.
+// Builds zTracker's macOS menu bar (zTracker / File / Playback / Instruments /
+// Settings / Window). Each item injects the equivalent in-app keystroke through
+// the shared KeyBuffer, so a menu click takes the exact same path as pressing
+// the key — and each item's keyEquivalent shows (and triggers) that shortcut.
 //
-// Same treatment for Cmd-W: the Window menu's Close item would otherwise
-// dismiss the SDL window instead of letting Cmd-W reach the app. The user
-// expects Cmd-W to behave like Ctrl-W (clear unused volumes in selection).
+// We also strip the Cmd-Q / Cmd-W key equivalents from any standard items: the
+// Pattern Editor reuses Cmd-Q as Transpose-Up (Cmd is treated as Alt via
+// KS_HAS_ALT) and Cmd-W as clear-unused-volumes, so neither may be claimed by
+// the menu bar. Quit is still reachable from the keyboard via Ctrl-Q and from
+// the app-menu click.
 
 #import <Cocoa/Cocoa.h>
+#include "keybuffer.h"
+
+#define FN_KEY(n) [NSString stringWithFormat:@"%C", (unichar)(NSF##n##FunctionKey)]
+
+extern KeyBuffer Keys;
+
+// View-menu hooks (src/CUI_MainMenu.cpp): reuse the in-app deferred resolution
+// change so a menu click is applied safely at the next frame.
+extern "C" void zt_view_apply_size_preset(int idx);
+extern "C" void zt_view_apply_zoom(float zoom);
+extern "C" int zt_view_size_preset_count(void);
+extern "C" const char *zt_view_size_preset_label(int idx);
+
+// NSMenuItem carrying the keystroke to inject when chosen. ztMod is an
+// SDL_KMOD_* mask (KeyBuffer::insert converts it to the KS_* state); ztCode is
+// the SDL scancode, needed only by layout-position lookups (note entry).
+@interface ZTKeyMenuItem : NSMenuItem
+@property (nonatomic, assign) unsigned int ztKey;
+@property (nonatomic, assign) unsigned int ztMod;
+@property (nonatomic, assign) unsigned int ztCode;
+@property (nonatomic, assign) float ztZoom;
+@end
+@implementation ZTKeyMenuItem
+@end
+
+@interface ZTMenuTarget : NSObject
+- (void)inject:(id)sender;
+- (void)applySize:(id)sender;
+- (void)applyZoom:(id)sender;
+@end
+@implementation ZTMenuTarget
+- (void)inject:(id)sender {
+    // Drop events initiated by the menubar hotkey, SDL will handle the keystroke
+    NSEvent *ev = [NSApp currentEvent];
+    if (ev && ev.type == NSEventTypeKeyDown) {
+        return;
+    }
+    ZTKeyMenuItem *item = (ZTKeyMenuItem *)sender;
+    Keys.insert((KBKey)item.ztKey, (KBMod)item.ztMod, 0, item.ztCode);
+}
+- (void)applySize:(id)sender {
+    zt_view_apply_size_preset((int)[(NSMenuItem *)sender tag]);
+}
+- (void)applyZoom:(id)sender {
+    zt_view_apply_zoom(((ZTKeyMenuItem *)sender).ztZoom);
+}
+@end
+
+// AppKit auto-injects a native "Enter Full Screen" (toggleFullScreen:) item
+// into any menu titled "View". Strip it before each open so only zt's own
+// Fullscreen item (Alt+Enter) appears.
+@interface ZTViewMenuDelegate : NSObject <NSMenuDelegate>
+@end
+@implementation ZTViewMenuDelegate
+- (void)menuNeedsUpdate:(NSMenu *)menu {
+    for (NSInteger i = menu.numberOfItems - 1; i >= 0; i--) {
+        if ([menu itemAtIndex:i].action == @selector(toggleFullScreen:))
+            [menu removeItemAtIndex:i];
+    }
+}
+@end
+
+// Retained for the process lifetime; NSMenuItem holds its target weakly.
+static ZTMenuTarget *g_zt_menu_target = nil;
+static ZTViewMenuDelegate *g_zt_view_delegate = nil;
+
+static void zt_add_key_item(NSMenu *menu, NSString *title,
+                            unsigned int key, unsigned int mod, unsigned int code,
+                            NSString *keyEquiv, NSEventModifierFlags mask) {
+    // keyEquiv/mask DISPLAY the shortcut in the menu. The keyboard double-fire
+    // that would otherwise cause (menu action + SDL both seeing the key) is
+    // handled in -inject:, which ignores keyDown-triggered fires.
+    ZTKeyMenuItem *item = [[ZTKeyMenuItem alloc] initWithTitle:title
+                                                        action:@selector(inject:)
+                                                 keyEquivalent:keyEquiv];
+    item.target = g_zt_menu_target;
+    item.ztKey  = key;
+    item.ztMod  = mod;
+    item.ztCode = code;
+    [item setKeyEquivalentModifierMask:mask];
+    [menu addItem:item];
+}
+
+static void zt_add_size_item(NSMenu *menu, NSString *title, int idx) {
+    NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:title
+                                                  action:@selector(applySize:)
+                                           keyEquivalent:@""];
+    item.target = g_zt_menu_target;
+    item.tag = idx;
+    [menu addItem:item];
+}
+
+static void zt_add_zoom_item(NSMenu *menu, NSString *title, float zoom) {
+    ZTKeyMenuItem *item = [[ZTKeyMenuItem alloc] initWithTitle:title
+                                                        action:@selector(applyZoom:)
+                                                 keyEquivalent:@""];
+    item.target = g_zt_menu_target;
+    item.ztZoom = zoom;
+    [menu addItem:item];
+}
+
+// Works for both a menu-bar submenu (the bar shows the submenu title) and a
+// nested submenu (the dropdown shows the item title) -- set both.
+static NSMenu *zt_add_submenu(NSMenu *parent, NSString *title) {
+    NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:title action:nil keyEquivalent:@""];
+    NSMenu *submenu = [[NSMenu alloc] initWithTitle:title];
+    [item setSubmenu:submenu];
+    [parent addItem:item];
+    return submenu;
+}
 
 static void zt_strip_key_equivalent_for_selector(SEL sel)
 {
@@ -28,13 +139,99 @@ static void zt_strip_key_equivalent_for_selector(SEL sel)
     }
 }
 
-extern "C" void zt_macos_disable_cmd_q(void)
-{
-    zt_strip_key_equivalent_for_selector(@selector(terminate:));
+static void zt_macos_create_menu(void) {
+    NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
+    if ([appName length] == 0) appName = [[NSProcessInfo processInfo] processName];
+
+    g_zt_menu_target = [[ZTMenuTarget alloc] init];
+
+    NSMenu *mainMenu = [[NSMenu alloc] initWithTitle:@""];
+
+    // --- zTracker (application menu) ---
+    NSMenu *appMenu = zt_add_submenu(mainMenu, appName);
+    // About -> in-app About page (Alt+F12). Shown as Cmd-equivalent ⌥F12.
+    zt_add_key_item(appMenu, [NSString stringWithFormat:@"About %@", appName],
+                    SDLK_F12, SDL_KMOD_ALT, SDL_SCANCODE_F12,
+                    FN_KEY(12), NSEventModifierFlagOption);
+    [appMenu addItem:[NSMenuItem separatorItem]];
+    // Main Menu -> in-app Main Menu page (ESC). Click-only: ESC is too
+    // context-dependent (closes popups, cancels edits) to claim as a shortcut.
+    zt_add_key_item(appMenu, @"Main Menu", SDLK_ESCAPE, SDL_KMOD_NONE, 0, @"", 0);
+    [appMenu addItem:[NSMenuItem separatorItem]];
+    // Quit: click-only. Cmd-Q is reserved for Pattern Editor Transpose-Up.
+    [appMenu addItemWithTitle:[NSString stringWithFormat:@"Quit %@", appName]
+                       action:@selector(terminate:)
+                keyEquivalent:@""];
+
+    // --- File ---
+    NSMenu *fileMenu = zt_add_submenu(mainMenu, @"File");
+    zt_add_key_item(fileMenu, @"New",  SDLK_N, SDL_KMOD_ALT,  SDL_SCANCODE_N, @"n", NSEventModifierFlagCommand);
+    zt_add_key_item(fileMenu, @"Load", SDLK_L, SDL_KMOD_CTRL, SDL_SCANCODE_L, @"l", NSEventModifierFlagControl);
+    zt_add_key_item(fileMenu, @"Save", SDLK_S, SDL_KMOD_CTRL, SDL_SCANCODE_S, @"s", NSEventModifierFlagControl);
+
+    // --- View ---
+    NSMenu *viewMenu = zt_add_submenu(mainMenu, @"View");
+    NSMenu *sizeMenu = zt_add_submenu(viewMenu, @"Size");
+    for (int i = 0, n = zt_view_size_preset_count(); i < n; i++) {
+        zt_add_size_item(sizeMenu,
+                         [NSString stringWithUTF8String:zt_view_size_preset_label(i)], i);
+    }
+    NSMenu *zoomMenu = zt_add_submenu(viewMenu, @"Zoom");
+    zt_add_zoom_item(zoomMenu, @"1.0x",  1.0f);
+    zt_add_zoom_item(zoomMenu, @"1.5x",  1.5f);
+    zt_add_zoom_item(zoomMenu, @"1.75x", 1.75f);
+    zt_add_zoom_item(zoomMenu, @"2.0x",  2.0f);
+    zt_add_zoom_item(zoomMenu, @"3.0x",  3.0f);
+    // Fullscreen -> Alt+Enter (attempt_fullscreen_toggle, main.cpp).
+    [viewMenu addItem:[NSMenuItem separatorItem]];
+    zt_add_key_item(viewMenu, @"Fullscreen", SDLK_RETURN, SDL_KMOD_ALT, 0, @"\r", NSEventModifierFlagOption);
+    g_zt_view_delegate = [[ZTViewMenuDelegate alloc] init];
+    viewMenu.delegate = g_zt_view_delegate;
+
+    // --- Song ---
+    NSMenu *songMenu = zt_add_submenu(mainMenu, @"Song");
+    zt_add_key_item(songMenu, @"Pattern Editor",    SDLK_F2, SDL_KMOD_NONE,  0, FN_KEY(2), 0);
+    zt_add_key_item(songMenu, @"Instrument Editor", SDLK_F3, SDL_KMOD_NONE,  0, FN_KEY(3), 0);
+    [songMenu addItem:[NSMenuItem separatorItem]];
+    zt_add_key_item(songMenu, @"MIDI Macro Editor", SDLK_F4, SDL_KMOD_NONE,  0, FN_KEY(4), 0);
+    zt_add_key_item(songMenu, @"Arpeggio Editor",   SDLK_F4, SDL_KMOD_SHIFT, 0, FN_KEY(4), NSEventModifierFlagShift);
+    [songMenu addItem:[NSMenuItem separatorItem]];
+    zt_add_key_item(songMenu, @"Song Configuration", SDLK_F11, SDL_KMOD_NONE, 0, FN_KEY(11), 0);
+
+    // --- Playback ---
+    NSMenu *playMenu = zt_add_submenu(mainMenu, @"Playback");
+    zt_add_key_item(playMenu, @"Play Song",    SDLK_F5, SDL_KMOD_NONE, 0, FN_KEY(5), 0);
+    zt_add_key_item(playMenu, @"Play Pattern", SDLK_F6, SDL_KMOD_NONE, 0, FN_KEY(6), 0);
+    zt_add_key_item(playMenu, @"Stop",         SDLK_F8, SDL_KMOD_NONE, 0, FN_KEY(8), 0);
+
+    // --- Settings ---
+    NSMenu *setMenu = zt_add_submenu(mainMenu, @"Settings");
+    zt_add_key_item(setMenu, @"System Configuration", SDLK_F12, SDL_KMOD_NONE, 0, FN_KEY(12), 0);
+    zt_add_key_item(setMenu, @"Global Configuration", SDLK_F12, SDL_KMOD_CTRL, 0, FN_KEY(12), NSEventModifierFlagControl);
+
+    // --- Window (standard; AppKit fills in the window list) ---
+    NSMenu *windowMenu = zt_add_submenu(mainMenu, @"Window");
+    NSMenuItem *minItem = [[NSMenuItem alloc] initWithTitle:@"Minimize"
+                                                     action:@selector(performMiniaturize:)
+                                              keyEquivalent:@"m"];
+    [minItem setKeyEquivalentModifierMask:NSEventModifierFlagCommand];
+    [windowMenu addItem:minItem];
+    [windowMenu addItemWithTitle:@"Zoom" action:@selector(performZoom:) keyEquivalent:@""];
+
+    // --- Help ---
+    NSMenu *helpMenu = zt_add_submenu(mainMenu, @"Help");
+    zt_add_key_item(helpMenu, @"Help", SDLK_F1, SDL_KMOD_NONE, 0, FN_KEY(1), 0);
+
+    [NSApp setMainMenu:mainMenu];
+    [NSApp setWindowsMenu:windowMenu];
 }
 
-extern "C" void zt_macos_disable_cmd_w(void)
-{
-    // performClose: is the standard "Close Window" action.
+extern "C" void zt_macos_menu_init(void) {
+
+    zt_macos_create_menu();
+
+    // Belt-and-suspenders: clear Cmd-Q / Cmd-W from any standard item AppKit
+    // may have attached, so those chords reach the app instead of the menu.
+    zt_strip_key_equivalent_for_selector(@selector(terminate:));
     zt_strip_key_equivalent_for_selector(@selector(performClose:));
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,16 +82,15 @@
 #include "ableton_link.h"
 #include "midi_clock_sync.h"
 
-#ifdef __APPLE__
-extern "C" void zt_macos_disable_cmd_q(void);
-extern "C" void zt_macos_disable_cmd_w(void);
-#endif
-
 #if defined(__APPLE__)
+
 #include <mach-o/dyld.h>
 #include <unistd.h>
 #include <limits.h>
 #include <cstring>
+
+extern "C" void zt_macos_menu_init(void);
+
 #endif
 
 
@@ -3156,9 +3155,22 @@ static void zt_queue_full_redraw(void)
     screenmanager.UpdateAll();
 }
 
+// Set while servicing an OS-driven resize (a drag, or the green-button native
+// fullscreen transition). Tells zt_backend_set_video_mode NOT to push window
+// size/fullscreen back to SDL, which can cause problem swith full-screen on macOS
+static bool g_zt_os_driven_resize = false;
+
 static void zt_handle_resize_event(int w, int h)
 {
-    if (!set_video_mode(w, h, errstr)) {
+    // Always drive off the window's POINT size, not the event payload: a
+    // PIXEL_SIZE_CHANGED event reports pixels (2x points on HiDPI)
+    if (zt_main_window) {
+        SDL_GetWindowSize(zt_main_window, &w, &h);
+    }
+    g_zt_os_driven_resize = true;
+    const int ok = set_video_mode(w, h, errstr);
+    g_zt_os_driven_resize = false;
+    if (!ok) {
         return;
     }
     zt_request_ui_full_refresh();
@@ -3296,17 +3308,27 @@ static bool zt_zoom_is_integer(float zoom_value)
     return std::fabs(zoom_value - nearest_integer) < 0.001f;
 }
 
+// True when the on-screen pixel scale (display density * zoom) is an integer,
+// i.e. the bitmap font pixel-doubles cleanly. On a 2x Retina panel this holds
+// for zoom 1.0/1.5/2.0/3.0..., so those stay crisp under nearest filtering.
+static bool zt_effective_scale_is_integer(void)
+{
+    float density = zt_main_window ? SDL_GetWindowPixelDensity(zt_main_window) : 1.0f;
+    if (density <= 0.0f) density = 1.0f;
+    return zt_zoom_is_integer(density * (float)ZOOM);
+}
+
 static SDL_ScaleMode zt_get_configured_scale_mode(void)
 {
     const char *scale_filter = zt_config_globals.scale_filter;
     if (!scale_filter || !scale_filter[0]) {
-        return zt_zoom_is_integer(ZOOM) ? SDL_SCALEMODE_NEAREST : SDL_SCALEMODE_LINEAR;
+        return zt_effective_scale_is_integer() ? SDL_SCALEMODE_NEAREST : SDL_SCALEMODE_LINEAR;
     }
     if (SDL_strcasecmp(scale_filter, "nearest") == 0) {
         return SDL_SCALEMODE_NEAREST;
     }
     if (SDL_strcasecmp(scale_filter, "linear") == 0) {
-        return zt_zoom_is_integer(ZOOM) ? SDL_SCALEMODE_NEAREST : SDL_SCALEMODE_LINEAR;
+        return zt_effective_scale_is_integer() ? SDL_SCALEMODE_NEAREST : SDL_SCALEMODE_LINEAR;
     }
 #ifdef SDL_SCALEMODE_PIXELART
     if (SDL_strcasecmp(scale_filter, "pixelart") == 0) {
@@ -3394,6 +3416,20 @@ static int zt_handle_platform_window_event(const SDL_Event *e)
     case SDL_EVENT_WINDOW_RESIZED:
     case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
         zt_handle_resize_event((int)e->window.data1, (int)e->window.data2);
+        return 1;
+    case SDL_EVENT_WINDOW_ENTER_FULLSCREEN:
+        // Fullscreen entered by the OS or Alt+Enter -- mirror it
+        // into zt's own state so config persistence and the next Alt+Enter
+        // toggle stay consistent. Do NOT grab the mouse: confining the cursor
+        // blocks the macOS menu bar (and Dock) from revealing on mouse-to-top.
+        bIsFullscreen = true;
+        zt_config_globals.full_screen = 1;
+        zt_request_ui_full_refresh();
+        return 1;
+    case SDL_EVENT_WINDOW_LEAVE_FULLSCREEN:
+        bIsFullscreen = false;
+        zt_config_globals.full_screen = 0;
+        zt_request_ui_full_refresh();
         return 1;
     default:
         return 0;
@@ -3552,7 +3588,11 @@ int action(Screen *S)
 //
 static int zt_backend_set_video_mode(char *errstr)
 {
-  Uint32 window_flags = SDL_WINDOW_RESIZABLE;
+  // HIGH_PIXEL_DENSITY: render at the display's native pixel resolution instead
+  // of letting the OS up-scale a 1x backing (which softens the bitmap font on
+  // Retina). zt then drives the up-scale itself via the frame-texture scale
+  // mode -- nearest at integer pixel scales for crisp pixel-doubling.
+  Uint32 window_flags = SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY;
   if (zt_config_globals.full_screen) {
     window_flags |= SDL_WINDOW_FULLSCREEN;
     bIsFullscreen = true;
@@ -3560,27 +3600,23 @@ static int zt_backend_set_video_mode(char *errstr)
     bIsFullscreen = false;
   }
 
+  const bool had_window = (zt_main_window != NULL);
+
   if (!zt_main_window) {
+    SDL_SetHint(SDL_HINT_VIDEO_MAC_FULLSCREEN_MENU_VISIBILITY, "1");
     zt_main_window = SDL_CreateWindow("zt", RESOLUTION_X, RESOLUTION_Y, window_flags);
     if (!zt_main_window) {
       sprintf(errstr, "Couldn't create SDL window: %s\n", SDL_GetError());
       zt_show_error("Error", errstr);
       return 0;
     }
+
 #ifdef __APPLE__
-    // Free Cmd-Q from the auto-created NSApp menu so the Pattern Editor can
-    // use it as Transpose-Up (KS_HAS_ALT treats Cmd as Alt). Quit reachable
-    // via Ctrl-Q / Ctrl-Alt-Q. Skipped under --headless because the dummy
-    // video driver doesn't create an NSApp menu in the first place; the
-    // disable call would touch a NULL menu and crash.
     if (!zt_headless_active()) {
-        zt_macos_disable_cmd_q();
-        // Free Cmd-W from the Window menu's Close item so it reaches our
-        // keyhandler instead of dismissing the SDL window. Pattern Editor
-        // treats Cmd-W as Ctrl-W (clear unused volumes in selection).
-        zt_macos_disable_cmd_w();
+        zt_macos_menu_init();
     }
 #endif
+
     zt_renderer = SDL_CreateRenderer(zt_main_window, NULL);
     if (!zt_renderer) {
       snprintf(errstr, 2048, "Couldn't create SDL renderer: %s\n", SDL_GetError());
@@ -3606,7 +3642,20 @@ static int zt_backend_set_video_mode(char *errstr)
       }
 #endif
     }
-  } else {
+  }
+
+  if (!g_zt_os_driven_resize) {
+    SDL_SetWindowMinimumSize(zt_main_window,
+                             (int)(MINIMUM_SCREEN_WIDTH  * (float)ZOOM),
+                             (int)(MINIMUM_SCREEN_HEIGHT * (float)ZOOM));
+  }
+
+  // Apply an explicit windowed mode change. Not on first creation (the window
+  // already has the right size) and not while fullscreen (SDL_SetWindowSize
+  // would change the size the window restores to on exit, and the flag is
+  // already asserted).
+  if (had_window && !g_zt_os_driven_resize &&
+      !(SDL_GetWindowFlags(zt_main_window) & SDL_WINDOW_FULLSCREEN)) {
     SDL_SetWindowSize(zt_main_window, RESOLUTION_X, RESOLUTION_Y);
     SDL_SetWindowFullscreen(zt_main_window, zt_config_globals.full_screen ? SDL_WINDOW_FULLSCREEN : 0);
   }
@@ -3615,6 +3664,16 @@ static int zt_backend_set_video_mode(char *errstr)
 
 int set_video_mode(int w, int h, char *errstr)
 {
+  // While the window is fullscreen it is the screen size, not the requested w/h
+  // (e.g. a Size preset's 1280). Drive the internal canvas off the ACTUAL size
+  // so the requested ZOOM is applied exactly -- otherwise the requested-sized
+  // canvas gets stretched to fill the screen, scaling the picture even at 1x.
+  if (zt_main_window && (SDL_GetWindowFlags(zt_main_window) & SDL_WINDOW_FULLSCREEN)) {
+    int fw = 0, fh = 0;
+    SDL_GetWindowSize(zt_main_window, &fw, &fh);
+    if (fw > 0 && fh > 0) { w = fw; h = fh; }
+  }
+
   RESOLUTION_X = w ;
   RESOLUTION_Y = h ;
 
@@ -4562,7 +4621,12 @@ static int zt_backend_toggle_fullscreen(void)
     if (window_h > 0) {
         RESOLUTION_Y = window_h;
     }
-    SDL_SetWindowMouseGrab(zt_main_window, enable_fullscreen);
+
+    // TODO: Ensure this is the right behavior on non-macOS targets
+    // No mouse grab in fullscreen: confining the cursor blocks the macOS menu
+    // bar / Dock from revealing when the mouse moves to the screen edge.
+    // SDL_SetWindowMouseGrab(zt_main_window, enable_fullscreen);
+
     return 1;
 }
 


### PR DESCRIPTION
Native macOS menu bar plus a set of fullscreen / HiDPI rendering fixes for the SDL3 window.

## Menu bar
- **zTracker / File / View / Song / Playback / Settings / Window / Help.** Each item injects the equivalent in-app keystroke through the shared `KeyBuffer`, so a menu click takes the exact same code path as pressing the key.
- Items **display their shortcut** via `keyEquivalent`. macOS fires the menu action on that keystroke *and* SDL still delivers the key, so `-inject:` drops `keyDown`-triggered fires and lets SDL own the keyboard — otherwise the action ran twice (e.g. F2 toggling PEParms open then immediately shut).
- **View → Size** is generated from `MM_RES_PRESETS` so the macOS menu can't drift from the in-app Window Size list.

## Fullscreen / rendering (main.cpp)
- **Green-button (native) fullscreen no longer reverts.** The resize handler is purely reactive (no longer re-asserts stale window state), OS fullscreen events mirror into zt's state, and the mouse is not grabbed — so the menu bar reveals on mouse-to-top.
- **Switching video mode while fullscreen** now applies the requested zoom correctly (internal canvas is driven off the actual window size, not the preset size).
- **Minimum window size scales with zoom** and is applied *before* resizing, so shrinking to a smaller preset takes effect in one click instead of two.
- **High-DPI window** (`SDL_WINDOW_HIGH_PIXEL_DENSITY`) + density-aware nearest filtering → crisp bitmap font on Retina (previously the OS up-scaled a 1× backing).

## Test plan
- [x] Builds clean; `ctest` 18/18 green.
- [x] Menu renders; clicking items switches pages / applies Size & Zoom presets.
- [x] Keyboard shortcuts (F2, ⌘N, ⌃S, …) fire **once** — PEParms toggles cleanly.
- [x] Green-button fullscreen enters and stays; Alt+Enter exits; menu bar reveals on hover.
- [x] Switching Size/Zoom in fullscreen keeps the picture at the requested scale (no stretch at 1×).
- [x] Font is crisp in both windowed and fullscreen on a Retina display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
